### PR TITLE
Update image.py

### DIFF
--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -9,6 +9,9 @@ import numpy as np
 import scipy.misc
 import math
 
+from PIL import ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
+
 from . import is_url, HTTP_TIMEOUT, errors
 
 # Library defaults:


### PR DESCRIPTION
Load Truncated images instead of ignoring them.

Ignoring too many seems to cause a crash with DIGITS