### PR TITLE
Double LMDB map_size on MapFullError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ gevent>=1.0
 Flask>=0.10.1
 Flask-WTF>=0.11
 gunicorn==17.5
+lmdb>=0.87
 pydot2
 Flask-SocketIO
-lmdb


### PR DESCRIPTION
*Closes #206.*

### Changed
* Don't set the initial map_size to 1TB like before
  * It seems to start with 10MB by default
* When LMDB throws a MapFullError, double the map size
  * Big thanks to @dw for https://github.com/dw/py-lmdb/commit/442096e1551e204894154436877080a5b2571813

### TODO before merge
* [x] Add this change to `digits/dataset/images/generic/test_lmdb_creator.py` as well
* [x] Write some tests
* [x] Update requirements.txt to require newest version of LMDB