### PR TITLE
Move "Trained Models" text inside form

### DIFF
--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -76,7 +76,6 @@
 
             {% set task = job.train_task() %}
             <hr>
-            <h2>Trained Models</h2>
             <form id="test-model-form"
                 enctype="multipart/form-data"
                 method="post"
@@ -85,6 +84,7 @@
                 style="display:none;"
                 {% endif %}
                 >
+                <h2>Trained Models</h2>
                 <div class="row">
                     <div class="col-sm-12">
                         <label for="snapshot_epoch">Select Model</label>

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -70,7 +70,6 @@
 
             {% set task = job.train_task() %}
             <hr>
-            <h2>Trained Models</h2>
             <form id="test-model-form"
                 enctype="multipart/form-data"
                 method="post"
@@ -79,6 +78,7 @@
                 style="display:none;"
                 {% endif %}
                 >
+                <h2>Trained Models</h2>
                 <div class="row">
                     <div class="col-sm-12">
                         <label for="snapshot_epoch">Select Model</label>


### PR DESCRIPTION
Fix for #244.

The form is hidden until the first model snapshot.