### PR TITLE
Fix data sharding in HDF5 files

### DIFF
--- a/tools/create_db.py
+++ b/tools/create_db.py
@@ -120,6 +120,7 @@ class Hdf5Writer(DbWriter):
         data_batch = data_batch.transpose((0,3,1,2))
         label_batch = np.array([i[1] for i in batch])
 
+
         # first batch
         if self._db is None:
             self._create_new_file(len(batch))
@@ -140,7 +141,7 @@ class Hdf5Writer(DbWriter):
             return
 
         # calculate how many will fit in current dataset
-        split = current_count + len(batch) - self._max_count
+        split = self._max_count - current_count
 
         if split > 0:
             # put what we can into the current dataset

--- a/tools/test_create_db.py
+++ b/tools/test_create_db.py
@@ -230,6 +230,10 @@ class TestHdf5Creation(BaseCreationTest):
     BACKEND = 'hdf5'
 
     def test_dset_limit(self):
-        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+        db_dir = os.path.join(self.empty_dir, 'db')
+        _.create_db(self.good_file[1], db_dir,
                 10, 10, 1, 'hdf5', hdf5_dset_limit=10*10)
+        with open(os.path.join(db_dir, 'list.txt')) as infile:
+            lines = infile.readlines()
+            assert len(lines) == self.image_count, '%d != %d' % (len(lines), self.image_count)
 


### PR DESCRIPTION
@gheinrich mentioned that the tests were still failing on Ubuntu 12. This should fix the issue.