### PR TITLE
Add dataset_id to ModelJob's JSON representation

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -331,7 +331,8 @@ class TestCreated(BaseViewsTestWithModel):
         rv = self.app.get('/models/%s.json' % self.model_id)
         assert rv.status_code == 200, 'page load failed with %s' % rv.status_code
         content = json.loads(rv.data)
-        assert content['id'] == self.model_id, 'expected different job_id'
+        assert content['id'] == self.model_id, 'id %s != %s' % (content['id'], self.model_id)
+        assert content['dataset_id'] == self.dataset_id, 'dataset_id %s != %s' % (content['dataset_id'], self.dataset_id)
         assert len(content['snapshots']) > 0, 'no snapshots in list'
 
     def test_classify_one(self):

--- a/digits/model/job.py
+++ b/digits/model/job.py
@@ -37,6 +37,7 @@ class ModelJob(Job):
     @override
     def json_dict(self, verbose=False):
         d = super(ModelJob, self).json_dict(verbose)
+        d['dataset_id'] = self.dataset_id
 
         if verbose:
             d.update({


### PR DESCRIPTION
Ahmed pointed out that the REST API doesn't expose any information about which `DatasetJob` a `ModelJob` depends on.