### PR TITLE
Fix rounding bug introduced by 80e3330

### DIFF
--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -94,8 +94,8 @@ def upscale(image, ratio):
         raise ValueError('Expected ndarray')
     if ratio<1:
         raise ValueError('Ratio must be greater than 1 (ratio=%f)' % ratio)
-    width = int(math.ceil(image.shape[1] * ratio))
-    height = int(math.ceil(image.shape[0] * ratio))
+    width = int(math.floor(image.shape[1] * ratio))
+    height = int(math.floor(image.shape[0] * ratio))
     channels = image.shape[2]
     out = np.ndarray((height, width, channels),dtype=np.uint8)
     for x, y in np.ndindex((width,height)):


### PR DESCRIPTION
We should take the floor of `dim*ratio` when calculating the size of the upscaled image. In some cases where the ratio is not numerically correct, taking the ceiling of `dim*ratio` will result in a slightly larger image than expected. For example if the minimum required dimension is 100 and an image with a minimum dimension of 78 must be upscaled:

```
>>> min_img_dim=100
>>> min_dim=78
>>> ratio=float(min_img_dim)/min_dim
>>> ratio
1.2820512820512822
>>> ratio*min_dim
100.00000000000001
>>> math.ceil(ratio*min_dim)
101.0
```

If we take the ceiling of `ratio*min_dim` then the resulting dimension in the upscaled image  is 101, as opposed to the expected 100. This can result in out-of-band read from the input image later on when populating the upscaled image matrix.