### PR TITLE
Add login facility to DIGITS

### DIFF
--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -4,7 +4,7 @@ import os
 
 import flask
 
-from digits import utils
+from digits.utils.session import session_required
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler, autodoc
 from digits.dataset import tasks
@@ -232,6 +232,7 @@ def from_files(job, form):
 
 
 @app.route(NAMESPACE + '/new', methods=['GET'])
+@session_required
 @autodoc('datasets')
 def image_classification_dataset_new():
     """
@@ -242,6 +243,7 @@ def image_classification_dataset_new():
 
 @app.route(NAMESPACE + '.json', methods=['POST'])
 @app.route(NAMESPACE, methods=['POST'])
+@session_required
 @autodoc(['datasets', 'api'])
 def image_classification_dataset_create():
     """
@@ -295,6 +297,7 @@ def show(job):
     return flask.render_template('datasets/images/classification/show.html', job=job)
 
 @app.route(NAMESPACE + '/summary', methods=['GET'])
+@session_required
 @autodoc('datasets')
 def image_classification_dataset_summary():
     """

--- a/digits/dataset/images/generic/views.py
+++ b/digits/dataset/images/generic/views.py
@@ -2,6 +2,7 @@
 
 import flask
 
+from digits.utils.session import session_required
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler, autodoc
 from digits.dataset import tasks
@@ -11,6 +12,7 @@ from job import GenericImageDatasetJob
 NAMESPACE = '/datasets/images/generic'
 
 @app.route(NAMESPACE + '/new', methods=['GET'])
+@session_required
 @autodoc('datasets')
 def generic_image_dataset_new():
     """
@@ -21,6 +23,7 @@ def generic_image_dataset_new():
 
 @app.route(NAMESPACE + '.json', methods=['POST'])
 @app.route(NAMESPACE, methods=['POST'])
+@session_required
 @autodoc(['datasets', 'api'])
 def generic_image_dataset_create():
     """
@@ -100,6 +103,7 @@ def show(job):
     return flask.render_template('datasets/images/generic/show.html', job=job)
 
 @app.route(NAMESPACE + '/summary', methods=['GET'])
+@session_required
 @autodoc('datasets')
 def generic_image_dataset_summary():
     """

--- a/digits/dataset/images/views.py
+++ b/digits/dataset/images/views.py
@@ -8,6 +8,7 @@ import PIL.Image
 
 import digits
 from digits import utils
+from digits.utils.session import session_required
 from digits.webapp import app, autodoc
 import classification.views
 import generic.views
@@ -15,6 +16,7 @@ import generic.views
 NAMESPACE = '/datasets/images'
 
 @app.route(NAMESPACE + '/resize-example', methods=['POST'])
+@session_required
 @autodoc('datasets')
 def image_dataset_resize_example():
     """

--- a/digits/dataset/views.py
+++ b/digits/dataset/views.py
@@ -3,7 +3,9 @@
 import flask
 import werkzeug.exceptions
 
+from digits import utils
 from digits.webapp import app, scheduler, autodoc
+from digits.utils.session import session_required
 from digits.utils.routing import request_wants_json
 import images.views
 import images as dataset_images
@@ -12,6 +14,7 @@ NAMESPACE = '/datasets/'
 
 @app.route(NAMESPACE + '<job_id>.json', methods=['GET'])
 @app.route(NAMESPACE + '<job_id>', methods=['GET'])
+@session_required
 @autodoc(['datasets', 'api'])
 def datasets_show(job_id):
     """

--- a/digits/forms.py
+++ b/digits/forms.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
+
+from flask.ext.wtf import Form
+from wtforms import StringField
+from wtforms.validators import DataRequired
+
+class LoginForm(Form):
+    username = StringField(u'Username',
+        validators=[DataRequired()]
+        )

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -18,6 +18,7 @@ except ImportError:
 import digits
 from digits.config import config_value
 from digits import utils
+from digits.utils.session import session_required
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler, autodoc
 from digits.dataset import ImageClassificationDatasetJob
@@ -30,6 +31,7 @@ import platform
 NAMESPACE   = '/models/images/classification'
 
 @app.route(NAMESPACE + '/new', methods=['GET'])
+@session_required
 @autodoc('models')
 def image_classification_model_new():
     """
@@ -51,6 +53,7 @@ def image_classification_model_new():
 
 @app.route(NAMESPACE + '.json', methods=['POST'])
 @app.route(NAMESPACE, methods=['POST'])
+@session_required
 @autodoc(['models', 'api'])
 def image_classification_model_create():
     """
@@ -223,6 +226,7 @@ def show(job):
     return flask.render_template('models/images/classification/show.html', job=job)
 
 @app.route(NAMESPACE + '/large_graph', methods=['GET'])
+@session_required
 @autodoc('models')
 def image_classification_model_large_graph():
     """
@@ -234,6 +238,7 @@ def image_classification_model_large_graph():
 
 @app.route(NAMESPACE + '/classify_one.json', methods=['POST'])
 @app.route(NAMESPACE + '/classify_one', methods=['POST', 'GET'])
+@session_required
 @autodoc(['models', 'api'])
 def image_classification_model_classify_one():
     """
@@ -291,6 +296,7 @@ def image_classification_model_classify_one():
 
 @app.route(NAMESPACE + '/classify_many.json', methods=['POST'])
 @app.route(NAMESPACE + '/classify_many', methods=['POST', 'GET'])
+@session_required
 @autodoc(['models', 'api'])
 def image_classification_model_classify_many():
     """
@@ -375,6 +381,7 @@ def image_classification_model_classify_many():
                 )
 
 @app.route(NAMESPACE + '/top_n', methods=['POST'])
+@session_required
 @autodoc('models')
 def image_classification_model_top_n():
     """

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -15,6 +15,7 @@ except ImportError:
 
 from digits.config import config_value
 from digits import utils
+from digits.utils.session import session_required
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler, autodoc
 from digits.dataset import GenericImageDatasetJob
@@ -27,6 +28,7 @@ import platform
 NAMESPACE   = '/models/images/generic'
 
 @app.route(NAMESPACE + '/new', methods=['GET'])
+@session_required
 @autodoc('models')
 def generic_image_model_new():
     """
@@ -47,6 +49,7 @@ def generic_image_model_new():
 
 @app.route(NAMESPACE + '.json', methods=['POST'])
 @app.route(NAMESPACE, methods=['POST'])
+@session_required
 @autodoc(['models', 'api'])
 def generic_image_model_create():
     """
@@ -201,6 +204,7 @@ def show(job):
     return flask.render_template('models/images/generic/show.html', job=job)
 
 @app.route(NAMESPACE + '/large_graph', methods=['GET'])
+@session_required
 @autodoc('models')
 def generic_image_model_large_graph():
     """
@@ -212,6 +216,7 @@ def generic_image_model_large_graph():
 
 @app.route(NAMESPACE + '/infer_one.json', methods=['POST'])
 @app.route(NAMESPACE + '/infer_one', methods=['POST', 'GET'])
+@session_required
 @autodoc(['models', 'api'])
 def generic_image_model_infer_one():
     """
@@ -265,6 +270,7 @@ def generic_image_model_infer_one():
 
 @app.route(NAMESPACE + '/infer_many.json', methods=['POST'])
 @app.route(NAMESPACE + '/infer_many', methods=['POST', 'GET'])
+@session_required
 @autodoc(['models', 'api'])
 def generic_image_model_infer_many():
     """

--- a/digits/model/views.py
+++ b/digits/model/views.py
@@ -20,6 +20,7 @@ import caffe.draw
 
 import digits
 from digits.webapp import app, scheduler, autodoc
+from digits.utils.session import session_required
 from digits.utils.routing import request_wants_json
 import images.views
 import images as model_images
@@ -28,6 +29,7 @@ NAMESPACE = '/models/'
 
 @app.route(NAMESPACE + '<job_id>.json', methods=['GET'])
 @app.route(NAMESPACE + '<job_id>', methods=['GET'])
+@session_required
 @autodoc(['models', 'api'])
 def models_show(job_id):
     """
@@ -52,6 +54,7 @@ def models_show(job_id):
                     'Invalid job type')
 
 @app.route(NAMESPACE + 'customize', methods=['POST'])
+@session_required
 @autodoc('models')
 def models_customize():
     """
@@ -89,6 +92,7 @@ def models_customize():
         })
 
 @app.route(NAMESPACE + 'visualize-network', methods=['POST'])
+@session_required
 @autodoc('models')
 def models_visualize_network():
     """
@@ -102,6 +106,7 @@ def models_visualize_network():
     return '<image src="data:image/png;base64,' + caffe.draw.draw_net(net, 'UD').encode('base64') + '" style="max-width:100%" />'
 
 @app.route(NAMESPACE + 'visualize-lr', methods=['POST'])
+@session_required
 @autodoc('models')
 def models_visualize_lr():
     """
@@ -157,6 +162,7 @@ def models_visualize_lr():
         defaults={'extension': 'tar.gz'})
 @app.route(NAMESPACE + '<job_id>/download.<extension>',
         methods=['GET', 'POST'])
+@session_required
 @autodoc('models')
 def models_download(job_id, extension):
     """

--- a/digits/templates/layout.html
+++ b/digits/templates/layout.html
@@ -36,6 +36,10 @@
                 {% if server_name %}
                 <li><a>{{server_name}}</a></li>
                 {% endif %}
+                {% if session.username %}
+                <li><a>{{ session.username }}</a></li>
+                <li><a href="{{ url_for('logout') }}">logout</a></li>
+                {% endif %}
             </ul>
         </div>
     </div>

--- a/digits/templates/login.html
+++ b/digits/templates/login.html
@@ -1,0 +1,53 @@
+{# Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% extends "layout.html" %}
+
+{% block title %}
+Login
+{% endblock %}
+
+{% block content %}
+
+<div class="page-header">
+    <h1>Login</h1>
+</div>
+
+<form action="{{ url_for('login') }}" enctype="multipart/form-data" method='post'>
+    {{ form.hidden_tag() }}
+
+    {% if form.errors %}
+        <div class="alert alert-danger">
+            {% for field, errors in form.errors.items() %}
+                <li>{{ field }}
+                    <ul>
+                        {% for e in errors %}
+                            <li>{{ e }}</li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    <div class="row">
+        <div class="col-sm-4 well">
+            <div class="row">
+                <div class="form-group{{ ' has-error' if form.username.errors else '' }}">
+                    {{ form.username.label }}
+                    <div class="input-group">
+                        {{ form.username(class='form-control') }}
+                        <span name="username_explanation"
+                            class="input-group-addon explanation-tooltip glyphicon glyphicon-question-sign"
+                            data-container="body"
+                            title="Username to tag future datasets and models with."
+                            ></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <input type="submit" name="login" class="btn btn-primary" value="Login">
+</form>
+
+{% endblock %}

--- a/digits/utils/session.py
+++ b/digits/utils/session.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
+
+from functools import update_wrapper
+
+from flask import session, redirect, url_for
+
+# simple session decorator
+def session_required(f):
+    def wrapper(*args, **kwargs):
+        if 'username' not in session:
+            return redirect(url_for('login'))
+
+        return f(*args, **kwargs)
+
+    update_wrapper(wrapper, f)
+    wrapper.__name__ = f.__name__
+
+    return wrapper


### PR DESCRIPTION
DO NOT merge yet!

This is a work in progress for "light login" capabilities. This does NOT attempt to recreate full authentication or access control. It lays the groundwork for doing things like tagging different jobs by the user that submitted them, or for warning the user if they're about to delete another person's job.

The design: add a decorator to all view functions except for the login page. The decorator checks for a signed cookie with the username in it. If there is no cookie, it redirects to the login page where a user can identify themselves.

NOTE: this pull request breaks nearly every test in the DIGITS test suite. Fake authentication will need to be added to each test.