### PR TITLE
Add support for HDF5 datasets

### DIFF
--- a/digits/dataset/images/classification/forms.py
+++ b/digits/dataset/images/classification/forms.py
@@ -15,6 +15,29 @@ class ImageClassificationDatasetForm(ImageDatasetForm):
     Defines the form used to create a new ImageClassificationDatasetJob
     """
 
+    backend = wtforms.SelectField('DB backend',
+            choices = [
+                ('lmdb', 'LMDB'),
+                ('hdf5', 'HDF5'),
+                ],
+            default='lmdb',
+            )
+
+    def validate_backend(form, field):
+        if field.data == 'lmdb':
+            form.compression.data = 'none'
+        elif field.data == 'hdf5':
+            form.encoding.data = 'none'
+
+    compression = utils.forms.SelectField('DB compression',
+            choices = [
+                ('none', 'None'),
+                ('gzip', 'GZIP'),
+                ],
+            default='none',
+            tooltip='Compressing the dataset may significantly decrease the size of your database files, but it may increase read and write times.',
+            )
+
     # Use a SelectField instead of a HiddenField so that the default value
     # is used when nothing is provided (through the REST API)
     method = wtforms.SelectField(u'Dataset type',

--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -84,7 +84,9 @@ def from_folders(job, form):
 
     ### Add CreateDbTasks
 
+    backend = form.backend.data
     encoding = form.encoding.data
+    compression = form.compression.data
 
     job.tasks.append(
             tasks.CreateDbTask(
@@ -92,9 +94,11 @@ def from_folders(job, form):
                 parents     = parse_train_task,
                 input_file  = utils.constants.TRAIN_FILE,
                 db_name     = utils.constants.TRAIN_DB,
+                backend     = backend,
                 image_dims  = job.image_dims,
                 resize_mode = job.resize_mode,
                 encoding    = encoding,
+                compression = compression,
                 mean_file   = utils.constants.MEAN_FILE_CAFFE,
                 labels_file = job.labels_file,
                 )
@@ -107,9 +111,11 @@ def from_folders(job, form):
                     parents     = val_parents,
                     input_file  = utils.constants.VAL_FILE,
                     db_name     = utils.constants.VAL_DB,
+                    backend     = backend,
                     image_dims  = job.image_dims,
                     resize_mode = job.resize_mode,
                     encoding    = encoding,
+                    compression = compression,
                     labels_file = job.labels_file,
                     )
                 )
@@ -121,9 +127,11 @@ def from_folders(job, form):
                     parents     = test_parents,
                     input_file  = utils.constants.TEST_FILE,
                     db_name     = utils.constants.TEST_DB,
+                    backend     = backend,
                     image_dims  = job.image_dims,
                     resize_mode = job.resize_mode,
                     encoding    = encoding,
+                    compression = compression,
                     labels_file = job.labels_file,
                     )
                 )
@@ -141,8 +149,10 @@ def from_files(job, form):
                 )
         job.labels_file = utils.constants.LABELS_FILE
 
-    encoding = form.encoding.data
     shuffle = bool(form.textfile_shuffle.data)
+    backend = form.backend.data
+    encoding = form.encoding.data
+    compression = form.compression.data
 
     ### train
     if form.textfile_use_local_files.data:
@@ -162,10 +172,12 @@ def from_files(job, form):
                 job_dir     = job.dir(),
                 input_file  = train_file,
                 db_name     = utils.constants.TRAIN_DB,
+                backend     = backend,
                 image_dims  = job.image_dims,
                 image_folder= image_folder,
                 resize_mode = job.resize_mode,
                 encoding    = encoding,
+                compression = compression,
                 mean_file   = utils.constants.MEAN_FILE_CAFFE,
                 labels_file = job.labels_file,
                 shuffle     = shuffle,
@@ -192,10 +204,12 @@ def from_files(job, form):
                     job_dir     = job.dir(),
                     input_file  = val_file,
                     db_name     = utils.constants.VAL_DB,
+                    backend     = backend,
                     image_dims  = job.image_dims,
                     image_folder= image_folder,
                     resize_mode = job.resize_mode,
                     encoding    = encoding,
+                    compression = compression,
                     labels_file = job.labels_file,
                     shuffle     = shuffle,
                     )
@@ -221,10 +235,12 @@ def from_files(job, form):
                     job_dir     = job.dir(),
                     input_file  = test_file,
                     db_name     = utils.constants.TEST_DB,
+                    backend     = backend,
                     image_dims  = job.image_dims,
                     image_folder= image_folder,
                     resize_mode = job.resize_mode,
                     encoding    = encoding,
+                    compression = compression,
                     labels_file = job.labels_file,
                     shuffle     = shuffle,
                     )

--- a/digits/dataset/images/views.py
+++ b/digits/dataset/images/views.py
@@ -28,6 +28,7 @@ def image_dataset_resize_example():
         height = int(flask.request.form['height'])
         channels = int(flask.request.form['channels'])
         resize_mode = flask.request.form['resize_mode']
+        backend = flask.request.form['backend']
         encoding = flask.request.form['encoding']
 
         image = utils.image.resize_image(image, height, width,
@@ -35,7 +36,7 @@ def image_dataset_resize_example():
                 resize_mode=resize_mode,
                 )
 
-        if encoding == 'none':
+        if backend != 'lmdb' or encoding == 'none':
             length = len(image.tostring())
         else:
             s = StringIO()

--- a/digits/dataset/job.py
+++ b/digits/dataset/job.py
@@ -25,12 +25,23 @@ class DatasetJob(Job):
 
         if verbose:
             d.update({
-                'ParseFolderTasks': [{"name":        t.name(),
-                                      "label_count": t.label_count,
-                                      "train_count": t.train_count,
-                                      "val_count":   t.val_count,
-                                      "test_count":  t.test_count,
-                                      } for t in self.parse_folder_tasks()],
+                'ParseFolderTasks': [{
+                    "name":        t.name(),
+                    "label_count": t.label_count,
+                    "train_count": t.train_count,
+                    "val_count":   t.val_count,
+                    "test_count":  t.test_count,
+                    } for t in self.parse_folder_tasks()],
+                'CreateDbTasks': [{
+                    "name":             t.name(),
+                    "entries":          t.entries_count,
+                    "image_width":      t.image_dims[0],
+                    "image_height":     t.image_dims[1],
+                    "image_channels":   t.image_dims[2],
+                    "backend":          t.backend,
+                    "encoding":         t.encoding,
+                    "compression":      t.compression,
+                                      } for t in self.create_db_tasks()],
                 })
         return d
 

--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -17,11 +17,12 @@ PICKLE_VERSION = 3
 class CreateDbTask(Task):
     """Creates a database"""
 
-    def __init__(self, input_file, db_name, image_dims, **kwargs):
+    def __init__(self, input_file, db_name, backend, image_dims, **kwargs):
         """
         Arguments:
         input_file -- read images and labels from this file
         db_name -- save database to this location
+        backend -- database backend (lmdb/hdf5)
         image_dims -- (height, width, channels)
 
         Keyword Arguments:
@@ -29,6 +30,7 @@ class CreateDbTask(Task):
         shuffle -- shuffle images before saving
         resize_mode -- used in utils.image.resize_image()
         encoding -- 'none', 'png' or 'jpg'
+        compression -- 'none' or 'gzip'
         mean_file -- save mean file to this location
         labels_file -- used to print category distribution
         """
@@ -37,6 +39,7 @@ class CreateDbTask(Task):
         self.shuffle = kwargs.pop('shuffle', True)
         self.resize_mode = kwargs.pop('resize_mode' , None)
         self.encoding = kwargs.pop('encoding', None)
+        self.compression = kwargs.pop('compression', None)
         self.mean_file = kwargs.pop('mean_file', None)
         self.labels_file = kwargs.pop('labels_file', None)
 
@@ -45,6 +48,7 @@ class CreateDbTask(Task):
 
         self.input_file = input_file
         self.db_name = db_name
+        self.backend = backend
         self.image_dims = image_dims
         if image_dims[2] == 3:
             self.image_channel_order = 'BGR'
@@ -86,6 +90,11 @@ class CreateDbTask(Task):
             else:
                 self.encoding = 'none'
         self.pickver_task_createdb = PICKLE_VERSION
+
+        if not hasattr(self, 'backend'):
+            self.backend = 'lmdb'
+        if not hasattr(self, 'compression'):
+            self.compression = 'none'
 
     @override
     def name(self):
@@ -133,6 +142,7 @@ class CreateDbTask(Task):
                 self.path(self.db_name),
                 self.image_dims[1],
                 self.image_dims[0],
+                '--backend=%s' % self.backend,
                 '--channels=%s' % self.image_dims[2],
                 '--resize_mode=%s' % self.resize_mode,
                 ]
@@ -147,6 +157,8 @@ class CreateDbTask(Task):
             args.append('--shuffle')
         if self.encoding and self.encoding != 'none':
             args.append('--encoding=%s' % self.encoding)
+        if self.compression and self.compression != 'none':
+            args.append('--compression=%s' % self.compression)
 
         return args
 

--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -49,6 +49,12 @@ class CreateDbTask(Task):
         self.input_file = input_file
         self.db_name = db_name
         self.backend = backend
+        if backend == 'hdf5':
+            # store a textfile that contains a path to the hdf5 file
+            self.textfile = '%s.txt' % self.db_name
+            with open(self.path(self.textfile), 'w') as outfile:
+                # XXX - this works because the model job will be in an adjacent folder
+                outfile.write('../%s/%s' % (self.job_id, self.db_name))
         self.image_dims = image_dims
         if image_dims[2] == 3:
             self.image_channel_order = 'BGR'

--- a/digits/templates/datasets/images/classification/new.html
+++ b/digits/templates/datasets/images/classification/new.html
@@ -34,15 +34,6 @@ New Image Classification Dataset
                 </div>
             </div>
             <div class="row">
-                <div class="form-group{{ ' has-error' if form.encoding.errors else '' }}">
-                    <div class="form-group{{' has-error' if form.encoding.errors}}">
-                        {{form.encoding.label}}
-                        {{form.encoding.tooltip}}
-                        {{form.encoding(class='form-control')}}
-                    </div>
-                </div>
-            </div>
-            <div class="row">
                 <div class="form-group{{ ' has-error' if form.resize_width.errors or form.resize_height.errors else '' }}">
                     <label>Image size</label>
                     <span name="resize_dims_explanation"
@@ -82,6 +73,7 @@ function showResizeExample()
                 "width":    $("#resize_width").val(),
                 "height":   $("#resize_height").val(),
                 "resize_mode":   $("#resize_mode").val(),
+                "backend": $("#backend").val(),
                 "encoding": $("#encoding").val(),
             },
             function(response) {
@@ -369,6 +361,49 @@ $('#db-tabs a[href="#db-{{ form.method.data }}"]').tab('show');
 
     <div class="row">
         <div class="col-sm-6 col-sm-offset-3 well">
+            <div class="form-group{{ ' has-error' if form.backend.errors else '' }}">
+                {{ form.backend.label }}
+                {{ form.backend.tooltip }}
+                {{ form.backend(class='form-control') }}
+            </div>
+            <div id="backend-hdf5-warning" class="alert alert-warning" style="display:none;">
+                <b>NOTE:</b> HDF5 is not fully supported by Caffe or by DIGITS
+                <ul>
+                    <li>The standard networks will need some minor customizations before use (change <i>Data</i> layers to <i>HDF5Data</i> layers)</li>
+                    <li><i>HDF5Data</i> layers do not support mean subtraction</li>
+                </ul>
+            </div>
+            <div class="form-group{{ ' has-error' if form.compression.errors else '' }}">
+                <div class="form-group{{' has-error' if form.compression.errors}}">
+                    {{form.compression.label}}
+                    {{form.compression.tooltip}}
+                    {{form.compression(class='form-control')}}
+                </div>
+            </div>
+            <div class="form-group{{ ' has-error' if form.encoding.errors else '' }}">
+                <div class="form-group{{' has-error' if form.encoding.errors}}">
+                    {{form.encoding.label}}
+                    {{form.encoding.tooltip}}
+                    {{form.encoding(class='form-control')}}
+                </div>
+            </div>
+            <script>
+function backendChanged()
+{
+    val = $("#backend").val();
+    if (val == 'lmdb') {
+        $("#compression").parent().hide();
+        $("#encoding").parent().show();
+        $("#backend-hdf5-warning").hide();
+    } else if (val == 'hdf5') {
+        $("#encoding").parent().hide();
+        $("#compression").parent().show();
+        $("#backend-hdf5-warning").show();
+    }
+}
+$("#backend").change(backendChanged);
+backendChanged();
+            </script>
             <div class="form-group{{ ' has-error' if form.dataset_name.errors else '' }}">
                 {{ form.dataset_name.label }}
                 {{ form.dataset_name(class='form-control') }}

--- a/digits/templates/datasets/images/classification/show.html
+++ b/digits/templates/datasets/images/classification/show.html
@@ -12,14 +12,18 @@
         <dd>{{ job.dir() }}</dd>
     </dl>
     <dl>
-        <dt>Image Type</dt>
-        <dd>{{'Color' if job.image_dims[2] == 3 else 'Grayscale'}}</dd>
-        <dt>Image Encoding</dt>
-        <dd>{{job.train_db_task().encoding}}</dd>
         <dt>Image Dimensions</dt>
         <dd>{{job.image_dims[1]}}x{{job.image_dims[0]}}</dd>
+        <dt>Image Type</dt>
+        <dd>{{'Color' if job.image_dims[2] == 3 else 'Grayscale'}}</dd>
         <dt>Resize Transformation</dt>
         <dd>{{ job.resize_mode_name() }}</dd>
+        <dt>DB Backend</dt>
+        <dd>{{job.train_db_task().backend}}</dd>
+        <dt>Image Encoding</dt>
+        <dd>{{job.train_db_task().encoding}}</dd>
+        <dt>DB Compression</dt>
+        <dd>{{job.train_db_task().compression}}</dd>
     </dl>
 </div>
 {% endmacro %}

--- a/digits/templates/datasets/images/classification/summary.html
+++ b/digits/templates/datasets/images/classification/summary.html
@@ -34,7 +34,5 @@
     {% endif %}
     </dd>
     {% endfor %}
-    <dt>Encoding</dt>
-    <dd>{{dataset.train_db_task().encoding}}</dd>
 </dl>
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # REST API
 
-*Generated Sep 10, 2015*
+*Generated Sep 15, 2015*
 
 DIGITS exposes its internal functionality through a REST API. You can access these endpoints by performing a GET or POST on the route, and a JSON object will be returned.
 

--- a/docs/FlaskRoutes.md
+++ b/docs/FlaskRoutes.md
@@ -1,6 +1,6 @@
 # Flask Routes
 
-*Generated Sep 10, 2015*
+*Generated Sep 15, 2015*
 
 Documentation on the various routes used internally for the web application.
 

--- a/tools/test_create_db.py
+++ b/tools/test_create_db.py
@@ -229,3 +229,7 @@ class TestLmdbCreation(BaseCreationTest):
 class TestHdf5Creation(BaseCreationTest):
     BACKEND = 'hdf5'
 
+    def test_dset_limit(self):
+        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+                10, 10, 1, 'hdf5', hdf5_dset_limit=10*10)
+


### PR DESCRIPTION
*Closes #224*

## TODO before merge

* [x] Create models from HDF5 datasets using `HDF5Data` layers
* [x] Expose backend and compression information in REST API
* [x] Shard HDF5 files into acceptable dataset sizes - https://github.com/BVLC/caffe/issues/2953#issuecomment-137274066

## TODO after merge

* Allow non-image data (see #197)
* Analyze prebuilt HDF5 datasets in "generic" path