### PR TITLE
Fixed issue#1: pretrained model selection bug

### DIFF
--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -16,6 +16,13 @@ class ModelForm(Form):
         super(ModelForm, self).__init__(csrf_enabled=csrf_enabled, *args, **kwargs)
 
     ### Methods
+    def selection_exists_in_choices(form, field):
+        found=False
+        for i, choice in enumerate(field.choices):
+            if choice[0] == field.data:
+                found=True
+        if found == False:
+            raise validators.ValidationError("Selected job doesn't exist. Maybe it was deleted by another user.")
 
     def required_if_method(value):
         def _required(form, field):
@@ -144,13 +151,8 @@ class ModelForm(Form):
             choices = [],
             validators = [
                 required_if_method('previous'),
+                selection_exists_in_choices,
                 ],
-            )
-
-    previous_network_snapshots = wtforms.FieldList(
-            wtforms.SelectField('Snapshots',
-                validators = [validators.Optional()]
-                ),
             )
 
     custom_network = wtforms.TextAreaField('Custom Network',
@@ -174,4 +176,6 @@ class ModelForm(Form):
                 validators.DataRequired()
                 ]
             )
+
+
 

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -421,12 +421,16 @@ function customizeNetwork(network, snapshot_list) {
                                 <a href="{{url_for("models_show", job_id=network.data)}}" target="_blank">View</a>
                             </td>
                             <td>
-                                {% set snapshot_list = form.previous_network_snapshots[loop.index0] %}
-                                {% if snapshot_list.choices|length %}
-                                {{snapshot_list(class='form-control')}}
+                                {% set snapshot_list = previous_network_snapshots[loop.index0] %}
+                                {% if snapshot_list|length %}
+                                <select class="form-control" id="{{network.data}}-snapshot" name="{{network.data}}-snapshot">
+                                    {% for each_epoch in snapshot_list %}
+                                    <option value="{{each_epoch[0]}}">{{each_epoch[1]}}</option>
+                                    {% endfor %}
+                                </select>
                                 {% endif %}
                             </td>
-                            <td><a class="btn btn-sm" onClick="customizeNetwork('{{network.data}}', '{{snapshot_list.id}}');">Customize</a></td>
+                            <td><a class="btn btn-sm" onClick="customizeNetwork('{{network.data}}', '{{network.data}}-snapshot');">Customize</a></td>
                         </tr>
                         {% else %}
                         <tr>
@@ -436,26 +440,41 @@ function customizeNetwork(network, snapshot_list) {
                     </table>
                 </div>
 		<script>
-                    $(".btn.btn-sm").hide();   // hide all the buttons
-                    $("#network-tab-previous").find(".form-control").prop('disabled', 'disabled');  //hide all the select elements in "Previous Networks" tab
+                    $(".btn.btn-sm").css('visibility', 'hidden');   // hide all the buttons
+                    $("#network-tab-previous").find(".form-control").css('visibility', 'hidden'); //hide all the select elements in "Previous Networks" tab
+
                     var $stdtab_prev_clicked_tr = null;   
                     $("input:radio[name=standard_networks]").click(function(){
                        if ($stdtab_prev_clicked_tr != null) {
-                            $stdtab_prev_clicked_tr.find(".btn.btn-sm").hide();
-                        }
-                        $(this).parents('tr').find(".btn.btn-sm").show();
-                        $stdtab_prev_clicked_tr = $(this).parents('tr');
+                            $stdtab_prev_clicked_tr.find(".btn.btn-sm").css('visibility', 'hidden');
+                       }
+                       $(this).parents('tr').find(".btn.btn-sm").css('visibility', 'visible');
+                       $stdtab_prev_clicked_tr = $(this).parents('tr');
                     });
+
                     var $prevtab_prev_clicked_tr = null;   
                     $("input:radio[name=previous_networks]").click(function(){
                        if ($prevtab_prev_clicked_tr != null) {
-                            $prevtab_prev_clicked_tr.find(".btn.btn-sm").hide();
-                            $prevtab_prev_clicked_tr.find(".form-control").prop('disabled', 'disabled');
+                            $prevtab_prev_clicked_tr.find(".btn.btn-sm").css('visibility', 'hidden');
+                            $prevtab_prev_clicked_tr.find(".form-control").css('visibility', 'hidden');
                         }
-                        $(this).parents('tr').find(".btn.btn-sm").show();
-                        $(this).parents('tr').find(".form-control").prop('disabled', false);
+                        $(this).parents('tr').find(".btn.btn-sm").css('visibility', 'visible');
+                        $(this).parents('tr').find(".form-control").css('visibility', 'visible');
                         $prevtab_prev_clicked_tr = $(this).parents('tr');
                     });
+
+                    //fix to the following issue: when validation fails and the screen was re-displayed, the selected radio buttons in "previous networks" tab remains selected but the select input field and customize button beside the selected previous network is in hidden status, which is wrong. same issue exists in standard networks tab. The below code ensures that select field and customize button beside selected radio button will be visible even when validation fails.
+
+                    if($("input:radio[name=standard_networks]").is(":checked")) {
+                       $stdtab_prev_clicked_tr = $("input:radio[name=standard_networks]:checked").parents('tr');
+                       $stdtab_prev_clicked_tr.find(".btn.btn-sm").css('visibility', 'visible');
+                    }
+                    if($("input:radio[name=previous_networks]").is(":checked")) {
+                        $prevtab_prev_clicked_tr =  $("input:radio[name=previous_networks]:checked").parents('tr');
+                        $prevtab_prev_clicked_tr.find(".btn.btn-sm").css('visibility', 'visible');
+                        $prevtab_prev_clicked_tr.find(".form-control").css('visibility', 'visible');
+                    }
+
                 </script>
                 <div id="network-tab-custom" class="tab-pane">
                     <script>

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -18,6 +18,10 @@
                 <dd><a href="{{url_for('serve_file', path=task.path(task.deploy_file, relative=True))}}">{{task.deploy_file}}</a></dd>
                 <dt>Raw caffe output</dt>
                 <dd><a href="{{url_for('serve_file', path=task.path(task.caffe_log_file, relative=True))}}">{{task.caffe_log_file}}</a></dd>
+                {% if task.pretrained_model %}
+                <dt>Pretrained Model</dt>
+                <dd>{{task.pretrained_model}}</dd>
+                {% endif %}
             </dl>
         </div>
     </div>


### PR DESCRIPTION
1) Removed the select field for previous networks snapshots from forms.py, due to wtforms validation issues. Then included code in views.py and new.html, to display the select fields for previous networks snapshots in html and for validating these fields. These changes fix the pretrained model selection bug. Also these changes ensure the display of error message, incase user selects the job that doesn't exists (this scenario happens when a user selects the job and at the same if another user deletes this job)
2) fix to the following issue: when validation fails, the selected radio buttons in "previous networks" tab remains selected but the select input field and customize button beside the selected previous network is in hidden status, which is wrong. same issue exists in standard networks tab. Modified new.html to ensure that select field and customize button beside selected radio button will be visible even when validation fails.
3) Modified the test case related to pretrained model selection.
4) Included the changes to display the selected "pretrained model" details in show.html file