### PR TITLE
Increase test timeouts (TravisCI can be slow)

### DIFF
--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -20,7 +20,7 @@ import digits.test_views
 from test_imageset_creator import create_classification_imageset, IMAGE_SIZE as DUMMY_IMAGE_SIZE, IMAGE_COUNT as DUMMY_IMAGE_COUNT
 
 # May be too short on a slow system
-TIMEOUT_DATASET = 15
+TIMEOUT_DATASET = 20
 
 ################################################################################
 # Base classes (they don't start with "Test" so nose won't run them)

--- a/digits/dataset/images/generic/test_views.py
+++ b/digits/dataset/images/generic/test_views.py
@@ -20,7 +20,7 @@ import digits.test_views
 from test_lmdb_creator import create_lmdbs
 
 # May be too short on a slow system
-TIMEOUT_DATASET = 15
+TIMEOUT_DATASET = 20
 
 ################################################################################
 # Base classes (they don't start with "Test" so nose won't run them)

--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -26,8 +26,8 @@ import digits.dataset.images.classification.test_views
 from digits.config import config_value
 
 # May be too short on a slow system
-TIMEOUT_DATASET = 15
-TIMEOUT_MODEL = 20
+TIMEOUT_DATASET = 20
+TIMEOUT_MODEL = 30
 
 ################################################################################
 # Base classes (they don't start with "Test" so nose won't run them)

--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -26,8 +26,8 @@ import digits.dataset.images.generic.test_views
 from digits.config import config_value
 
 # May be too short on a slow system
-TIMEOUT_DATASET = 15
-TIMEOUT_MODEL = 20
+TIMEOUT_DATASET = 20
+TIMEOUT_MODEL = 30
 
 ################################################################################
 # Base classes (they don't start with "Test" so nose won't run them)


### PR DESCRIPTION
TravisCI builds have started timing out sometimes (https://github.com/NVIDIA/DIGITS/pull/331#issuecomment-143792884). Since the build machines don't have GPUs, Caffe takes a LOT longer to run.