### PR TITLE
changed shebang line in executable python files 

### DIFF
--- a/digits-devserver
+++ b/digits-devserver
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/digits-walkthrough
+++ b/digits-walkthrough
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import os

--- a/digits/config.py
+++ b/digits/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import os

--- a/tools/create_db.py
+++ b/tools/create_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/tools/parse_folder.py
+++ b/tools/parse_folder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/tools/resize_image.py
+++ b/tools/resize_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys


### PR DESCRIPTION
I was having trouble running the scripts as executables because it was using #!/usr/bin/python instead of the python in my PATH. This updates the shebang line to #!/usr/bin/env python for all of the executable python files.