### PR TITLE
Make alert box into a macro and try to prety up the field name

### DIFF
--- a/digits/templates/datasets/images/classification/new.html
+++ b/digits/templates/datasets/images/classification/new.html
@@ -1,6 +1,7 @@
 {# Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved. #}
 
 {% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
 
 {% extends "layout.html" %}
 
@@ -21,19 +22,7 @@ New Image Classification Dataset
 <form action="{{url_for('image_classification_dataset_create')}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
-    {% if form.errors %}
-        <div class="alert alert-danger">
-            {% for field, errors in form.errors.items() %}
-                <li>{{ field }}
-                    <ul>
-                        {% for e in errors %}
-                            <li>{{ e }}</li>
-                        {% endfor %}
-                    </ul>
-                </li>
-            {% endfor %}
-        </div>
-    {% endif %}
+    {{ print_errors(form) }}
 
     <div class="row">
         <div class="col-sm-4 well">

--- a/digits/templates/datasets/images/generic/new.html
+++ b/digits/templates/datasets/images/generic/new.html
@@ -1,6 +1,7 @@
 {# Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved. #}
 
 {% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
 
 {% extends "layout.html" %}
 
@@ -20,19 +21,7 @@ New Image Dataset
 <form action="{{url_for('generic_image_dataset_create')}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
-    {% if form.errors %}
-        <div class="alert alert-danger">
-            {% for field, errors in form.errors.items() %}
-                <li>{{ field }}
-                    <ul>
-                        {% for e in errors %}
-                            <li>{{ e }}</li>
-                        {% endfor %}
-                    </ul>
-                </li>
-            {% endfor %}
-        </div>
-    {% endif %}
+    {{ print_errors(form) }}
 
     <div class="row">
         <div class="col-sm-8 col-sm-offset-2">

--- a/digits/templates/helper.html
+++ b/digits/templates/helper.html
@@ -12,3 +12,20 @@
     {% endwith %}
 {% endmacro %}
 
+{% macro print_errors(form) %}
+    {% if form.errors %}
+        <div class="alert alert-danger">
+            {% for field_name, field in form._fields.iteritems() %}
+                {% if field.errors %}
+                    <li><label>{{ field.label.text }}</label>
+                        <ul>
+                            {% for e in field.errors %}
+                                <li>{{ e }}</li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -1,6 +1,7 @@
 {# Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved. #}
 
 {% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
 
 {% extends "layout.html" %}
 
@@ -20,19 +21,7 @@ New Image Classification Model
 <form id="model-form" action="{{url_for('image_classification_model_create')}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
-    {% if form.errors %}
-        <div class="alert alert-danger">
-            {% for field, errors in form.errors.items() %}
-                <li>{{ field }}
-                    <ul>
-                        {% for e in errors %}
-                            <li>{{ e }}</li>
-                        {% endfor %}
-                    </ul>
-                </li>
-            {% endfor %}
-        </div>
-    {% endif %}
+    {{ print_errors(form) }}
 
     <div class="row">
         <div class="col-sm-4">

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -1,6 +1,7 @@
 {# Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved. #}
 
 {% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
 
 {% extends "layout.html" %}
 
@@ -20,19 +21,7 @@ New Image Model
 <form id="model-form" action="{{url_for('generic_image_model_create')}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
-    {% if form.errors %}
-        <div class="alert alert-danger">
-            {% for field, errors in form.errors.items() %}
-                <li>{{ field }}
-                    <ul>
-                        {% for e in errors %}
-                            <li>{{ e }}</li>
-                        {% endfor %}
-                    </ul>
-                </li>
-            {% endfor %}
-        </div>
-    {% endif %}
+    {{ print_errors(form) }}
 
     <div class="row">
         <div class="col-sm-4">


### PR DESCRIPTION
I tried to find a way to use the field.label in the error messages, but couldn't make that work.  I thought the next best thing would be pretty up the field name. So that crop_size becomes Crop Size.  Looks a little cleaner. Many of the field names are very close to the field.label.  Some are way off.