### PR TITLE
Bugfix - wrong shape calculated for infer_many

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -568,3 +568,13 @@ layer {
 }
 """
 
+class TestLeNet(TestCreated):
+    IMAGE_WIDTH = 28
+    IMAGE_HEIGHT = 28
+
+    CAFFE_NETWORK=open(
+            os.path.join(
+                os.path.dirname(digits.__file__),
+                'standard-networks', 'lenet.prototxt')
+            ).read()
+

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -1180,7 +1180,7 @@ class CaffeTrainTask(TrainTask):
 
         caffe_images = np.array(caffe_images)
 
-        data_shape = tuple(self.get_transformer().inputs['data'])
+        data_shape = tuple(self.get_transformer().inputs['data'])[1:]
 
         if self.batch_size:
             data_shape = (self.batch_size,) + data_shape
@@ -1226,7 +1226,7 @@ class CaffeTrainTask(TrainTask):
 
         caffe_images = np.array(caffe_images)
 
-        data_shape = tuple(self.get_transformer().inputs['data'])
+        data_shape = tuple(self.get_transformer().inputs['data'])[1:]
 
         if self.batch_size:
             data_shape = (self.batch_size,) + data_shape


### PR DESCRIPTION
Thanks to @RadicoLabs for reporting this bug (several times):

* https://github.com/NVIDIA/DIGITS/issues/234
* https://github.com/BVLC/caffe/issues/2965
* https://groups.google.com/d/msg/digits-users/fv1lcvvmXNE/QXPl7qCPJQAJ

I introduced a bug in f3cee358fa1105d96b5ddd9cc6fd2aa9db3a5857 that wasn't caught by the test suite. I introduced an additional axis to the shape of the data. The reason this wasn't caught is because the `InnerProduct` layer in the deploy network saw the same number of neurons in the previous layer as it did during training - `10x1x10x10` ~= `10x1x1x10x10`. Convolution layers, however, check for the number of axes and throw an error. 

This commit fixes the bug and adds a test class which uses LeNet (including Convolution layers).