### PR TITLE
Fix create_db_task.backend == None scenario

### DIFF
--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -94,9 +94,9 @@ class CreateDbTask(Task):
                 self.encoding = 'none'
         self.pickver_task_createdb = PICKLE_VERSION
 
-        if not hasattr(self, 'backend'):
+        if not hasattr(self, 'backend') or self.backend is None:
             self.backend = 'lmdb'
-        if not hasattr(self, 'compression'):
+        if not hasattr(self, 'compression') or self.compression is None:
             self.compression = 'none'
 
     @override


### PR DESCRIPTION
If you switch around between different versions of the code, the backend
field can get set to None and that breaks things. This is a more
explicit check.