### PR TITLE
Change file inputs to look the same in chrome and firefox and have bo…

### DIFF
--- a/digits/dataset/images/classification/forms.py
+++ b/digits/dataset/images/classification/forms.py
@@ -188,7 +188,7 @@ class ImageClassificationDatasetForm(ImageDatasetForm):
     textfile_use_local_files = wtforms.BooleanField(u'Use local files',
         default=False)
 
-    textfile_train_images = wtforms.FileField(u'Training images',
+    textfile_train_images = utils.forms.FileField(u'Training images',
             validators=[
                 validate_required_iff(method='textfile',
                                       textfile_use_local_files=False)
@@ -219,7 +219,7 @@ class ImageClassificationDatasetForm(ImageDatasetForm):
                 validate_required_iff(method='textfile')
                 ]
             )
-    textfile_val_images = wtforms.FileField(u'Validation images',
+    textfile_val_images = utils.forms.FileField(u'Validation images',
             validators=[
                 validate_required_iff(
                     method='textfile',
@@ -254,7 +254,7 @@ class ImageClassificationDatasetForm(ImageDatasetForm):
                 validate_required_iff(method='textfile')
                 ]
             )
-    textfile_test_images = wtforms.FileField(u'Test images',
+    textfile_test_images = utils.forms.FileField(u'Test images',
             validators=[
                 validate_required_iff(
                     method='textfile',

--- a/digits/static/css/style.css
+++ b/digits/static/css/style.css
@@ -26,3 +26,35 @@ path.c3-line {
 .autocomplete-suggestions strong { font-weight: normal; color: #3399FF; }
 .autocomplete-group { padding: 2px 5px; }
 .autocomplete-group strong { display: block; border-bottom: 1px solid #000; }
+
+.btn-file {
+    position: relative;
+    overflow: hidden;
+}
+
+.btn-file input[type=file] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-width: 100%;
+    min-height: 100%;
+    font-size: 100px;
+    text-align: right;
+    filter: alpha(opacity=0);
+    opacity: 0;
+    outline: none;
+    background: white;
+    cursor: inherit;
+    display: block;
+}
+
+input[readonly] {
+    background-color: white !important;
+    cursor: text !important;
+}
+
+input[readonly]:disabled {
+    background-color: #EEE !important;
+    cursor: not-allowed !important;
+}
+

--- a/digits/static/js/file_field.js
+++ b/digits/static/js/file_field.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
+
+$(document).on('change', '.btn-file :file', function() {
+  var input = $(this),
+      numFiles = input.get(0).files ? input.get(0).files.length : 1,
+      label = input.val().replace(/\\/g, '/').replace(/.*\//, '');
+  input.trigger('fileselect', [numFiles, label]);
+});
+
+$(document).ready( function() {
+    $('.btn-file :file').on('fileselect', function(event, numFiles, label) {
+
+        var input = $(this).parents('.input-group').find(':text'),
+            log = numFiles > 1 ? numFiles + ' files selected' : label;
+
+        if( input.length ) {
+            input.val(log);
+        } else {
+            if( log ) alert(log);
+        }
+    });
+});

--- a/digits/templates/datasets/images/classification/new.html
+++ b/digits/templates/datasets/images/classification/new.html
@@ -213,15 +213,15 @@ hasTestFolderChanged();
                     <div class="row">
                         <table class="table">
                             <tr>
-                                <th>Set</th>
+                                <th width="20%">Set</th>
 
-                                <th>Text file <span name="text_file_explanation"
+                                <th width="40%">Text file <span name="text_file_explanation"
                           class="explanation-tooltip glyphicon glyphicon-question-sign"
                                     data-container="body"
                                     title="Each line in the file should be formatted as '<PATH> <LABEL>' where <PATH> specifies image path either on the local filesystem or a URL, and the <LABEL> is a numeric label that matches the uploaded labels file"
                                 ></span></th>
 
-                                <th>Image folder <i>(optional)</i> <span name="image_folder_explanation"
+                                <th width="40%">Image folder <i>(optional)</i> <span name="image_folder_explanation"
                                     class="explanation-tooltip glyphicon glyphicon-question-sign"
                                     data-container="body"
                                     title="Paths in the text files will be appended with this value before reading"
@@ -328,11 +328,25 @@ function textfile_image_sets_disabled() {
         $(".cl-upload-files").show();
         $(".cl-local-files").hide();
     }
-    $("#textfile_val_images").prop("disabled", !value);
+
+     if (value) {
+         $("#textfile_val_images_btn").removeClass("disabled");
+     } else {
+         $("#textfile_val_images_btn").addClass("disabled");
+     }
+
+    $("#textfile_val_images_text").prop("disabled", !value);
     $("#textfile_local_val_images").prop("disabled", !value);
     $("#textfile_val_folder").prop("disabled", !value);
     value = $("#textfile_use_test").prop("checked");
-    $("#textfile_test_images").prop("disabled", !value);
+
+     if (value) {
+         $("#textfile_test_images_btn").removeClass("disabled");
+     } else {
+         $("#textfile_test_images_btn").addClass("disabled");
+     }
+
+    $("#textfile_test_images_text").prop("disabled", !value);
     $("#textfile_local_test_images").prop("disabled", !value);
     $("#textfile_test_folder").prop("disabled", !value);
 }

--- a/digits/templates/layout.html
+++ b/digits/templates/layout.html
@@ -16,6 +16,7 @@
     <script src="{{ url_for('static', filename='js/d3.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/c3.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/jquery.autocomplete.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/file_field.js') }}"></script>
 
     {% block head %}
     {% endblock %}

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -144,6 +144,7 @@ showHideAdvancedLROptions();
                 </script>
 
                 <div id="advanced-lr-options" style="display:none;">
+
                     <div class="form-group{{' has-error' if form.lr_policy.errors}}">
                         {{form.lr_policy.label}}
                         {{form.lr_policy(class='form-control learning-rate-option')}}

--- a/digits/utils/forms.py
+++ b/digits/utils/forms.py
@@ -177,13 +177,35 @@ class StringField(wtforms.StringField):
         self.explanation = Explanation(self.id, self.short_name, explanation_file)
 
 
+class FileInput(object):
+    """
+    Renders a file input chooser field.
+    """
+
+    def __call__(self, field, **kwargs):
+        kwargs.setdefault('id', field.id)
+        return wtforms.widgets.HTMLString(
+            ('<div class="input-group">' +
+             '  <span class="input-group-btn">' +
+             '    <span class="btn btn-info btn-file" %s>' +
+             '      Browse&hellip;' +
+             '      <input %s>' +
+             '    </span>' +
+             '  </span>' +
+             '  <input class="form-control" %s readonly>' +
+             '</div>') % (wtforms.widgets.html_params(id=field.name + '_btn', name=field.name + '_btn'),
+                          wtforms.widgets.html_params(name=field.name, type='file', **kwargs),
+                          wtforms.widgets.html_params(id=field.id + '_text', name=field.name + '_text', type='text')))
+
 class FileField(wtforms.FileField):
+    # Comment out the following line to use the native file input
+    widget = FileInput()
+
     def __init__(self, label='', validators=None, tooltip='', explanation_file = '', **kwargs):
         super(FileField, self).__init__(label, validators, **kwargs)
 
         self.tooltip = Tooltip(self.id, self.short_name, tooltip)
         self.explanation = Explanation(self.id, self.short_name, explanation_file)
-
 
 class TextAreaField(wtforms.TextAreaField):
     def __init__(self, label='', validators=None, tooltip='', explanation_file = '', **kwargs):


### PR DESCRIPTION
This is an attempt to unuglify the input file widgets in FireFox, and apply the bootstrap look. Now they look the same in FireFox and Chrome.

![screenshot from 2015-09-22 13 43 51](https://cloud.githubusercontent.com/assets/13259615/10031095/18cb4ffe-6130-11e5-9dc5-7f82dfaeb6c7.png)
