### PR TITLE
Fix error reporting when deleting a dataset fails because of dependent models

### DIFF
--- a/digits/test_scheduler.py
+++ b/digits/test_scheduler.py
@@ -6,7 +6,6 @@ import mock
 from . import scheduler as _
 from config import config_option
 from job import Job
-from digits.utils import errors
 
 class TestScheduler():
 

--- a/digits/test_scheduler.py
+++ b/digits/test_scheduler.py
@@ -47,9 +47,6 @@ class TestSchedulerFlow():
         job = Job('tmp')
         assert self.s.add_job(job), 'failed to add job'
         assert len(self.s.jobs) == 1, 'scheduler has %d jobs' % len(self.s.jobs)
-        try:
-            self.s.delete_job(job)
-        except errors.DeleteError as e:
-            raise AssertionError(e.__str__())
+        assert self.s.delete_job(job), 'failed to delete job'
         assert len(self.s.jobs) == 0, 'scheduler has %d jobs' % len(self.s.jobs)
 

--- a/digits/test_scheduler.py
+++ b/digits/test_scheduler.py
@@ -6,6 +6,7 @@ import mock
 from . import scheduler as _
 from config import config_option
 from job import Job
+from digits.utils import errors
 
 class TestScheduler():
 
@@ -46,6 +47,9 @@ class TestSchedulerFlow():
         job = Job('tmp')
         assert self.s.add_job(job), 'failed to add job'
         assert len(self.s.jobs) == 1, 'scheduler has %d jobs' % len(self.s.jobs)
-        assert self.s.delete_job(job), 'failed to delete job'
+        try:
+            self.s.delete_job(job)
+        except errors.DeleteError as e:
+            raise AssertionError(e.__str__())
         assert len(self.s.jobs) == 0, 'scheduler has %d jobs' % len(self.s.jobs)
 

--- a/digits/utils/__init__.py
+++ b/digits/utils/__init__.py
@@ -120,5 +120,5 @@ def sizeof_fmt(size, suffix='B'):
 
 ### Import the other utility functions
 
-from . import constants, image, time_filters
+from . import constants, image, time_filters, errors
 

--- a/digits/utils/errors.py
+++ b/digits/utils/errors.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
+
+# This class contains all the DIGITS user-defined exceptions
+
+class DigitsError(Exception):
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return self.value
+
+class DeleteError(DigitsError):
+    def __init__(self, value):
+        DigitsError.__init__(self, value)

--- a/digits/utils/errors.py
+++ b/digits/utils/errors.py
@@ -3,11 +3,6 @@
 # This class contains all the DIGITS user-defined exceptions
 
 class DigitsError(Exception):
-    def __init__(self, value):
-        self.value = value
-    def __str__(self):
-        return self.value
-
+    pass
 class DeleteError(DigitsError):
-    def __init__(self, value):
-        DigitsError.__init__(self, value)
+    pass

--- a/digits/views.py
+++ b/digits/views.py
@@ -13,6 +13,7 @@ from webapp import app, socketio, scheduler
 from status import Status
 import dataset.views
 import model.views
+from digits.utils import errors
 
 @app.route('/')
 def home():
@@ -119,10 +120,11 @@ def delete_job(job_id):
     job = scheduler.get_job(job_id)
     if not job:
         return 'Job not found!', 404
-    if scheduler.delete_job(job_id):
-        return 'Job deleted.'
-    else:
-        return 'Job could not deleted!', 403
+    try:
+        if scheduler.delete_job(job_id):
+            return 'Job deleted.'
+    except errors.DeleteError as e:
+        return e.__str__(), 403
 
 @app.route('/datasets/<job_id>/abort', methods=['POST'])
 @app.route('/models/<job_id>/abort', methods=['POST'])

--- a/digits/views.py
+++ b/digits/views.py
@@ -123,6 +123,8 @@ def delete_job(job_id):
     try:
         if scheduler.delete_job(job_id):
             return 'Job deleted.'
+        else:
+            return 'Job could not be deleted! Check log for more details', 403
     except errors.DeleteError as e:
         return e.__str__(), 403
 


### PR DESCRIPTION
1) Included DigitsError.py for including DIGITS custom exceptions
2) Created DeleteError custom exception
3) Changed scheduler.delete_job() function to display detail error message instead of default message.