### PR TITLE
Remove all references to LevelDB

### DIFF
--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -30,7 +30,6 @@ class CreateDbTask(Task):
         resize_mode -- used in utils.image.resize_image()
         encoding -- 'none', 'png' or 'jpg'
         mean_file -- save mean file to this location
-        backend -- type of database to use
         labels_file -- used to print category distribution
         """
         # Take keyword arguments out of kwargs
@@ -39,7 +38,6 @@ class CreateDbTask(Task):
         self.resize_mode = kwargs.pop('resize_mode' , None)
         self.encoding = kwargs.pop('encoding', None)
         self.mean_file = kwargs.pop('mean_file', None)
-        self.backend = kwargs.pop('backend', None)
         self.labels_file = kwargs.pop('labels_file', None)
 
         super(CreateDbTask, self).__init__(**kwargs)

--- a/tools/test_create_db.py
+++ b/tools/test_create_db.py
@@ -25,15 +25,11 @@ class TestInit():
         except OSError:
             pass
 
-    @raises(ValueError)
-    def test_bad_backend(self):
-        _.DbCreator(self.db_name, 'not-a-backend')
-
 class TestCreate():
     @classmethod
     def setUpClass(cls):
         cls.db_name = tempfile.mkdtemp()
-        cls.db = _.DbCreator(cls.db_name, 'leveldb')
+        cls.db = _.DbCreator(cls.db_name)
 
         fd, cls.input_file = tempfile.mkstemp()
         os.close(fd)
@@ -97,7 +93,7 @@ class TestPathToDatum():
     def setUpClass(cls):
         cls.tmpdir = tempfile.mkdtemp()
         cls.db_name = tempfile.mkdtemp(dir=cls.tmpdir)
-        cls.db = _.DbCreator(cls.db_name, 'lmdb')
+        cls.db = _.DbCreator(cls.db_name)
         _handle, cls.image_path = tempfile.mkstemp(dir=cls.tmpdir, suffix='.jpg')
         with open(cls.image_path, 'w') as outfile:
             PIL.Image.fromarray(np.zeros((10,10,3),dtype=np.uint8)).save(outfile, format='JPEG', quality=100)


### PR DESCRIPTION
@crohkohl partially addressed this in #199 for the sake of platforms where LevelDB isn't supported. This takes his partial solution to its logical extension. You can't actually use LevelDB with DIGITS anyway, so I think we should just go ahead and remove all references to it.