### PR TITLE
Use Flask-Autodoc v0.1.2

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 nose>=1.3.1
 mock>=1.0.1
 beautifulsoup4>=4.2.1
--e git://github.com/lukeyeager/flask-autodoc.git#egg=Flask_Autodoc-master
+Flask-Autodoc>=0.1.2
 selenium>=2.25.0
 coverage>=3.7.1
 coveralls>=0.5

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -148,7 +148,7 @@ class DocGenerator(object):
                     args[-1] = '%s (`%s`)' % (args[-1], route['defaults'][arg])
             self.w('Arguments: ' + ', '.join(args))
             self.w()
-        if 'location' in route:
+        if 'location' in route and route['location']:
             # get location relative to digits root
             digits_root = os.path.dirname(
                     os.path.dirname(


### PR DESCRIPTION
`v0.1.2` [was released](https://github.com/acoomans/flask-autodoc/releases/tag/0.1.2) this week, including grouping fixes (https://github.com/acoomans/flask-autodoc/commit/e4d58f4cb4d75f0b0bd8f93524eba98a6d8b6a9f) and file location information (https://github.com/acoomans/flask-autodoc/pull/17). Let's use it instead of my custom version.