### PR TITLE
Remove Landscape.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/NVIDIA/DIGITS.svg?branch=master)](https://travis-ci.org/NVIDIA/DIGITS)
 [![Coverage Status](https://coveralls.io/repos/NVIDIA/DIGITS/badge.svg?branch=master)](https://coveralls.io/r/NVIDIA/DIGITS?branch=master)
-[![Code Health](https://landscape.io/github/NVIDIA/DIGITS/master/landscape.svg?style=flat)](https://landscape.io/github/NVIDIA/DIGITS/master)
 
 DIGITS (the **D**eep Learning **G**PU **T**raining **S**ystem) is is a webapp for training deep learning models.
 


### PR DESCRIPTION
*See https://github.com/landscapeio/landscape-issues/issues/179*

Let's remove the icon (which fails to load) from the README. When/if the website comes back up, we'll still be able to access it at https://landscape.io/github/NVIDIA/DIGITS without the badge.