### PR TITLE
Don't show mean image during dataset creation

### DIFF
--- a/digits/templates/datasets/images/classification/show.html
+++ b/digits/templates/datasets/images/classification/show.html
@@ -89,7 +89,7 @@
         {% endautoescape %}
         );
     </script>
-    {% if task.mean_file %}
+    {% if task.status=='D' and task.mean_file %}
     <b>Image Mean:</b>
     <img src="{{url_for('serve_file', path=task.path('mean.jpg', relative=True))}}" />
     {% endif %}


### PR DESCRIPTION
To avoid broken-image icon being displayed as mean image file
not yet created.