### PR TITLE
Support for train data augmentation

### DIFF
--- a/digits/dataset/images/classification/forms.py
+++ b/digits/dataset/images/classification/forms.py
@@ -38,6 +38,158 @@ class ImageClassificationDatasetForm(ImageDatasetForm):
             tooltip='Compressing the dataset may significantly decrease the size of your database files, but it may increase read and write times.',
             )
 
+    ### Data augmentation - rotation 
+    has_augmentation_rotation = utils.forms.BooleanField('Perform rotations on images',
+            default = False,
+            tooltip = "You can augment your dataset by performing rotation on images.",
+            validators=[ 
+                ]
+            )
+
+    augmentation_rotation_angle_min = utils.forms.IntegerField(u'angle min',
+            default=-90,
+            validators=[ 
+                validators.NumberRange(min=-360, max=360)
+                ],
+            tooltip = "The minimum rotation angle that can be performed during augmentation."
+            )
+
+    augmentation_rotation_angle_max = utils.forms.IntegerField(u'angle max',
+            default=90,
+            validators=[ 
+                validators.NumberRange(min=-360, max=360)
+                ],
+            tooltip = "The maximum rotation angle that can be performed during augmentation."
+            )
+
+    augmentation_rotation_probability = utils.forms.FloatField(u'probability',
+            default=0.75,
+            validators=[ 
+                validators.NumberRange(min=0.0, max=1.0)
+                ],
+            tooltip = "The probability for an image to be rotated during augmentation."
+            )
+
+    ### Data augmentation - hue 
+    has_augmentation_hue = utils.forms.BooleanField('Perform hue modulation on images',
+            tooltip="You can augment your dataset by performing hue modulation on images.",
+            default=False,
+            validators=[ 
+                ]
+            )
+ 
+    augmentation_hue_angle = utils.forms.FloatField(u'angle',
+            default=0.5,
+            validators=[ 
+                validators.NumberRange(min=0.0, max=1.0)
+                ],
+            tooltip = "The maximum angle of the hue modulation."
+            )
+
+    augmentation_hue_angle_min = utils.forms.IntegerField(u'angle min',
+            default=66,
+            validators=[ 
+                validators.NumberRange(min=0, max=360)
+                ],
+            tooltip = "The minimum angle of the hue modulation."
+            )
+    augmentation_hue_angle_max = utils.forms.IntegerField(u'angle max',
+            default=122,
+            validators=[ 
+                validators.NumberRange(min=0, max=360)
+                ],
+            tooltip = "The maximum angle of the hue modulation."
+            )
+
+    augmentation_hue_probability = utils.forms.FloatField(u'probability',
+            default=0.75,
+            validators=[ 
+                validators.NumberRange(min=0.0, max=1.0)
+                ],
+            tooltip = "The probability for an image to be hue-modulated during augmentation."
+            )
+
+    ### Data augmentation - contrast
+    has_augmentation_contrast = utils.forms.BooleanField('Perform contrast modulation on images',
+            tooltip="You can augment your dataset by performing contrast modulation on images.",
+            default=False,
+            validators=[ 
+                ]
+            )
+ 
+    augmentation_contrast_strength_min = utils.forms.FloatField(u'strength min',
+            default=0.75,
+            validators=[ 
+                validators.NumberRange(min=0.0, max=2.0)
+                ],
+            tooltip = "The minimum strength of the contrast modulation."
+            )
+
+    augmentation_contrast_strength_max = utils.forms.FloatField(u'strength max',
+            default=1.25,
+            validators=[ 
+                validators.NumberRange(min=0.0, max=2.0)
+                ],
+            tooltip = "The maximum strength of the contrast modulation."
+            )
+
+    augmentation_contrast_probability = utils.forms.FloatField(u'probability',
+            default=0.75,
+            validators=[ 
+                validators.NumberRange(min=0.0, max=1.0)
+                ],
+            tooltip = "The probability for an image to be contrast-modulated during augmentation."
+            )
+
+    ### Data augmentation - translation
+    has_augmentation_translation = utils.forms.BooleanField('Perform translation on images',
+            tooltip="You can augment your dataset by performing translation on images.",
+            default=False,
+            validators=[ 
+                ]
+            )
+ 
+    augmentation_translation_dx_min = utils.forms.FloatField(u'dx min',
+            default=-0.5,
+            validators=[ 
+                validators.NumberRange(min=-1.0, max=1.0)
+                ],
+            tooltip = "The minimum dx of the translation."
+            )
+
+    augmentation_translation_dx_max = utils.forms.FloatField(u'dx max',
+            default=0.5,
+            validators=[ 
+                validators.NumberRange(min=-1.0, max=1.0)
+                ],
+            tooltip = "The maximum dx of the translation."
+            )
+
+    augmentation_translation_dy_min = utils.forms.FloatField(u'dy min',
+            default=-0.5,
+            validators=[ 
+                validators.NumberRange(min=-1.0, max=1.0)
+                ],
+            tooltip = "The minimum dy of the translation."
+            )
+
+    augmentation_translation_dy_max = utils.forms.FloatField(u'dy max',
+            default=0.5,
+            validators=[ 
+                validators.NumberRange(min=-1.0, max=1.0)
+                ],
+            tooltip = "The maximum dy of the translation."
+            )
+
+    augmentation_translation_probability = utils.forms.FloatField(u'probability',
+            default=0.75,
+            validators=[ 
+                validators.NumberRange(min=0.0, max=1.0)
+                ],
+            tooltip = "The probability for an image to be translation-modulated during augmentation."
+            )
+
+
     # Use a SelectField instead of a HiddenField so that the default value
     # is used when nothing is provided (through the REST API)
     method = wtforms.SelectField(u'Dataset type',

--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -66,7 +66,7 @@ class BaseViewsTestWithImageset(BaseViewsTest):
     IMAGE_WIDTH     = 10
     IMAGE_CHANNELS  = 3
     BACKEND         = 'lmdb'
-    COMPRESSION     = 'none' 
+    COMPRESSION     = 'none'
 
     UNBALANCED_CATEGORY = False
 

--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -66,7 +66,7 @@ class BaseViewsTestWithImageset(BaseViewsTest):
     IMAGE_WIDTH     = 10
     IMAGE_CHANNELS  = 3
     BACKEND         = 'lmdb'
-    COMPRESSION     = 'none'
+    COMPRESSION     = 'none' 
 
     UNBALANCED_CATEGORY = False
 
@@ -383,6 +383,23 @@ class TestMinPerClass(BaseViewsTestWithImageset):
         assert not self.dataset_exists(job_id), 'dataset exists after delete'
 
 
+class TestAugmentedDataset(BaseViewsTestWithImageset):
+
+    def test_augmented_rotation_dataset_creation(self):
+        # create dataset with rotations
+        data = {}
+        data['has_augmentation_rotation'] = True
+        data['augmentation_rotation_angle_min'] = -90
+        data['augmentation_rotation_angle_max'] = 90
+        data['augmentation_rotation_probability'] = 1.0
+
+        job_id = self.create_dataset(**data)
+        assert self.dataset_wait_completion(job_id) == 'Done', 'create failed'
+        info = self.dataset_info(job_id)
+ 
+        assert self.delete_dataset(job_id) == 200, 'delete failed'
+        assert not self.dataset_exists(job_id), 'dataset exists after delete'
+
 class TestCreated(BaseViewsTestWithDataset):
     """
     Tests on a dataset that has already been created
@@ -441,6 +458,9 @@ class TestCreatedWide(TestCreated):
 
 class TestCreatedTall(TestCreated):
     IMAGE_HEIGHT = 20
+
+class TestCreatedAugmentation(TestCreated):
+    IMAGE_CHANNELS = 1
 
 class TestCreatedHdf5(TestCreated):
     BACKEND = 'hdf5'

--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -396,7 +396,54 @@ class TestAugmentedDataset(BaseViewsTestWithImageset):
         job_id = self.create_dataset(**data)
         assert self.dataset_wait_completion(job_id) == 'Done', 'create failed'
         info = self.dataset_info(job_id)
- 
+
+        assert self.delete_dataset(job_id) == 200, 'delete failed'
+        assert not self.dataset_exists(job_id), 'dataset exists after delete'
+
+    def test_augmented_hue_dataset_creation(self):
+        # create dataset with rotations
+        data = {}
+        data['has_augmentation_hue'] = True
+        data['augmentation_hue_angle_min'] = 0
+        data['augmentation_hue_angle_max'] = 360
+        data['augmentation_hue_probability'] = 1.0
+
+        job_id = self.create_dataset(**data)
+        assert self.dataset_wait_completion(job_id) == 'Done', 'create failed'
+        info = self.dataset_info(job_id)
+
+        assert self.delete_dataset(job_id) == 200, 'delete failed'
+        assert not self.dataset_exists(job_id), 'dataset exists after delete'
+
+    def test_augmented_contrast_dataset_creation(self):
+        # create dataset with rotations
+        data = {}
+        data['has_augmentation_contrast'] = True
+        data['augmentation_contrast_strength_min'] = 0.5
+        data['augmentation_contrast_strength_max'] = 1.5
+        data['augmentation_contrast_probability'] = 1.0
+
+        job_id = self.create_dataset(**data)
+        assert self.dataset_wait_completion(job_id) == 'Done', 'create failed'
+        info = self.dataset_info(job_id)
+
+        assert self.delete_dataset(job_id) == 200, 'delete failed'
+        assert not self.dataset_exists(job_id), 'dataset exists after delete'
+
+    def test_augmented_translation_dataset_creation(self):
+        # create dataset with rotations
+        data = {}
+        data['has_augmentation_translation'] = True
+        data['augmentation_translation_dx_min'] = -0.5
+        data['augmentation_translation_dx_max'] = 0.5
+        data['augmentation_translation_dy_min'] = -0.5
+        data['augmentation_translation_dy_max'] = 0.5
+        data['augmentation_translation_probability'] = 1.0
+
+        job_id = self.create_dataset(**data)
+        assert self.dataset_wait_completion(job_id) == 'Done', 'create failed'
+        info = self.dataset_info(job_id)
+
         assert self.delete_dataset(job_id) == 200, 'delete failed'
         assert not self.dataset_exists(job_id), 'dataset exists after delete'
 
@@ -458,9 +505,6 @@ class TestCreatedWide(TestCreated):
 
 class TestCreatedTall(TestCreated):
     IMAGE_HEIGHT = 20
-
-class TestCreatedAugmentation(TestCreated):
-    IMAGE_CHANNELS = 1
 
 class TestCreatedHdf5(TestCreated):
     BACKEND = 'hdf5'

--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -13,6 +13,42 @@ from job import ImageClassificationDatasetJob
 
 NAMESPACE = '/datasets/images/classification'
 
+
+def augmentation_from_form(form, job):
+    augmentation = {}
+
+    if form.has_augmentation_contrast.data:
+        augmentation['contrast'] = {
+            'strength_min': form.augmentation_contrast_strength_min.data,
+            'strength_max': form.augmentation_contrast_strength_max.data,
+            'probability': form.augmentation_contrast_probability.data
+        }
+
+    if form.has_augmentation_hue.data and job.image_dims[2] == 3:
+        augmentation['hue'] = {
+            'angle_min': form.augmentation_hue_angle_min.data,
+            'angle_max': form.augmentation_hue_angle_max.data,
+            'probability': form.augmentation_hue_probability.data
+        }
+
+    if form.has_augmentation_rotation.data:
+        augmentation['rotation'] = {
+            'angle_min': form.augmentation_rotation_angle_min.data,
+            'angle_max': form.augmentation_rotation_angle_max.data,
+            'probability': form.augmentation_rotation_probability.data
+        }
+
+    if form.has_augmentation_translation.data:
+        augmentation['translation'] = {
+            'dx_min': form.augmentation_translation_dx_min.data,
+            'dx_max': form.augmentation_translation_dx_max.data,
+            'dy_min': form.augmentation_translation_dy_min.data,
+            'dy_max': form.augmentation_translation_dy_max.data,
+            'probability': form.augmentation_translation_probability.data
+        }
+    return augmentation
+
+
 def from_folders(job, form):
     """
     Add tasks for creating a dataset by parsing folders of images
@@ -88,38 +124,7 @@ def from_folders(job, form):
     encoding = form.encoding.data
     compression = form.compression.data
 
-    augmentation = { 
-    }
-
-    if form.has_augmentation_contrast.data:
-        augmentation['contrast'] = {
-            'strength_min': form.augmentation_contrast_strength_min.data,
-            'strength_max': form.augmentation_contrast_strength_max.data,
-            'probability': form.augmentation_contrast_probability.data
-        }
-
-    if form.has_augmentation_hue.data and job.image_dims[2] == 3:
-        augmentation['hue'] = {
-            'angle_min': form.augmentation_hue_angle_min.data,
-            'angle_max': form.augmentation_hue_angle_max.data,
-            'probability': form.augmentation_hue_probability.data
-        }
-
-    if form.has_augmentation_rotation.data:
-        augmentation['rotation'] = {
-            'angle_min': form.augmentation_rotation_angle_min.data,
-            'angle_max': form.augmentation_rotation_angle_max.data,
-            'probability': form.augmentation_rotation_probability.data
-        }
-
-    if form.has_augmentation_translation.data:
-        augmentation['translation'] = {
-            'dx_min': form.augmentation_translation_dx_min.data,
-            'dx_max': form.augmentation_translation_dx_max.data,
-            'dy_min': form.augmentation_translation_dy_min.data,
-            'dy_max': form.augmentation_translation_dy_max.data,
-            'probability': form.augmentation_translation_probability.data
-        }
+    augmentation = augmentation_from_form(form, job)
 
     job.tasks.append(
             tasks.CreateDbTask(
@@ -203,36 +208,7 @@ def from_files(job, form):
     if not image_folder:
         image_folder = None
 
-    augmentation = {
-    }
-
-    if form.has_augmentation_contrast.data:
-        augmentation['contrast'] = {
-            'strength': form.augmentation_contrast_strength.data,
-            'probability': form.augmentation_contrast_probability.data
-        }
-
-    if form.has_augmentation_hue.data and job.image_dims[2] == 3:
-        augmentation['hue'] = {
-            'angle': form.augmentation_hue_angle.data,
-            'probability': form.augmentation_hue_probability.data
-        }
-
-    if form.has_augmentation_rotation.data:
-        augmentation['rotation'] = {
-            'angle_min': form.augmentation_rotation_angle_min.data,
-            'angle_max': form.augmentation_rotation_angle_max.data,
-            'probability': form.augmentation_rotation_probability.data
-        }
-
-    if form.has_augmentation_translation.data:
-        augmentation['translation'] = {
-            'dx_min': form.augmentation_translation_dx_min.data,
-            'dx_max': form.augmentation_translation_dx_max.data,
-            'dy_min': form.augmentation_translation_dy_min.data,
-            'dy_max': form.augmentation_translation_dy_max.data,
-            'probability': form.augmentation_translation_probability.data
-        }
+    augmentation = augmentation_from_form(form, job)
 
     job.tasks.append(
             tasks.CreateDbTask(

--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -88,19 +88,53 @@ def from_folders(job, form):
     encoding = form.encoding.data
     compression = form.compression.data
 
+    augmentation = { 
+    }
+
+    if form.has_augmentation_contrast.data:
+        augmentation['contrast'] = {
+            'strength_min': form.augmentation_contrast_strength_min.data,
+            'strength_max': form.augmentation_contrast_strength_max.data,
+            'probability': form.augmentation_contrast_probability.data
+        }
+
+    if form.has_augmentation_hue.data and job.image_dims[2] == 3:
+        augmentation['hue'] = {
+            'angle_min': form.augmentation_hue_angle_min.data,
+            'angle_max': form.augmentation_hue_angle_max.data,
+            'probability': form.augmentation_hue_probability.data
+        }
+
+    if form.has_augmentation_rotation.data:
+        augmentation['rotation'] = {
+            'angle_min': form.augmentation_rotation_angle_min.data,
+            'angle_max': form.augmentation_rotation_angle_max.data,
+            'probability': form.augmentation_rotation_probability.data
+        }
+
+    if form.has_augmentation_translation.data:
+        augmentation['translation'] = {
+            'dx_min': form.augmentation_translation_dx_min.data,
+            'dx_max': form.augmentation_translation_dx_max.data,
+            'dy_min': form.augmentation_translation_dy_min.data,
+            'dy_max': form.augmentation_translation_dy_max.data,
+            'probability': form.augmentation_translation_probability.data
+        }
+
     job.tasks.append(
             tasks.CreateDbTask(
-                job_dir     = job.dir(),
-                parents     = parse_train_task,
-                input_file  = utils.constants.TRAIN_FILE,
-                db_name     = utils.constants.TRAIN_DB,
-                backend     = backend,
-                image_dims  = job.image_dims,
-                resize_mode = job.resize_mode,
-                encoding    = encoding,
-                compression = compression,
-                mean_file   = utils.constants.MEAN_FILE_CAFFE,
-                labels_file = job.labels_file,
+                job_dir      = job.dir(),
+                parents      = parse_train_task,
+                input_file   = utils.constants.TRAIN_FILE,
+                db_name      = utils.constants.TRAIN_DB,
+                backend      = backend,
+                image_dims   = job.image_dims,
+                resize_mode  = job.resize_mode,
+                encoding     = encoding,
+                compression  = compression,
+                mean_file    = utils.constants.MEAN_FILE_CAFFE,
+                labels_file  = job.labels_file,
+                augmentation = augmentation,
                 )
             )
 
@@ -117,6 +151,7 @@ def from_folders(job, form):
                     encoding    = encoding,
                     compression = compression,
                     labels_file = job.labels_file,
+                    augmentation= {},
                     )
                 )
 
@@ -133,6 +168,7 @@ def from_folders(job, form):
                     encoding    = encoding,
                     compression = compression,
                     labels_file = job.labels_file,
+                    augmentation= {},
                     )
                 )
 
@@ -167,6 +203,37 @@ def from_files(job, form):
     if not image_folder:
         image_folder = None
 
+    augmentation = {
+    }
+
+    if form.has_augmentation_contrast.data:
+        augmentation['contrast'] = {
+            'strength': form.augmentation_contrast_strength.data,
+            'probability': form.augmentation_contrast_probability.data
+        }
+
+    if form.has_augmentation_hue.data and job.image_dims[2] == 3:
+        augmentation['hue'] = {
+            'angle': form.augmentation_hue_angle.data,
+            'probability': form.augmentation_hue_probability.data
+        }
+
+    if form.has_augmentation_rotation.data:
+        augmentation['rotation'] = {
+            'angle_min': form.augmentation_rotation_angle_min.data,
+            'angle_max': form.augmentation_rotation_angle_max.data,
+            'probability': form.augmentation_rotation_probability.data
+        }
+
+    if form.has_augmentation_translation.data:
+        augmentation['translation'] = {
+            'dx_min': form.augmentation_translation_dx_min.data,
+            'dx_max': form.augmentation_translation_dx_max.data,
+            'dy_min': form.augmentation_translation_dy_min.data,
+            'dy_max': form.augmentation_translation_dy_max.data,
+            'probability': form.augmentation_translation_probability.data
+        }
+
     job.tasks.append(
             tasks.CreateDbTask(
                 job_dir     = job.dir(),
@@ -181,6 +248,7 @@ def from_files(job, form):
                 mean_file   = utils.constants.MEAN_FILE_CAFFE,
                 labels_file = job.labels_file,
                 shuffle     = shuffle,
+                augmentation= augmentation,
                 )
             )
 
@@ -212,6 +280,7 @@ def from_files(job, form):
                     compression = compression,
                     labels_file = job.labels_file,
                     shuffle     = shuffle,
+                    augmentation= {},
                     )
                 )
 
@@ -243,6 +312,7 @@ def from_files(job, form):
                     compression = compression,
                     labels_file = job.labels_file,
                     shuffle     = shuffle,
+                    augmentation= {},
                     )
                 )
 

--- a/digits/dataset/job.py
+++ b/digits/dataset/job.py
@@ -41,6 +41,7 @@ class DatasetJob(Job):
                     "backend":          t.backend,
                     "encoding":         t.encoding,
                     "compression":      t.compression,
+                    "augmentation":     t.augmentation,
                                       } for t in self.create_db_tasks()],
                 })
         return d

--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -33,6 +33,7 @@ class CreateDbTask(Task):
         compression -- 'none' or 'gzip'
         mean_file -- save mean file to this location
         labels_file -- used to print category distribution
+        augmentation -- used to perform data augmentation
         """
         # Take keyword arguments out of kwargs
         self.image_folder = kwargs.pop('image_folder', None)
@@ -42,6 +43,7 @@ class CreateDbTask(Task):
         self.compression = kwargs.pop('compression', None)
         self.mean_file = kwargs.pop('mean_file', None)
         self.labels_file = kwargs.pop('labels_file', None)
+        self.augmentation = kwargs.pop('augmentation', None)
 
         super(CreateDbTask, self).__init__(**kwargs)
         self.pickver_task_createdb = PICKLE_VERSION
@@ -91,13 +93,15 @@ class CreateDbTask(Task):
                     self.encoding = 'none'
                 delattr(self, 'encode')
             else:
-                self.encoding = 'none'
+                self.encoding = 'none' 
         self.pickver_task_createdb = PICKLE_VERSION
 
         if not hasattr(self, 'backend') or self.backend is None:
             self.backend = 'lmdb'
         if not hasattr(self, 'compression') or self.compression is None:
             self.compression = 'none'
+        if not hasattr(self, 'augmentation'):
+            self.augmentation = None
 
     @override
     def name(self):
@@ -164,6 +168,12 @@ class CreateDbTask(Task):
             args.append('--compression=%s' % self.compression)
         if self.backend == 'hdf5':
             args.append('--hdf5_dset_limit=%d' % 2**31)
+        # Data augmentation
+        if self.augmentation is not None:
+            for k in self.augmentation:
+                args.append('--augmentation_%s' % k)
+                for attribute in self.augmentation[k]:
+                    args.append('--augmentation_{0}_{1}={2}'.format(k, attribute, self.augmentation[k][attribute]))
 
         return args
 

--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -93,7 +93,7 @@ class CreateDbTask(Task):
                     self.encoding = 'none'
                 delattr(self, 'encode')
             else:
-                self.encoding = 'none' 
+                self.encoding = 'none'
         self.pickver_task_createdb = PICKLE_VERSION
 
         if not hasattr(self, 'backend') or self.backend is None:
@@ -101,7 +101,7 @@ class CreateDbTask(Task):
         if not hasattr(self, 'compression') or self.compression is None:
             self.compression = 'none'
         if not hasattr(self, 'augmentation'):
-            self.augmentation = None
+            self.augmentation = {}
 
     @override
     def name(self):

--- a/digits/templates/datasets/images/classification/new.html
+++ b/digits/templates/datasets/images/classification/new.html
@@ -360,7 +360,164 @@ $('#db-tabs a[href="#db-{{ form.method.data }}"]').tab('show');
     </script>
 
     <div class="row">
-        <div class="col-sm-6 col-sm-offset-3 well">
+        <div class="col-sm-4 well">
+            <!-- Dataset augmentation -->
+            <h4>Dataset augmentation</h4>
+            <!-- Rotation -->
+            {{form.has_augmentation_rotation}}
+            {{form.has_augmentation_rotation.label}}
+            {{form.has_augmentation_rotation.tooltip}} 
+            <div class="row cl-augmentation-rotation">
+                <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_rotation_angle_min.errors else '' }}">
+                    {{ form.augmentation_rotation_angle_min.label }}
+                    {{ form.augmentation_rotation_angle_min.tooltip }}
+                    {{ form.augmentation_rotation_angle_min(class='form-control') }}
+                </div>
+                <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_rotation_angle_max.errors else '' }}">
+                    {{ form.augmentation_rotation_angle_max.label }}
+                    {{ form.augmentation_rotation_angle_max.tooltip }}
+                    {{ form.augmentation_rotation_angle_max(class='form-control') }}
+                </div>
+                <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_rotation_probability.errors else '' }}">
+                    {{ form.augmentation_rotation_probability.label }}
+                    {{ form.augmentation_rotation_probability.tooltip }}
+                    {{ form.augmentation_rotation_probability(class='form-control') }}
+                </div>
+            </div>
+<script>
+function hasAugmentationRotationChanged() {
+    if ($("#has_augmentation_rotation").prop("checked"))
+    {
+        $(".cl-augmentation-rotation").show();
+    }
+    else
+    {
+        $(".cl-augmentation-rotation").hide();
+    }
+}
+$("#has_augmentation_rotation").click(hasAugmentationRotationChanged);
+hasAugmentationRotationChanged();
+</script>            
+            <!-- Hue -->
+            <br>
+            {{form.has_augmentation_hue}}
+            {{form.has_augmentation_hue.label}} 
+            {{form.has_augmentation_hue.tooltip}} 
+            <div class="row cl-augmentation-hue">
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_hue_angle_min.errors else '' }}">
+                    {{ form.augmentation_hue_angle_min.label }}
+                    {{ form.augmentation_hue_angle_min.tooltip }}
+                    {{ form.augmentation_hue_angle_min(class='form-control') }}
+                </div>
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_hue_angle_max.errors else '' }}">
+                    {{ form.augmentation_hue_angle_max.label }}
+                    {{ form.augmentation_hue_angle_max.tooltip }}
+                    {{ form.augmentation_hue_angle_max(class='form-control') }}
+                </div>
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_hue_probability.errors else '' }}">
+                    {{ form.augmentation_hue_probability.label }}
+                    {{ form.augmentation_hue_probability.tooltip }}
+                    {{ form.augmentation_hue_probability(class='form-control') }}
+                </div>
+            </div>
+<script>
+function hasAugmentationHueChanged() {
+    if ($("#has_augmentation_hue").prop("checked"))
+    {
+        $(".cl-augmentation-hue").show();
+    }
+    else
+    {
+        $(".cl-augmentation-hue").hide();
+    }
+}
+$("#has_augmentation_hue").click(hasAugmentationHueChanged);
+hasAugmentationHueChanged();
+</script>
+            <!-- Contrast -->
+            <br>
+            {{form.has_augmentation_contrast}}
+            {{form.has_augmentation_contrast.label}} 
+            {{form.has_augmentation_contrast.tooltip}} 
+            <div class="row cl-augmentation-contrast">
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_contrast_strength_min.errors else '' }}">
+                    {{ form.augmentation_contrast_strength_min.label }}
+                    {{ form.augmentation_contrast_strength_min.tooltip }}
+                    {{ form.augmentation_contrast_strength_min(class='form-control') }}
+                </div>
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_contrast_strength_max.errors else '' }}">
+                    {{ form.augmentation_contrast_strength_max.label }}
+                    {{ form.augmentation_contrast_strength_max.tooltip }}
+                    {{ form.augmentation_contrast_strength_max(class='form-control') }}
+                </div>
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_contrast_probability.errors else '' }}">
+                    {{ form.augmentation_contrast_probability.label }}
+                    {{ form.augmentation_contrast_probability.tooltip }}
+                    {{ form.augmentation_contrast_probability(class='form-control') }}
+                </div>
+            </div>
+<script>
+function hasAugmentationContrastChanged() {
+    if ($("#has_augmentation_contrast").prop("checked"))
+    {
+        $(".cl-augmentation-contrast").show();
+    }
+    else
+    {
+        $(".cl-augmentation-contrast").hide();
+    }
+}
+$("#has_augmentation_contrast").click(hasAugmentationContrastChanged);
+hasAugmentationContrastChanged();
+</script> 
+            <!-- Translation -->
+            <br>
+            {{form.has_augmentation_translation}}
+            {{form.has_augmentation_translation.label}} 
+            {{form.has_augmentation_translation.tooltip}} 
+            <div class="row cl-augmentation-translation">
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_translation_dx_min.errors else '' }}">
+                    {{ form.augmentation_translation_dx_min.label }}
+                    {{ form.augmentation_translation_dx_min.tooltip }}
+                    {{ form.augmentation_translation_dx_min(class='form-control') }}
+                </div>
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_translation_dx_max.errors else '' }}">
+                    {{ form.augmentation_translation_dx_max.label }}
+                    {{ form.augmentation_translation_dx_max.tooltip }}
+                    {{ form.augmentation_translation_dx_max(class='form-control') }}
+                </div>
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_translation_dy_min.errors else '' }}">
+                    {{ form.augmentation_translation_dy_min.label }}
+                    {{ form.augmentation_translation_dy_min.tooltip }}
+                    {{ form.augmentation_translation_dy_min(class='form-control') }}
+                </div>
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_translation_dy_max.errors else '' }}">
+                    {{ form.augmentation_translation_dy_max.label }}
+                    {{ form.augmentation_translation_dy_max.tooltip }}
+                    {{ form.augmentation_translation_dy_max(class='form-control') }}
+                </div>
+                 <div class="form-group col-sm-6{{ ' has-error' if form.augmentation_translation_probability.errors else '' }}">
+                    {{ form.augmentation_translation_probability.label }}
+                    {{ form.augmentation_translation_probability.tooltip }}
+                    {{ form.augmentation_translation_probability(class='form-control') }}
+                </div>
+            </div>
+<script>
+function hasAugmentationTranslationChanged() {
+    if ($("#has_augmentation_translation").prop("checked"))
+    {
+        $(".cl-augmentation-translation").show();
+    }
+    else
+    {
+        $(".cl-augmentation-translation").hide();
+    }
+}
+$("#has_augmentation_translation").click(hasAugmentationTranslationChanged);
+hasAugmentationTranslationChanged();
+</script> 
+        </div> 
+        <div class="col-sm-6 col-sm-offset-1 well">
             <div class="form-group{{ ' has-error' if form.backend.errors else '' }}">
                 {{ form.backend.label }}
                 {{ form.backend.tooltip }}

--- a/digits/templates/datasets/images/classification/show.html
+++ b/digits/templates/datasets/images/classification/show.html
@@ -47,7 +47,7 @@
         <dd>{{task.label_count}}</dd>
         {% endif %}
         {% if task.train_count %}
-        <dt>Training Images</dt>
+        <dt>Original Training Images</dt>
         <dd>{{task.train_count}}</dd>
         {% endif %}
         {% if task.val_count %}
@@ -100,6 +100,19 @@
     {% if task.status=='D' and task.mean_file %}
     <b>Image Mean:</b>
     <img src="{{url_for('serve_file', path=task.path('mean.jpg', relative=True))}}" />
+    {% endif %}
+    <br/>
+    {% if task.augmentation|length != 0 %}
+    <b>Augmentations:</b>
+    <br/>
+    <pre>
+{% for a, v in task.augmentation.iteritems() %}
+<b>{{ a }} parameters:</b>
+    {% for key, value in v.iteritems()  %}
+    {{ key }}: {{ value }} 
+    {% endfor %}
+
+{% endfor %}</pre>
     {% endif %}
     {% endif %}
 </div>

--- a/digits/utils/test_image.py
+++ b/digits/utils/test_image.py
@@ -185,3 +185,174 @@ class TestResizeImage():
         shape=%s""" % args
 
 
+class TestRotateImage():
+
+    @classmethod
+    def setup_class(cls):
+        cls.np_gray = np.random.randint(0, 255, (10,10)).astype('uint8')
+        cls.pil_gray = PIL.Image.fromarray(cls.np_gray)
+        cls.np_color = np.random.randint(0, 255, (10,10,3)).astype('uint8')
+        cls.pil_color = PIL.Image.fromarray(cls.np_color)
+
+    def test_configs(self):
+        # lots of configs tested here
+        for angle in [-3, 3]:
+            for t in ['gray', 'color']:
+                yield self.verify_pil, (angle, t)
+                yield self.verify_np, (angle, t)
+ 
+
+    def verify_pil(self, args):
+        # pass a PIL.Image to resize_image and check the returned dimensions
+        a, t = args
+        if t == 'gray':
+            i = self.pil_gray
+        else:
+            i = self.pil_color
+        r = _.rotate_image(i, a)
+        assert r.shape == np.array(i).shape, 'Rotated PIL.Image (orig=%s) should have been %s, but was %s %s' % (i.size, i.size, r.shape, self.args_to_str(args))
+        assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
+
+    def verify_np(self, args):
+        # pass a numpy.ndarray to resize_image and check the returned dimensions
+        a, t = args
+        if t == 'gray':
+            i = self.np_gray
+        else:
+            i = self.np_color
+        r = _.rotate_image(i, a)
+        assert r.shape == i.shape, 'Rotated np.ndarray (orig=%s) should have been %s, but was %s %s' % (i.shape, i.shape, r.shape, self.args_to_str(args))
+        assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
+
+    def args_to_str(self, args):
+        return """
+        angle=%s
+        image_type=%s""" % args
+
+class TestTranslateImage():
+
+    @classmethod
+    def setup_class(cls):
+        cls.np_gray = np.random.randint(0, 255, (10,10)).astype('uint8')
+        cls.pil_gray = PIL.Image.fromarray(cls.np_gray)
+        cls.np_color = np.random.randint(0, 255, (10,10,3)).astype('uint8')
+        cls.pil_color = PIL.Image.fromarray(cls.np_color)
+
+    def test_configs(self):
+        # lots of configs tested here
+        for dx in [-0.1, 0.1]:
+            for dy in [-0.1, 0.1]:
+                for t in ['gray', 'color']:
+                    yield self.verify_pil, (dx, dy, t)
+                    yield self.verify_np, (dx, dy, t)
+ 
+
+    def verify_pil(self, args):
+        # pass a PIL.Image to resize_image and check the returned dimensions
+        dx, dy, t = args
+        if t == 'gray':
+            i = self.pil_gray
+        else:
+            i = self.pil_color
+        r = _.translate_image(i, dx, dy)
+        assert r.shape == np.array(i).shape, 'Rotated PIL.Image (orig=%s) should have been %s, but was %s %s' % (i.size, i.size, r.shape, self.args_to_str(args))
+        assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
+
+    def verify_np(self, args):
+        # pass a numpy.ndarray to resize_image and check the returned dimensions
+        dx, dy, t = args
+        if t == 'gray':
+            i = self.np_gray
+        else:
+            i = self.np_color
+        r = _.translate_image(i, dx, dy)
+        assert r.shape == i.shape, 'Rotated np.ndarray (orig=%s) should have been %s, but was %s %s' % (i.shape, i.shape, r.shape, self.args_to_str(args))
+        assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
+
+    def args_to_str(self, args):
+        return """
+        dx=%s
+        dy=%s
+        image_type=%s""" % args
+
+class TestModulateContrastImage():
+
+    @classmethod
+    def setup_class(cls):
+        cls.np_gray = np.random.randint(0, 255, (10,10)).astype('uint8')
+        cls.pil_gray = PIL.Image.fromarray(cls.np_gray)
+        cls.np_color = np.random.randint(0, 255, (10,10,3)).astype('uint8')
+        cls.pil_color = PIL.Image.fromarray(cls.np_color)
+
+    def test_configs(self):
+        # lots of configs tested here
+        for s in [0.5, 1.0, 1.5]:
+            for t in ['gray', 'color']:
+                yield self.verify_pil, (s, t)
+                yield self.verify_np, (s, t)
+
+
+    def verify_pil(self, args):
+        # pass a PIL.Image to resize_image and check the returned dimensions
+        s, t = args
+        if t == 'gray':
+            i = self.pil_gray
+        else:
+            i = self.pil_color
+        r = _.modulate_contrast_image(i, s)
+        assert r.shape == np.array(i).shape, 'Contrast modulated PIL.Image (orig=%s) should have been %s, but was %s %s' % (i.size, i.size, r.shape, self.args_to_str(args))
+        assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
+
+    def verify_np(self, args):
+        # pass a numpy.ndarray to resize_image and check the returned dimensions
+        s, t = args
+        if t == 'gray':
+            i = self.np_gray
+        else:
+            i = self.np_color
+        r = _.modulate_contrast_image(i, s)
+        assert r.shape == i.shape, 'Contrast modulated np.ndarray (orig=%s) should have been %s, but was %s %s' % (i.shape, i.shape, r.shape, self.args_to_str(args))
+        assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
+
+    def args_to_str(self, args):
+        return """
+        strength=%s
+        image_type=%s""" % args
+
+class TestModulateHueImage():
+
+    @classmethod
+    def setup_class(cls):
+        cls.np_gray = np.random.randint(0, 255, (10,10)).astype('uint8')
+        cls.pil_gray = PIL.Image.fromarray(cls.np_gray)
+        cls.np_color = np.random.randint(0, 255, (10,10,3)).astype('uint8')
+        cls.pil_color = PIL.Image.fromarray(cls.np_color)
+
+    def test_configs(self):
+        # lots of configs tested here
+        t = 'color'
+        for a in [0, 66, 122, 360]:
+            yield self.verify_pil, (a, t)
+            yield self.verify_np, (a, t)
+
+
+    def verify_pil(self, args):
+        # pass a PIL.Image to resize_image and check the returned dimensions
+        a, t = args
+        i = self.pil_color
+        r = _.modulate_hue_image(i, a)
+        assert r.shape == np.array(i).shape, 'Hue modulated PIL.Image (orig=%s) should have been %s, but was %s %s' % (i.size, i.size, r.shape, self.args_to_str(args))
+        assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
+
+    def verify_np(self, args):
+        # pass a numpy.ndarray to resize_image and check the returned dimensions
+        a, t = args
+        i = self.np_color
+        r = _.modulate_hue_image(i, a)
+        assert r.shape == i.shape, 'Hue modulated np.ndarray (orig=%s) should have been %s, but was %s %s' % (i.shape, i.shape, r.shape, self.args_to_str(args))
+        assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
+
+    def args_to_str(self, args):
+        return """
+        a=%s
+        image_type=%s""" % args

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ lmdb>=0.87
 h5py>=2.2.1
 pydot2
 Flask-SocketIO
+matplotlib

--- a/tools/test_create_db.py
+++ b/tools/test_create_db.py
@@ -223,6 +223,44 @@ class BaseCreationTest(BaseTest):
         _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
                 10, 10, 1, self.BACKEND, mean_files=mean_files)
 
+    def test_augmentation_rotation(self):
+        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+                10, 10, 1, self.BACKEND, augmentation_rotation=True, 
+                augmentation_rotation_probability=0.75,
+                augmentation_rotation_angle_min=-90,
+                augmentation_rotation_angle_max=90)
+
+    def test_augmentation_rotation_color(self):
+        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+                10, 10, 3, self.BACKEND, augmentation_rotation=True, 
+                augmentation_rotation_probability=0.75,
+                augmentation_rotation_angle_min=-90,
+                augmentation_rotation_angle_max=90)
+
+    def test_augmentation_contrast(self):
+        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+                10, 10, 1, self.BACKEND, augmentation_contrast=True, 
+                augmentation_contrast_probability=0.75,
+                augmentation_contrast_strength_min=0.75,
+                augmentation_contrast_strength_max=1.25)
+
+    def test_augmentation_hue(self):
+        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+                10, 10, 3, self.BACKEND, augmentation_hue=True, 
+                augmentation_hue_probability=0.75,
+                augmentation_hue_angle_min=66,
+                augmentation_hue_angle_max=122)
+
+    def test_augmentation_translation(self):
+        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+                10, 10, 3, self.BACKEND, augmentation_translation=True, 
+                augmentation_translation_probability=0.75,
+                augmentation_translation_dx_min=-0.5,
+                augmentation_translation_dx_max=0.5,
+                augmentation_translation_dy_min=-0.5,
+                augmentation_translation_dy_max=0.5)
+ 
+
 class TestLmdbCreation(BaseCreationTest):
     BACKEND = 'lmdb'
 


### PR DESCRIPTION
Added data augmentation to classification dataset creation. Only the train set is augmented at db creation with new images obtained by a combination of the following transformations : 
- Rotation 
- Translation
- Contrast modulation
- Hue modulation

There are a few parameters for each transformation, including the probability for each image of being augmented. 

<img width="300" alt="Dataset augmentation" src="https://cloud.githubusercontent.com/assets/5939621/10099739/bd8d96ec-638c-11e5-8654-ccabdb2dad87.png">

For now, only added tests to tools/create_db, but will add a few more regarding task creation and utils/image. Edit: done. 

Translating is quite slow, so I should check if the way I do it can be improved. 

### TODO before merge

- [ ] Fix hue modulation and translation
- [ ] Add the possibility of setting the number of images generated out of each training sample
- [ ] Fix the UI 

