### PR TITLE
Fix previous network snapshot lists

### DIFF
--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -427,7 +427,9 @@ frameworks['{{ fw.get_id() }}'] = framework;
                 <div id="network-tab-previous" class="tab-pane">
 
                     <div class="tab-content">
-                        {% for batch in form.previous_networks|batch(10) %}
+                        {% set batch_size = 10 %}
+                        {% for batch in form.previous_networks|batch(batch_size) %}
+                        {% set batch_loop_index = loop.index0 %}
                         <div class="tab-pane{{' active' if loop.index==1}}" id="previous_networks-page-{{loop.index}}">
 
                             <table class="table">
@@ -437,16 +439,17 @@ frameworks['{{ fw.get_id() }}'] = framework;
                                     <th></th>
                                 </tr>
                                 {% for network in batch %}
-                                {% set each_previous_network = previous_networks_fullinfo[loop.index0] %}
+                                {% set inner_index = batch_loop_index * batch_size + loop.index0 %}
+                                {% set previous_job = previous_networks_fullinfo[inner_index] %}
                                 <tr>
                                     <td>
                                         {{network}}
                                         {{network.label}}
                                         <a href="{{url_for("models_show", job_id=network.data)}}" target="_blank">View</a>
-                                        <span class="badge">{{each_previous_network.train_task().get_framework_id()}}</span>
+                                        <span class="badge">{{previous_job.train_task().get_framework_id()}}</span>
                                     </td>
                                     <td>
-                                        {% set snapshot_list = previous_network_snapshots[loop.index0] %}
+                                        {% set snapshot_list = previous_network_snapshots[inner_index] %}
                                         {% if snapshot_list|length %}
                                         <select class="form-control" id="{{network.data}}-snapshot" name="{{network.data}}-snapshot">
                                             {% for each_epoch in snapshot_list %}
@@ -455,7 +458,7 @@ frameworks['{{ fw.get_id() }}'] = framework;
                                         </select>
                                         {% endif %}
                                     </td>
-                                    <td><a class="btn btn-sm" onClick="customizeNetwork('{{network.data}}', '{{network.data}}-snapshot', '{{each_previous_network.train_task().get_framework_id()}}' );">Customize</a></td>
+                                    <td><a class="btn btn-sm" onClick="customizeNetwork('{{network.data}}', '{{network.data}}-snapshot', '{{previous_job.train_task().get_framework_id()}}' );">Customize</a></td>
                                 </tr>
                                 {% else %}
                                 <tr>
@@ -468,10 +471,10 @@ frameworks['{{ fw.get_id() }}'] = framework;
                         {% endfor %}
                     </div>
 
-                    {% if form.previous_networks.choices|length > 10 %}
+                    {% if form.previous_networks.choices|length > batch_size %}
                     <div class="text-center">
                         <ul class="pagination">
-                            {% for i in range((form.previous_networks.choices|length/10)|round(0,'ceil')|int) %}
+                            {% for i in range((form.previous_networks.choices|length/batch_size)|round(0,'ceil')|int) %}
                             <li class="{{'active' if i==0}}"><a href="#previous_networks-page-{{i+1}}" data-toggle="tab">{{i+1}}</a></li>
                             {% endfor %}
                         </ul>

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -352,40 +352,62 @@ function customizeNetwork(network, snapshot_list) {
 
                 </div>
                 <div id="network-tab-previous" class="tab-pane">
-                    <table class="table">
-                        <tr>
-                            <th>Network</th>
-                            <th>Pretrained Model</th>
-                            <th></th>
-                        </tr>
-                        {% for network in form.previous_networks %}
-                        {% set each_previous_network = previous_networks_fullinfo[loop.index0] %}
-                        <tr>
-                            <td>
-                                {{network}}
-                                {{network.label}}
-                                <a href="{{url_for("models_show", job_id=network.data)}}" target="_blank">View</a>
-                                <span class="badge">{{each_previous_network.train_task().get_framework_id()}}</span>
-                            </td>
-                            <td>
-                                {% set snapshot_list = previous_network_snapshots[loop.index0] %}
-                                {% if snapshot_list|length %}
-                                <select class="form-control" id="{{network.data}}-snapshot" name="{{network.data}}-snapshot">
-                                    {% for each_epoch in snapshot_list %}
-                                    <option value="{{each_epoch[0]}}">{{each_epoch[1]}}</option>
-                                    {% endfor %}
-                                </select>
-                                {% endif %}
-                            </td>
-                            <td><a class="btn btn-sm" onClick="customizeNetwork('{{network.data}}', '{{network.data}}-snapshot');">Customize</a></td>
-                        </tr>
-                        {% else %}
-                        <tr>
-                            <td><i>None</i></td>
-                        </tr>
+
+                    <div class="tab-content">
+                        {% set batch_size = 10 %}
+                        {% for batch in form.previous_networks|batch(batch_size) %}
+                        {% set batch_loop_index = loop.index0 %}
+                        <div class="tab-pane{{' active' if loop.index==1}}" id="previous_networks-page-{{loop.index}}">
+                            <table class="table">
+                                <tr>
+                                    <th>Network</th>
+                                    <th>Pretrained Model</th>
+                                    <th></th>
+                                </tr>
+                                {% for network in batch %}
+                                {% set inner_index = batch_loop_index * batch_size + loop.index0 %}
+                                {% set previous_job = previous_networks_fullinfo[inner_index] %}
+                                <tr>
+                                    <td>
+                                        {{network}}
+                                        {{network.label}}
+                                        <a href="{{url_for("models_show", job_id=network.data)}}" target="_blank">View</a>
+                                        <span class="badge">{{previous_job.train_task().get_framework_id()}}</span>
+                                    </td>
+                                    <td>
+                                        {% set snapshot_list = previous_network_snapshots[inner_index] %}
+                                        {% if snapshot_list|length %}
+                                        <select class="form-control" id="{{network.data}}-snapshot" name="{{network.data}}-snapshot">
+                                            {% for each_epoch in snapshot_list %}
+                                            <option value="{{each_epoch[0]}}">{{each_epoch[1]}}</option>
+                                            {% endfor %}
+                                        </select>
+                                        {% endif %}
+                                    </td>
+                                    <td><a class="btn btn-sm" onClick="customizeNetwork('{{network.data}}', '{{network.data}}-snapshot');">Customize</a></td>
+                                </tr>
+                                {% else %}
+                                <tr>
+                                    <td><i>None</i></td>
+                                </tr>
+                                {% endfor %}
+                            </table>
+                        </div>
                         {% endfor %}
-                    </table>
+                    </div>
+
+                    {% if form.previous_networks.choices|length > batch_size %}
+                    <div class="text-center">
+                        <ul class="pagination">
+                            {% for i in range((form.previous_networks.choices|length/batch_size)|round(0,'ceil')|int) %}
+                            <li class="{{'active' if i==0}}"><a href="#previous_networks-page-{{i+1}}" data-toggle="tab">{{i+1}}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+
                 </div>
+
                 <script>
                     // hide some buttons and form elements
                     $("#network-tab-standard .btn.btn-sm").css('visibility', 'hidden');


### PR DESCRIPTION
Fix bug introduced in 66d8404713b0fa94f84a33a2cf4031fa20e6aa3c for `ClassificationJobs` - the snapshot list for the first job on the second page was really the list for the first job on the first page.

Add pagination for `GenericJobs`. It wasn't added with 66d8404713b0fa94f84a33a2cf4031fa20e6aa3c.