### PR TITLE
Show training accuracy for standard networks

### DIFF
--- a/digits/standard-networks/caffe/alexnet.prototxt
+++ b/digits/standard-networks/caffe/alexnet.prototxt
@@ -363,9 +363,6 @@ layer {
   bottom: "fc8"
   bottom: "label"
   top: "accuracy"
-  include {
-    phase: TEST
-  }
 }
 layer {
   name: "loss"

--- a/digits/standard-networks/caffe/lenet.prototxt
+++ b/digits/standard-networks/caffe/lenet.prototxt
@@ -154,9 +154,6 @@ layer {
   bottom: "ip2"
   bottom: "label"
   top: "accuracy"
-  include {
-    phase: TEST
-  }
 }
 layer {
   name: "loss"


### PR DESCRIPTION
@borisgin suggested this as a debugging tool - thanks for the suggestion!

**Network output ordering**
DIGITS does some weird ordering of network outputs in the loss/accuracy graph. This is done in an attempt to keep the loss and accuracy the same color for all standard networks. With this fix, they would appear in one order on the initial page load, and then in a different order when you refresh the page. If we did this, we should probably order them with validation outputs before training outputs to match the order in which Caffe outputs them.

**GoogLeNet**
GoogLeNet already has a ton of outputs (12). It has a loss layer and two accuracy layers for each of the three classifiers. This change would increase that to 18 outputs overall if we did it for all accuracy layers. Should we remove the accuracy for the first two classifiers entirely (down to 8, then up to 10)?