### PR TITLE
Dataset visualization

### DIFF
--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -433,6 +433,37 @@ class TestCreated(BaseViewsTestWithDataset):
         for task in content['CreateDbTasks']:
             assert task['backend'] == self.BACKEND
 
+class TestCreatedLMDBExplore(TestCreated):
+    def test_explore_train(self):
+        rv = self.app.get('/datasets/images/classification/explore?job_id=%s&db=train' % self.dataset_id)
+        assert rv.status_code == 200, 'page load failed with %s' % rv.status_code
+        assert 'Items per page' in rv.data, 'unexpected page format'
+
+    def test_explore_val(self):
+        rv = self.app.get('/datasets/images/classification/explore?job_id=%s&db=val' % self.dataset_id)
+        assert rv.status_code == 200, 'page load failed with %s' % rv.status_code
+        assert 'Items per page' in rv.data, 'unexpected page format'
+
+    def test_abort_explore_fail(self):
+        job_id = self.create_dataset()
+        self.abort_dataset(job_id)
+        rv = self.app.get('/datasets/images/classification/explore?job_id=%s&db=val' % job_id)
+        assert rv.status_code == 500, 'page load should have failed'
+        assert 'status should be' in rv.data, 'unexpected page format'
+
+    def test_explore_not_existing_db_fail(self):
+        rv = self.app.get('/datasets/images/classification/explore?job_id=%s&db=test' % self.dataset_id)
+        assert rv.status_code == 500, 'page load should have failed'
+        assert 'No create_db task' in rv.data, 'unexpected page format'
+
+class TestCreatedHDF5Explore(TestCreated):
+    BACKEND = 'hdf5'
+
+    def test_explore_train_fail(self):
+        rv = self.app.get('/datasets/images/classification/explore?job_id=%s&db=train' % self.dataset_id)
+        assert rv.status_code == 500, 'page load should have failed'
+        assert 'expected backend is lmdb' in rv.data, 'unexpected page format'
+
 class TestCreatedGrayscale(TestCreated):
     IMAGE_CHANNELS = 1
 
@@ -453,5 +484,3 @@ class TestCreatedHdf5(TestCreated):
 
 class TestCreatedHdf5Gzip(TestCreatedHdf5):
     COMPRESSION = 'gzip'
-
-

--- a/digits/static/css/style.css
+++ b/digits/static/css/style.css
@@ -58,3 +58,13 @@ input[readonly]:disabled {
     cursor: not-allowed !important;
 }
 
+a.active {
+	font-weight: 900;
+	color: black;
+}
+
+ul.inline li {
+	display: inline-block;
+}
+
+

--- a/digits/templates/datasets/images/classification/explore.html
+++ b/digits/templates/datasets/images/classification/explore.html
@@ -1,0 +1,65 @@
+{# Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% extends "layout.html" %}
+
+{% block title %}
+{{job.name()}} - Explorer
+{% endblock %}
+
+{% block head %}
+{% endblock %}
+
+{% block nav %}
+<li class="active"><a href="{{ url_for('show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
+{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <h2>Exploring {{job.name()}} ({{ db }}) images</h2>
+    </div>
+    <div class="row">
+        <ul class="list-unstyled list-inline">
+            <li><a href="?job_id={{job.id()}}&page=0&size={{size}}&db={{db}}">Show all images</a></li>
+            <li>or</li>
+            <li><h5>filter by class:</h5></li>
+        {% for l in labels %}
+            <li><a {% if label==loop.index0 %}class="active"{% endif %} href="?job_id={{job.id()}}&page=0&size={{size}}&db={{db}}&label={{loop.index0}}">{{l}}</a></li>
+        {% endfor %}
+        </ul>
+    </div>
+    <div class="row">Items per page: <a href="?job_id={{job.id()}}&page=0&db={{db}}&size=10&label={{label}}" {% if size==10 %}class="active"{% endif %}>10</a> - <a href="?job_id={{job.id()}}&page=0&db={{db}}&size=25&label={{label}}" {% if size==25 %}class="active"{% endif %}>25</a> - <a href="?job_id={{job.id()}}&page=0&db={{db}}&size=50&label={{label}}" {% if size==50 %}class="active"{% endif %}>50</a> - <a href="?job_id={{job.id()}}&page=0&db={{db}}&size=100&label={{label}}" {% if size==100 %}class="active"{% endif %}>100</a></div>
+    <div class="row">
+    <ul class="pagination">
+        <li {% if page == 0 %}class="disabled"{%endif%}>
+          <a href="?job_id={{job.id()}}&page={{ page - 1 }}&size={{size}}&db={{db}}&label={{label}}" aria-label="Previous">
+            <span aria-hidden="true">&laquo;</span>
+          </a>
+        </li>
+        {% if pages[0] != 0 %}
+        <li><a href="?job_id={{job.id()}}&page=0&size={{size}}&db={{db}}&label={{label}}">0</a></li>
+        <li class="disabled"><a href="#">...</a></li>
+        {% endif %}
+        {% for p in pages %}
+        <li {% if p == page %}class="active"{% endif %}><a href="?job_id={{job.id()}}&page={{ p }}&size={{size}}&db={{db}}&label={{label}}">{{p}}</a></li>
+        {% endfor %}
+        {% if pages[-1] != (total_entries-1)//size %}
+        <li class="disabled"><a href="#">...</a></li>
+        <li><a href="?job_id={{job.id()}}&page={{(total_entries-1)//size}}&size={{size}}&db={{db}}&label={{label}}">{{(total_entries-1)//size}}</a></li>
+        {% endif %}
+        {% if page != (total_entries-1)//size %}<li>
+          <a href="?job_id={{job.id()}}&page={{ page + 1 }}&size={{size}}&db={{db}}&label={{label}}" aria-label="Next">
+            <span aria-hidden="true">&raquo;</span>
+          </a>
+        </li>{%endif %}
+    </ul>
+    </div>
+    <div class="row">
+    {% for i in imgs %}
+        <div class="col-sm-3">
+            <div class="row text-center"><img src="{{ i.b64 }}"/></div>
+            <div class="row text-center"><h5>{{ i.label }}</h5></div>
+            <br/>
+        </div>
+    {% endfor %}
+    </div>
+{% endblock %}

--- a/digits/templates/datasets/images/classification/show.html
+++ b/digits/templates/datasets/images/classification/show.html
@@ -97,9 +97,17 @@
         {% endautoescape %}
         );
     </script>
-    {% if task.status=='D' and task.mean_file %}
+    {% if task.status=='D' %}
+    {% if task.mean_file %}
     <b>Image Mean:</b>
     <img src="{{url_for('serve_file', path=task.path('mean.jpg', relative=True))}}" />
+    {% endif %}
+    {% if task.backend=='lmdb' %}
+    <dl>
+        <br/>
+        <a href="{{url_for('image_classification_dataset_explore', job_id=job.id(), db=task.db_name.lower())}}" class="btn btn-primary">Explore the db</a>
+    </dl>
+    {% endif %}
     {% endif %}
     {% endif %}
 </div>
@@ -212,4 +220,3 @@
 {% endfor %}
 
 {% endblock %}
-

--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -2,12 +2,14 @@
 
 import os.path
 
+import io
 import requests
 import cStringIO
 import PIL.Image
 import numpy as np
 import scipy.misc
 import math
+import base64
 
 from . import is_url, HTTP_TIMEOUT, errors
 
@@ -461,3 +463,14 @@ def get_color_map(name):
         greenmap    = [0,0,0.5,1,1,1,0.5,0,0]
         bluemap     = [0.5,1,1,1,0.5,0,0,0,0]
     return 255.0 * np.array(redmap), 255.0 * np.array(greenmap), 255.0 * np.array(bluemap)
+
+def image_to_base64(image):
+    if isinstance(image, np.ndarray):
+        image = PIL.Image.fromarray(image)
+    elif not isinstance(image, PIL.Image.Image):
+        raise ValueError('image must be a PIL.Image or a np.ndarray')
+    bytesio = io.BytesIO()
+    image.save(bytesio, image.format)
+    byte_value = bytesio.getvalue()
+    b64 = base64.b64encode(byte_value)
+    return 'data:image/%s;base64,%s' % (image.format.lower(), b64)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # REST API
 
-*Generated Sep 16, 2015*
+*Generated Oct 04, 2015*
 
 DIGITS exposes its internal functionality through a REST API. You can access these endpoints by performing a GET or POST on the route, and a JSON object will be returned.
 

--- a/docs/FlaskRoutes.md
+++ b/docs/FlaskRoutes.md
@@ -1,6 +1,6 @@
 # Flask Routes
 
-*Generated Sep 16, 2015*
+*Generated Oct 04, 2015*
 
 Documentation on the various routes used internally for the web application.
 
@@ -177,6 +177,14 @@ Location: [`digits/dataset/views.py`](../digits/dataset/views.py)
 > Returns JSON when requested: {job_id,name,status} or {errors:[]}
 
 Methods: **POST**
+
+Location: [`digits/dataset/images/classification/views.py`](../digits/dataset/images/classification/views.py)
+
+### `/datasets/images/classification/explore`
+
+> Returns a gallery consisting of the images of one of the dbs
+
+Methods: **GET**
 
 Location: [`digits/dataset/images/classification/views.py`](../digits/dataset/images/classification/views.py)
 


### PR DESCRIPTION
*Closes #21*

Implemented some way to visualize a dataset db as a gallery, solving #21. I did that to debug #330, as some transformations were not doing what I expected. 

You can browse a dataset page by page, reading directly from the db. For now it's only working with lmdb . You can filter by one of the labels from the classification task, as well as change the number of images displayed. 

<img width="400" alt="Screenshot 1" src="https://cloud.githubusercontent.com/assets/5939621/10139366/cc12217e-6602-11e5-8aa7-8cc6b83ec65d.png">

The explorer is accessible from a button in the dataset show view, once a task is done. 
<img width="300" alt="Screenshot 2" src="https://cloud.githubusercontent.com/assets/5939621/10139414/0a38086a-6603-11e5-9c08-7f7ce2e2ee0a.png">

The UI is a bit rough and can probably be improved but at least it's functional. 

I'll write some tests when I have enough time. 
