### PR TITLE
Correction of tooltip for labels file

### DIFF
--- a/digits/templates/datasets/images/classification/new.html
+++ b/digits/templates/datasets/images/classification/new.html
@@ -312,7 +312,7 @@ textfile_image_sets_disabled();
                                 <span name="textfile_labels_file_explanation"
                                     class="input-group-addon explanation-tooltip glyphicon glyphicon-question-sign"
                                     data-container="body"
-                                    title="The 'i'th line of the file should give the string label associated with the 'i'th numberic label."
+                                    title="The 'i'th line of the file should give the string label associated with the '(i-1)'th numberic label. (E.g. the string label for the numeric label 0 is supposed to be on line 1.))"
                                     ></span>
                             </div>
                         </div>


### PR DESCRIPTION
If I interprete [titles.append(labels[int(key)]](https://github.com/NVIDIA/DIGITS/blob/master/digits/dataset/tasks/create_db.py#L243) correctly then the then numeric labels start at 0 and line numbers at 1.