### PR TITLE
Add ability to clone previous jobs

### DIFF
--- a/digits/dataset/images/generic/test_views.py
+++ b/digits/dataset/images/generic/test_views.py
@@ -92,7 +92,6 @@ class BaseViewsTestWithImageset(BaseViewsTest):
                 'prebuilt_train_labels': os.path.join(cls.imageset_folder, 'train_labels'),
                 'prebuilt_val_images': os.path.join(cls.imageset_folder, 'val_images'),
                 'prebuilt_val_labels': os.path.join(cls.imageset_folder, 'val_labels'),
-                'prebuilt_val_labels': os.path.join(cls.imageset_folder, 'val_labels'),
                 'prebuilt_mean_file': os.path.join(cls.imageset_folder, 'train_mean.binaryproto'),
                 }
         data.update(kwargs)
@@ -190,6 +189,40 @@ class TestCreation(BaseViewsTestWithImageset):
     def test_no_force_same_shape(self):
         job_id = self.create_dataset(force_same_shape=0)
         assert self.dataset_wait_completion(job_id) == 'Done', 'create failed'
+
+    def test_clone(self):
+        options_1 = {
+            'resize_channels': '1',
+        }
+
+        job1_id = self.create_dataset(**options_1)
+        assert self.dataset_wait_completion(job1_id) == 'Done', 'first job failed'
+        rv = self.app.get('/datasets/%s.json' % job1_id)
+        assert rv.status_code == 200, 'json load failed with %s' % rv.status_code
+        content1 = json.loads(rv.data)
+
+        ## Clone job1 as job2
+        options_2 = {
+            'clone': job1_id,
+        }
+
+        job2_id = self.create_dataset(**options_2)
+        assert self.dataset_wait_completion(job2_id) == 'Done', 'second job failed'
+        rv = self.app.get('/datasets/%s.json' % job2_id)
+        assert rv.status_code == 200, 'json load failed with %s' % rv.status_code
+        content2 = json.loads(rv.data)
+
+        ## These will be different
+        content1.pop('id')
+        content2.pop('id')
+        content1.pop('directory')
+        content2.pop('directory')
+        assert (content1 == content2), 'job content does not match'
+
+        job1 = digits.webapp.scheduler.get_job(job1_id)
+        job2 = digits.webapp.scheduler.get_job(job2_id)
+
+        assert (job1.form_data == job2.form_data), 'form content does not match'
 
 class TestCreated(BaseViewsTestWithDataset):
     """

--- a/digits/dataset/images/generic/views.py
+++ b/digits/dataset/images/generic/views.py
@@ -2,6 +2,7 @@
 
 import flask
 
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler, autodoc
 from digits.dataset import tasks
@@ -17,6 +18,10 @@ def generic_image_dataset_new():
     Returns a form for a new GenericImageDatasetJob
     """
     form = GenericImageDatasetForm()
+
+    ## Is there a request to clone a job with ?clone=<job_id>
+    fill_form_if_cloned(form)
+
     return flask.render_template('datasets/images/generic/new.html', form=form)
 
 @app.route(NAMESPACE + '.json', methods=['POST'])
@@ -29,6 +34,10 @@ def generic_image_dataset_create():
     Returns JSON when requested: {job_id,name,status} or {errors:[]}
     """
     form = GenericImageDatasetForm()
+
+    ## Is there a request to clone a job with ?clone=<job_id>
+    fill_form_if_cloned(form)
+
     if not form.validate_on_submit():
         if request_wants_json():
             return flask.jsonify({'errors': form.errors}), 400
@@ -86,6 +95,9 @@ def generic_image_dataset_create():
                             force_same_shape = force_same_shape,
                             )
                         )
+
+        ## Save form data with the job so we can easily clone it later.
+        save_form_to_job(job, form)
 
         scheduler.add_job(job)
 

--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -389,6 +389,54 @@ class BaseTestCreation(BaseViewsTestWithDataset):
         job_info = self.job_info_html(job_id=job_id, job_type='models')
         assert 'BogusCode' in job_info
 
+    def test_clone(self):
+        options_1 = {
+            'shuffle': True,
+            'snapshot_interval': 2.0,
+            'lr_step_size': 33.0,
+            'lr_inv_power': 0.5,
+            'lr_inv_gamma': 0.1,
+            'lr_poly_power': 3.0,
+            'lr_exp_gamma': 0.9,
+            'use_mean': 0,
+            'lr_multistep_gamma': 0.5,
+            'lr_policy': 'exp',
+            'val_interval': 3.0,
+            'random_seed': 123,
+            'learning_rate': 0.0125,
+            'lr_step_gamma': 0.1,
+            'lr_sigmoid_step': 50.0,
+            'lr_sigmoid_gamma': 0.1,
+            'lr_multistep_values': '50,85',
+        }
+
+        job1_id = self.create_model(**options_1)
+        assert self.model_wait_completion(job1_id) == 'Done', 'first job failed'
+        rv = self.app.get('/models/%s.json' % job1_id)
+        assert rv.status_code == 200, 'json load failed with %s' % rv.status_code
+        content1 = json.loads(rv.data)
+
+        ## Clone job1 as job2
+        options_2 = {
+            'clone': job1_id,
+        }
+
+        job2_id = self.create_model(**options_2)
+        assert self.model_wait_completion(job2_id) == 'Done', 'second job failed'
+        rv = self.app.get('/models/%s.json' % job2_id)
+        assert rv.status_code == 200, 'json load failed with %s' % rv.status_code
+        content2 = json.loads(rv.data)
+
+        ## These will be different
+        content1.pop('id')
+        content2.pop('id')
+        content1.pop('directory')
+        content2.pop('directory')
+        assert (content1 == content2), 'job content does not match'
+
+        job1 = digits.webapp.scheduler.get_job(job1_id)
+        job2 = digits.webapp.scheduler.get_job(job2_id)
+        assert (job1.form_data == job2.form_data), 'form content does not match'
 
 class BaseTestCreated(BaseViewsTestWithModel):
     """

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -21,6 +21,7 @@ from job import ImageClassificationModelJob
 from digits.status import Status
 import platform
 from digits.utils import errors
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 
 NAMESPACE   = '/models/images/classification'
 
@@ -37,6 +38,9 @@ def image_classification_model_new():
     form.previous_networks.choices = get_previous_networks()
 
     prev_network_snapshots = get_previous_network_snapshots()
+
+    ## Is there a request to clone a job with ?clone=<job_id>
+    fill_form_if_cloned(form)
 
     return flask.render_template('models/images/classification/new.html',
             form = form,
@@ -62,6 +66,9 @@ def image_classification_model_create():
     form.previous_networks.choices = get_previous_networks()
 
     prev_network_snapshots = get_previous_network_snapshots()
+
+    ## Is there a request to clone a job with ?clone=<job_id>
+    fill_form_if_cloned(form)
 
     if not form.validate_on_submit():
         if request_wants_json():
@@ -200,6 +207,9 @@ def image_classification_model_create():
                     shuffle         = form.shuffle.data,
                     )
                 )
+
+        ## Save form data with the job so we can easily clone it later.
+        save_form_to_job(job, form)
 
         scheduler.add_job(job)
         if request_wants_json():

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -11,6 +11,7 @@ from digits import frameworks
 from digits.config import config_value
 from digits import utils
 from digits.utils.routing import request_wants_json, job_from_request
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.webapp import app, scheduler, autodoc
 from digits.dataset import GenericImageDatasetJob
 from digits import frameworks
@@ -35,6 +36,9 @@ def generic_image_model_new():
 
     prev_network_snapshots = get_previous_network_snapshots()
 
+    ## Is there a request to clone a job with ?clone=<job_id>
+    fill_form_if_cloned(form)
+
     return flask.render_template('models/images/generic/new.html',
             form = form,
             frameworks = frameworks.get_frameworks(),
@@ -58,6 +62,9 @@ def generic_image_model_create():
     form.previous_networks.choices = get_previous_networks()
 
     prev_network_snapshots = get_previous_network_snapshots()
+
+    ## Is there a request to clone a job with ?clone=<job_id>
+    fill_form_if_cloned(form)
 
     if not form.validate_on_submit():
         if request_wants_json():
@@ -183,6 +190,9 @@ def generic_image_model_create():
                     shuffle         = form.shuffle.data,
                     )
                 )
+
+        ## Save form data with the job so we can easily clone it later.
+        save_form_to_job(job, form)
 
         scheduler.add_job(job)
         if request_wants_json():

--- a/digits/templates/datasets/images/classification/new.html
+++ b/digits/templates/datasets/images/classification/new.html
@@ -2,6 +2,7 @@
 
 {% from "helper.html" import print_flashes %}
 {% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
 
 {% extends "layout.html" %}
 
@@ -27,14 +28,14 @@ New Image Classification Dataset
     <div class="row">
         <div class="col-sm-4 well">
             <div class="row">
-                <div class="form-group{{ ' has-error' if form.resize_channels.errors else '' }}">
+                <div class="form-group{{mark_errors([form.resize_channels])}}">
                     {{ form.resize_channels.label }}
                     {{ form.resize_channels.tooltip }}
                     {{ form.resize_channels(class='form-control') }}
                 </div>
             </div>
             <div class="row">
-                <div class="form-group{{ ' has-error' if form.resize_width.errors or form.resize_height.errors else '' }}">
+                <div class="form-group{{mark_errors([form.resize_width, form.resize_height])}}">
                     <label>Image size</label>
                     <span name="resize_dims_explanation"
                           class="explanation-tooltip glyphicon glyphicon-question-sign"
@@ -49,7 +50,7 @@ New Image Classification Dataset
                 </div>
             </div>
             <div class="row">
-                <div class="form-group{{ ' has-error' if form.resize_mode.errors else '' }}">
+                <div class="form-group{{mark_errors([form.resize_mode])}}">
                     {{ form.resize_mode.label }}
                     {{ form.resize_mode.tooltip }}
                     {{ form.resize_mode(class='form-control') }}
@@ -98,7 +99,7 @@ function showResizeExample()
             <div class="tab-content well">
                 <!-- Folder -->
                 <div class="tab-pane" id="db-folder">
-                    <div class="form-group{{ ' has-error' if form.folder_train.errors else '' }}">
+                    <div class="form-group{{mark_errors([form.folder_train])}}">
                         {{ form.folder_train.label }}
                         {{ form.folder_train.tooltip }}
                         {{ form.folder_train(class='form-control autocomplete_path', placeholder='folder or URL')}}
@@ -110,24 +111,24 @@ function showResizeExample()
                         </div>
                     </div>
                     <div class="row">
-                        <div class="form-group col-sm-6{{ ' has-error' if form.folder_train_min_per_class.errors else '' }}">
+                        <div class="form-group col-sm-6{{mark_errors([form.folder_train_min_per_class])}}">
                             {{ form.folder_train_min_per_class.label }}
                             {{ form.folder_train_min_per_class.tooltip }}
                             {{ form.folder_train_min_per_class(class='form-control') }}
                         </div>
-                        <div class="form-group col-sm-6{{ ' has-error' if form.folder_train_max_per_class.errors else '' }}">
+                        <div class="form-group col-sm-6{{mark_errors([form.folder_train_max_per_class])}}">
                             {{ form.folder_train_max_per_class.label }}
                             {{ form.folder_train_max_per_class.tooltip }}
                             {{ form.folder_train_max_per_class(class='form-control') }}
                         </div>
                     </div>
                     <div class="row">
-                        <div class="form-group col-sm-6{{ ' has-error' if form.folder_pct_val.errors else '' }}">
+                        <div class="form-group col-sm-6{{mark_errors([form.folder_pct_val])}}">
                             {{ form.folder_pct_val.label }}
                             {{ form.folder_pct_val.tooltip }}
                             {{ form.folder_pct_val(class='form-control') }}
                         </div>
-                        <div class="form-group col-sm-6{{ ' has-error' if form.folder_pct_test.errors else '' }}">
+                        <div class="form-group col-sm-6{{mark_errors([form.folder_pct_test])}}">
                             {{ form.folder_pct_test.label }}
                             {{ form.folder_pct_test.tooltip }}
                             {{ form.folder_pct_test(class='form-control') }}
@@ -136,17 +137,17 @@ function showResizeExample()
                     <br>
                     {{form.has_val_folder}}
                     {{form.has_val_folder.label}}
-                    <div style="display:none;" class="form-group{{ ' has-error' if form.folder_val.errors else '' }} cl-separate-val-folder">
+                    <div style="display:none;" class="form-group{{mark_errors([form.folder_val])}} cl-separate-val-folder">
                         {{ form.folder_val.label }}
                         {{ form.folder_val(class='form-control autocomplete_path') }}
                     </div>
                     <div class="row cl-separate-val-folder">
-                        <div class="form-group col-sm-6{{ ' has-error' if form.folder_val_min_per_class.errors else '' }}">
+                        <div class="form-group col-sm-6{{mark_errors([form.folder_val_min_per_class])}}">
                             {{ form.folder_val_min_per_class.label }}
                             {{ form.folder_val_min_per_class.tooltip }}
                             {{ form.folder_val_min_per_class(class='form-control') }}
                         </div>
-                        <div class="form-group col-sm-6{{ ' has-error' if form.folder_val_max_per_class.errors else '' }}">
+                        <div class="form-group col-sm-6{{mark_errors([form.folder_val_max_per_class])}}">
                             {{ form.folder_val_max_per_class.label }}
                             {{ form.folder_val_max_per_class.tooltip }}
                             {{ form.folder_val_max_per_class(class='form-control') }}
@@ -173,17 +174,17 @@ hasValFolderChanged();
                     <br>
                     {{form.has_test_folder}}
                     {{form.has_test_folder.label}}
-                    <div style="display:none;" class="form-group{{ ' has-error' if form.folder_test.errors else '' }} cl-separate-test-folder">
+                    <div style="display:none;" class="form-group{{mark_errors([form.folder_test])}} cl-separate-test-folder">
                         {{ form.folder_test.label }}
                         {{ form.folder_test(class='form-control autocomplete_path') }}
                     </div>
                     <div style="display:none;" class="row cl-separate-test-folder">
-                        <div class="form-group col-sm-6{{ ' has-error' if form.folder_test_min_per_class.errors else '' }}">
+                        <div class="form-group col-sm-6{{mark_errors([form.folder_test_min_per_class])}}">
                             {{ form.folder_test_min_per_class.label }}
                             {{ form.folder_test_min_per_class.tooltip }}
                             {{ form.folder_test_min_per_class(class='form-control') }}
                         </div>
-                        <div class="form-group col-sm-6{{ ' has-error' if form.folder_test_max_per_class.errors else '' }}">
+                        <div class="form-group col-sm-6{{mark_errors([form.folder_test_max_per_class])}}">
                             {{ form.folder_test_max_per_class.label }}
                             {{ form.folder_test_max_per_class.tooltip }}
                             {{ form.folder_test_max_per_class(class='form-control') }}
@@ -244,13 +245,13 @@ hasTestFolderChanged();
                             </tr>
                             <tr>
                                 <td><b>Training</b></td>
-                                <td class="form-group{{' has-error' if form.textfile_train_images.errors}} cl-upload-files">
+                                <td class="form-group{{mark_errors([form.textfile_train_images])}} cl-upload-files">
                                     {{ form.textfile_train_images(class='form-control') }}
                                 </td>
-                                <td class="form-group{{' has-error' if form.textfile_local_train_images.errors}} cl-local-files">
+                                <td class="form-group{{mark_errors([form.textfile_local_train_images])}} cl-local-files">
                                     {{ form.textfile_local_train_images(class='form-control autocomplete_path',placeholder='enter path') }}
                                 </td>
-                                <td class="form-group{{' has-error' if form.textfile_train_folder.errors}}">
+                                <td class="form-group{{mark_errors([form.textfile_train_folder])}}">
                                     {{ form.textfile_train_folder(class='form-control autocomplete_path') }}
                                 </td>
                             </tr>
@@ -261,13 +262,13 @@ hasTestFolderChanged();
                                         Validation
                                     </label>
                                 </td>
-                                <td class="form-group{{' has-error' if form.textfile_val_images.errors}} cl-upload-files">
+                                <td class="form-group{{mark_errors([form.textfile_val_images])}} cl-upload-files">
                                     {{ form.textfile_val_images(class='form-control') }}
                                 </td>
-                                <td class="form-group{{' has-error' if form.textfile_local_val_images.errors}} cl-local-files">
+                                <td class="form-group{{mark_errors([form.textfile_local_val_images])}} cl-local-files">
                                     {{ form.textfile_local_val_images(class='form-control autocomplete_path',placeholder='enter path') }}
                                 </td>
-                                <td class="form-group{{' has-error' if form.textfile_val_folder.errors}}">
+                                <td class="form-group{{mark_errors([form.textfile_val_folder])}}">
                                     {{ form.textfile_val_folder(class='form-control autocomplete_path') }}
                                 </td>
                             </tr>
@@ -278,13 +279,13 @@ hasTestFolderChanged();
                                         Test
                                     </label>
                                 </td>
-                                <td class="form-group{{' has-error' if form.textfile_test_images.errors}} cl-upload-files">
+                                <td class="form-group{{mark_errors([form.textfile_test_images])}} cl-upload-files">
                                     {{ form.textfile_test_images(class='form-control') }}
                                 </td>
-                                <td class="form-group{{' has-error' if form.textfile_local_test_images.errors}} cl-local-files">
+                                <td class="form-group{{mark_errors([form.textfile_local_test_images])}} cl-local-files">
                                     {{ form.textfile_local_test_images(class='form-control autocomplete_path',placeholder='enter path') }}
                                 </td>
-                                <td class="form-group{{' has-error' if form.textfile_test_folder.errors}}">
+                                <td class="form-group{{mark_errors([form.textfile_test_folder])}}">
                                     {{ form.textfile_test_folder(class='form-control autocomplete_path') }}
                                 </td>
                             </tr>
@@ -292,17 +293,17 @@ hasTestFolderChanged();
                     </div>
                     <div class="row">
                         <div class="col-sm-6 col-sm-offset-1">
-                            <div class="form-group{{ ' has-error' if form.textfile_shuffle.errors else '' }}">
+                            <div class="form-group{{mark_errors([form.textfile_shuffle])}}">
                                 {{ form.textfile_shuffle.label }}
                                 {{ form.textfile_shuffle.tooltip }}
                                 {{ form.textfile_shuffle(class='form-control') }}
                             </div>
-                            <div class="form-group{{ ' has-error' if form.textfile_labels_file.errors else '' }} cl-upload-files">
+                            <div class="form-group{{mark_errors([form.textfile_labels_file])}} cl-upload-files">
                                 {{ form.textfile_labels_file.label }}
                                 {{ form.textfile_labels_file.tooltip }}
                                 {{ form.textfile_labels_file(class='form-control') }}
                             </div>
-                            <div class="form-group{{ ' has-error' if form.textfile_local_labels_file.errors else '' }} cl-local-files">
+                            <div class="form-group{{mark_errors([form.textfile_local_labels_file])}} cl-local-files">
                                 {{ form.textfile_local_labels_file.label }}
                                 {{ form.textfile_local_labels_file.tooltip }}
                                 {{ form.textfile_local_labels_file(class='form-control autocomplete_path',placeholder='enter path') }}
@@ -375,7 +376,7 @@ $('#db-tabs a[href="#db-{{ form.method.data }}"]').tab('show');
 
     <div class="row">
         <div class="col-sm-6 col-sm-offset-3 well">
-            <div class="form-group{{ ' has-error' if form.backend.errors else '' }}">
+            <div class="form-group{{mark_errors([form.backend])}}">
                 {{ form.backend.label }}
                 {{ form.backend.tooltip }}
                 {{ form.backend(class='form-control') }}
@@ -387,15 +388,15 @@ $('#db-tabs a[href="#db-{{ form.method.data }}"]').tab('show');
                     <li><i>HDF5Data</i> layers do not support mean subtraction</li>
                 </ul>
             </div>
-            <div class="form-group{{ ' has-error' if form.compression.errors else '' }}">
-                <div class="form-group{{' has-error' if form.compression.errors}}">
+            <div class="form-group{{mark_errors([form.compression])}}">
+                <div class="form-group{{mark_errors([form.compression])}}">
                     {{form.compression.label}}
                     {{form.compression.tooltip}}
                     {{form.compression(class='form-control')}}
                 </div>
             </div>
-            <div class="form-group{{ ' has-error' if form.encoding.errors else '' }}">
-                <div class="form-group{{' has-error' if form.encoding.errors}}">
+            <div class="form-group{{mark_errors([form.encoding])}}">
+                <div class="form-group{{mark_errors([form.encoding])}}">
                     {{form.encoding.label}}
                     {{form.encoding.tooltip}}
                     {{form.encoding(class='form-control')}}
@@ -418,7 +419,7 @@ function backendChanged()
 $("#backend").change(backendChanged);
 backendChanged();
             </script>
-            <div class="form-group{{ ' has-error' if form.dataset_name.errors else '' }}">
+            <div class="form-group{{mark_errors([form.dataset_name])}}">
                 {{ form.dataset_name.label }}
                 {{ form.dataset_name(class='form-control') }}
             </div>

--- a/digits/templates/datasets/images/generic/new.html
+++ b/digits/templates/datasets/images/generic/new.html
@@ -2,6 +2,7 @@
 
 {% from "helper.html" import print_flashes %}
 {% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
 
 {% extends "layout.html" %}
 
@@ -43,19 +44,19 @@ New Image Dataset
                             </tr>
                             <tr>
                                 <td><b>Training</b></td>
-                                <td class="form-group{{' has-error' if form.prebuilt_train_images.errors}}">
+                                <td class="form-group{{mark_errors([form.prebuilt_train_images])}}">
                                     {{ form.prebuilt_train_images(class='form-control autocomplete_path') }}
                                 </td>
-                                <td class="form-group{{' has-error' if form.prebuilt_train_labels.errors}}">
+                                <td class="form-group{{mark_errors([form.prebuilt_train_labels])}}">
                                     {{ form.prebuilt_train_labels(class='form-control autocomplete_path') }}
                                 </td>
                             </tr>
                             <tr>
                                 <td><b>Validation</b></td>
-                                <td class="form-group{{' has-error' if form.prebuilt_val_images.errors}}">
+                                <td class="form-group{{mark_errors([form.prebuilt_val_images])}}">
                                     {{ form.prebuilt_val_images(class='form-control autocomplete_path') }}
                                 </td>
-                                <td class="form-group{{' has-error' if form.prebuilt_val_labels.errors}}">
+                                <td class="form-group{{mark_errors([form.prebuilt_val_labels])}}">
                                     {{ form.prebuilt_val_labels(class='form-control autocomplete_path') }}
                                 </td>
                             </tr>
@@ -63,7 +64,7 @@ New Image Dataset
                     </div>
                     <div class="row">
                         <div class="col-sm-6 col-sm-offset-3">
-                            <div class="form-group{{ ' has-error' if form.force_same_shape.errors else '' }}">
+                            <div class="form-group{{mark_errors([form.force_same_shape])}}">
                                 {{ form.force_same_shape.label }}
                                 {{ form.force_same_shape.tooltip }}
                                 {{ form.force_same_shape(class='form-control') }}
@@ -72,7 +73,7 @@ New Image Dataset
                     </div>
                     <div class="row">
                         <div class="col-sm-6 col-sm-offset-3">
-                            <div class="form-group{{ ' has-error' if form.prebuilt_mean_file.errors else '' }}">
+                            <div class="form-group{{mark_errors([form.prebuilt_mean_file])}}">
                                 {{ form.prebuilt_mean_file.label }}
                                 {{ form.prebuilt_mean_file.tooltip }}
                                 {{ form.prebuilt_mean_file(class='form-control autocomplete_path') }}
@@ -97,7 +98,7 @@ $('#db-tabs a[href="#db-{{ form.method.data }}"]').tab('show');
 
     <div class="row">
         <div class="col-sm-6 col-sm-offset-3 well">
-            <div class="form-group{{ ' has-error' if form.dataset_name.errors else '' }}">
+            <div class="form-group{{mark_errors([form.dataset_name])}}">
                 {{ form.dataset_name.label }}
                 {{ form.dataset_name(class='form-control') }}
             </div>

--- a/digits/templates/helper.html
+++ b/digits/templates/helper.html
@@ -28,4 +28,26 @@
             {% endfor %}
         </div>
     {% endif %}
+    {% if form.warnings %}
+        <div class="alert alert-warning">
+            {% for field_name, field in form._fields.iteritems() %}
+                {% if field.warnings %}
+                    <li><label>{{ field.label.text }}</label>
+                        <ul>
+                            {% for e in field.warnings %}
+                                <li>{{ e }}</li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% macro mark_errors(list) %}
+    {% for form in list %}
+        {{ ' has-error' if form.errors else '' }}
+        {{ ' has-warning' if form.warnings else '' }}
+    {% endfor %}
 {% endmacro %}

--- a/digits/templates/job.html
+++ b/digits/templates/job.html
@@ -112,6 +112,11 @@ function updateJobName() {
         </div>
         <small>{{ job.job_type() }}</small>
         <div class="pull-right">
+            {% if job.form_data is defined %}
+            <a id="clone-job" class="btn btn-info" href="{{url_for('clone_job', clone=job.id())}}">Clone Job</a>
+            {% else %}
+            <a id="clone-job" class="btn btn-info " disabled>Clone Job</a>
+            {% endif %}
             <a id="abort-job" class="btn btn-warning{{ ' hidden' if not job.status.is_running() }}">Abort Job</a>
             <a id="delete-job" class="btn btn-danger">Delete Job</a>
         </div>

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -2,6 +2,7 @@
 
 {% from "helper.html" import print_flashes %}
 {% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
 
 {% extends "layout.html" %}
 
@@ -26,7 +27,7 @@ New Image Classification Model
     <div class="row">
         <div class="col-sm-4">
             <div class="well">
-                <div class="form-group{{' has-error' if form.dataset.errors}}">
+                <div class="form-group{{mark_errors([form.dataset])}}">
                     {{form.dataset.label}}
                     {{form.dataset.tooltip}}
                     {{form.dataset(class='form-control', size=5)}}
@@ -56,12 +57,12 @@ $("#dataset").change(function() {
         <div class="col-sm-4">
             <div class="well">
                 <h4>Data Transformations</h4>
-                <div class="form-group{{' has-error' if form.crop_size.errors}}">
+                <div class="form-group{{mark_errors([form.crop_size])}}">
                     {{form.crop_size.label}}
                     {{form.crop_size.tooltip}}
                     {{form.crop_size(class='form-control', placeholder='none')}}
                 </div>
-                <div class="form-group{{' has-error' if form.use_mean.errors}}">
+                <div class="form-group{{mark_errors([form.use_mean])}}">
                     {{form.use_mean.label}}
                     {{form.use_mean.tooltip}}
                     {{form.use_mean(class='form-control')}}
@@ -78,7 +79,7 @@ $("#dataset").change(function() {
                 <h4>Solver Options</h4>
 
                 <!-- Length -->
-                <div class="form-group{{' has-error' if form.shuffle.errors}}" id="shuffle-data" style="display:none;">
+                <div class="form-group{{mark_errors([form.shuffle])}}" id="shuffle-data" style="display:none;">
                     <label for={{form.shuffle.name}}>
                         {{form.shuffle}}
                         {{form.shuffle.label.text}}
@@ -86,38 +87,38 @@ $("#dataset").change(function() {
                     {{ form.shuffle.tooltip }}
                 </div>
 
-                <div class="form-group{{' has-error' if form.train_epochs.errors}}">
+                <div class="form-group{{mark_errors([form.train_epochs])}}">
                     {{form.train_epochs.label}}
                     {{form.train_epochs.tooltip}}
                     {{form.train_epochs(class='form-control')}}
                 </div>
-                <div class="form-group{{' has-error' if form.snapshot_interval.errors}}">
+                <div class="form-group{{mark_errors([form.snapshot_interval])}}">
                     {{form.snapshot_interval.label}}
                     {{form.snapshot_interval.tooltip}}
                     {{form.snapshot_interval(class='form-control')}}
                 </div>
-                <div class="form-group{{' has-error' if form.val_interval.errors}}">
+                <div class="form-group{{mark_errors([form.val_interval])}}">
                     {{form.val_interval.label}}
                     {{form.val_interval.tooltip}}
                     {{form.val_interval(class='form-control')}}
                 </div>
                 {# TODO: neat progress bar #}
-                <div class="form-group{{' has-error' if form.random_seed.errors}}">
+                <div class="form-group{{mark_errors([form.random_seed])}}">
                     {{form.random_seed.label}}
                     {{form.random_seed.tooltip}}
                     {{form.random_seed(class='form-control', placeholder='[none]')}}
                 </div>
-                <div class="form-group{{' has-error' if form.batch_size.errors}}">
+                <div class="form-group{{mark_errors([form.batch_size])}}">
                     {{form.batch_size.label}}
                     {{form.batch_size.tooltip}}
                     {{form.batch_size(class='form-control', placeholder='[network defaults]')}}
                 </div>
-                <div class="form-group{{' has-error' if form.solver_type.errors}}">
+                <div class="form-group{{mark_errors([form.solver_type])}}">
                     {{form.solver_type.label}}
                     {{form.solver_type.tooltip}}
                     {{form.solver_type(class='form-control')}}
                 </div>
-                <div class="form-group{{' has-error' if form.learning_rate.errors}}">
+                <div class="form-group{{mark_errors([form.learning_rate])}}">
                     {{form.learning_rate.label}}
                     {{form.learning_rate.tooltip}}
                     {{form.learning_rate(class='form-control learning-rate-option')}}
@@ -145,57 +146,57 @@ showHideAdvancedLROptions();
 
                 <div id="advanced-lr-options" style="display:none;">
 
-                    <div class="form-group{{' has-error' if form.lr_policy.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_policy])}}">
                         {{form.lr_policy.label}}
                         {{form.lr_policy(class='form-control learning-rate-option')}}
                     </div>
 
-                    <div class="form-group{{' has-error' if form.lr_step_size.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_step_size])}}">
                         {{form.lr_step_size.label}}
                         <div class="input-group">
                             {{form.lr_step_size(class='form-control learning-rate-option')}}
                             <span class="input-group-addon">%</span>
                         </div>
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_step_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_step_gamma])}}">
                         {{form.lr_step_gamma.label}}
                         {{form.lr_step_gamma(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_multistep_values.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_multistep_values])}}">
                         {{form.lr_multistep_values.label}}
                         <div class="input-group">
                             {{form.lr_multistep_values(class='form-control learning-rate-option')}}
                             <span class="input-group-addon">%</span>
                         </div>
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_multistep_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_multistep_gamma])}}">
                         {{form.lr_multistep_gamma.label}}
                         {{form.lr_multistep_gamma(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_exp_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_exp_gamma])}}">
                         {{form.lr_exp_gamma.label}}
                         {{form.lr_exp_gamma(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_inv_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_inv_gamma])}}">
                         {{form.lr_inv_gamma.label}}
                         {{form.lr_inv_gamma(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_inv_power.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_inv_power])}}">
                         {{form.lr_inv_power.label}}
                         {{form.lr_inv_power(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_poly_power.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_poly_power])}}">
                         {{form.lr_poly_power.label}}
                         {{form.lr_poly_power(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_sigmoid_step.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_sigmoid_step])}}">
                         {{form.lr_sigmoid_step.label}}
                         <div class="input-group">
                             {{form.lr_sigmoid_step(class='form-control learning-rate-option')}}
                             <span class="input-group-addon">%</span>
                         </div>
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_sigmoid_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_sigmoid_gamma])}}">
                         {{form.lr_sigmoid_gamma.label}}
                         {{form.lr_sigmoid_gamma(class='form-control learning-rate-option')}}
                     </div>
@@ -579,7 +580,7 @@ function visualizeNetwork() {
                     </script>
                        <div class="tab-content" id="custom_textareas">
 
-                                <div class="form-group{{' has-error' if form.custom_network.errors}}">
+                                <div class="form-group{{mark_errors([form.custom_network])}}">
                                     {{form.custom_network.label}}
                                     {{form.custom_network.explanation(file='/models/images/classification/custom_network_explanation.html')}}
                                     <div class="pull-right">
@@ -591,7 +592,7 @@ function visualizeNetwork() {
                         <script>$(this).addClass('active');
                             $('#custom_textareas div:first').addClass('tab-pane active') // Select first tab
                         </script>
-                    <div class="form-group{{' has-error' if form.custom_network_snapshot.errors}}">
+                    <div class="form-group{{mark_errors([form.custom_network_snapshot])}}">
                         {{form.custom_network_snapshot.label}}
                         {{form.custom_network_snapshot.tooltip}}
                         {{form.custom_network_snapshot(class='form-control autocomplete_path')}}
@@ -615,7 +616,7 @@ $('#network-tabs a[href="#network-tab-'+$("#method").val()+'"]').tab('show');
     <div class="row">
         <div class="col-sm-6 col-sm-offset-3 well">
             {% if form.select_gpu.choices|length > 2 and not multi_gpu %}
-            <div class="form-group{{' has-error' if form.select_gpu.errors}}">
+            <div class="form-group{{mark_errors([form.select_gpu])}}">
                 <b>{{form.select_gpu.label.text}}</b><br>
                 {% for choice in form.select_gpu %}
                 <div class="radio">
@@ -628,12 +629,12 @@ $('#network-tabs a[href="#network-tab-'+$("#method").val()+'"]').tab('show');
             </div>
             {% endif %}
             {% if form.select_gpus.choices| length > 1 and multi_gpu %}
-            <div class="form-group{{' has-error' if form.select_gpu_count.errors}}">
+            <div class="form-group{{mark_errors([form.select_gpu_count])}}">
                 {{form.select_gpu_count.label}}
                 {{form.select_gpu_count(class='form-control')}}
             </div>
             <p class="text-center"><i>or</i></p>
-            <div class="form-group{{' has-error' if form.select_gpus.errors}}">
+            <div class="form-group{{mark_errors([form.select_gpus])}}">
                 {{form.select_gpus.label}}
                 {{form.select_gpus.tooltip}}
                 {{form.select_gpus(class='form-control', size=4)}}
@@ -644,7 +645,7 @@ $('#network-tabs a[href="#network-tab-'+$("#method").val()+'"]').tab('show');
                 $("#select_gpu_count").change(function(){ $("#select_gpus").val(null);});
             </script>
             {% endif %}
-            <div class="form-group{{' has-error' if form.model_name.errors}}">
+            <div class="form-group{{mark_errors([form.model_name])}}">
                 {{form.model_name.label}}
                 {{form.model_name.tooltip}}
                 {{form.model_name(class='form-control')}}

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -2,6 +2,7 @@
 
 {% from "helper.html" import print_flashes %}
 {% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
 
 {% extends "layout.html" %}
 
@@ -26,7 +27,7 @@ New Image Model
     <div class="row">
         <div class="col-sm-4">
             <div class="well">
-                <div class="form-group{{' has-error' if form.dataset.errors}}">
+                <div class="form-group{{mark_errors([form.dataset])}}">
                     {{form.dataset.label}}
                     {{form.dataset.tooltip}}
                     {{form.dataset(class='form-control', size=5)}}
@@ -56,12 +57,12 @@ $("#dataset").change(function() {
         <div class="col-sm-4">
             <div class="well">
                 <h4>Data Transformations</h4>
-                <div class="form-group{{' has-error' if form.crop_size.errors}}">
+                <div class="form-group{{mark_errors([form.crop_size])}}">
                     {{form.crop_size.label}}
                     {{form.crop_size.tooltip}}
                     {{form.crop_size(class='form-control', placeholder='none')}}
                 </div>
-                <div class="form-group{{' has-error' if form.use_mean.errors}}">
+                <div class="form-group{{mark_errors([form.use_mean])}}">
                     {{form.use_mean.label}}
                     {{form.use_mean.tooltip}}
                     {{form.use_mean(class='form-control')}}
@@ -87,38 +88,38 @@ $("#dataset").change(function() {
 
                 <!-- Length -->
 
-                <div class="form-group{{' has-error' if form.train_epochs.errors}}">
+                <div class="form-group{{mark_errors([form.train_epochs])}}">
                     {{form.train_epochs.label}}
                     {{form.train_epochs.tooltip}}
                     {{form.train_epochs(class='form-control')}}
                 </div>
-                <div class="form-group{{' has-error' if form.snapshot_interval.errors}}">
+                <div class="form-group{{mark_errors([form.snapshot_interval])}}">
                     {{form.snapshot_interval.label}}
                     {{form.snapshot_interval.tooltip}}
                     {{form.snapshot_interval(class='form-control')}}
                 </div>
-                <div class="form-group{{' has-error' if form.val_interval.errors}}">
+                <div class="form-group{{mark_errors([form.val_interval])}}">
                     {{form.val_interval.label}}
                     {{form.val_interval.tooltip}}
                     {{form.val_interval(class='form-control')}}
                 </div>
                 {# TODO: neat progress bar #}
-                <div class="form-group{{' has-error' if form.random_seed.errors}}">
+                <div class="form-group{{mark_errors([form.random_seed])}}">
                     {{form.random_seed.label}}
                     {{form.random_seed.tooltip}}
                     {{form.random_seed(class='form-control', placeholder='[none]')}}
                 </div>
-                <div class="form-group{{' has-error' if form.batch_size.errors}}">
+                <div class="form-group{{mark_errors([form.batch_size])}}">
                     {{form.batch_size.label}}
                     {{form.batch_size.tooltip}}
                     {{form.batch_size(class='form-control', placeholder='[network defaults]')}}
                 </div>
-                <div class="form-group{{' has-error' if form.solver_type.errors}}">
+                <div class="form-group{{mark_errors([form.solver_type])}}">
                     {{form.solver_type.label}}
                     {{form.solver_type.tooltip}}
                     {{form.solver_type(class='form-control')}}
                 </div>
-                <div class="form-group{{' has-error' if form.learning_rate.errors}}">
+                <div class="form-group{{mark_errors([form.learning_rate])}}">
                     {{form.learning_rate.label}}
                     {{form.learning_rate.tooltip}}
                     {{form.learning_rate(class='form-control learning-rate-option')}}
@@ -145,57 +146,57 @@ showHideAdvancedLROptions();
                 </script>
 
                 <div id="advanced-lr-options" style="display:none;">
-                    <div class="form-group{{' has-error' if form.lr_policy.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_policy])}}">
                         {{form.lr_policy.label}}
                         {{form.lr_policy(class='form-control learning-rate-option')}}
                     </div>
 
-                    <div class="form-group{{' has-error' if form.lr_step_size.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_step_size])}}">
                         {{form.lr_step_size.label}}
                         <div class="input-group">
                             {{form.lr_step_size(class='form-control learning-rate-option')}}
                             <span class="input-group-addon">%</span>
                         </div>
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_step_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_step_gamma])}}">
                         {{form.lr_step_gamma.label}}
                         {{form.lr_step_gamma(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_multistep_values.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_multistep_values])}}">
                         {{form.lr_multistep_values.label}}
                         <div class="input-group">
                             {{form.lr_multistep_values(class='form-control learning-rate-option')}}
                             <span class="input-group-addon">%</span>
                         </div>
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_multistep_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_multistep_gamma])}}">
                         {{form.lr_multistep_gamma.label}}
                         {{form.lr_multistep_gamma(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_exp_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_exp_gamma])}}">
                         {{form.lr_exp_gamma.label}}
                         {{form.lr_exp_gamma(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_inv_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_inv_gamma])}}">
                         {{form.lr_inv_gamma.label}}
                         {{form.lr_inv_gamma(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_inv_power.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_inv_power])}}">
                         {{form.lr_inv_power.label}}
                         {{form.lr_inv_power(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_poly_power.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_poly_power])}}">
                         {{form.lr_poly_power.label}}
                         {{form.lr_poly_power(class='form-control learning-rate-option')}}
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_sigmoid_step.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_sigmoid_step])}}">
                         {{form.lr_sigmoid_step.label}}
                         <div class="input-group">
                             {{form.lr_sigmoid_step(class='form-control learning-rate-option')}}
                             <span class="input-group-addon">%</span>
                         </div>
                     </div>
-                    <div class="form-group{{' has-error' if form.lr_sigmoid_gamma.errors}}">
+                    <div class="form-group{{mark_errors([form.lr_sigmoid_gamma])}}">
                         {{form.lr_sigmoid_gamma.label}}
                         {{form.lr_sigmoid_gamma(class='form-control learning-rate-option')}}
                     </div>
@@ -507,7 +508,7 @@ function visualizeNetwork() {
     return false;
 }
                     </script>
-                    <div class="form-group{{' has-error' if form.custom_network.errors}}">
+                    <div class="form-group{{mark_errors([form.custom_network])}}">
                         {{form.custom_network.label}}
                         {{form.custom_network.explanation(file='/models/images/generic/custom_network_explanation.html')}}
                         <div class="pull-right">
@@ -515,7 +516,7 @@ function visualizeNetwork() {
                         </div>
                         {{form.custom_network(class='form-control', rows=10)}}
                     </div>
-                    <div class="form-group{{' has-error' if form.custom_network_snapshot.errors}}">
+                    <div class="form-group{{mark_errors([form.custom_network_snapshot])}}">
                         {{form.custom_network_snapshot.label}}
                         {{form.custom_network_snapshot.tooltip}}
                         {{form.custom_network_snapshot(class='form-control autocomplete_path')}}
@@ -539,7 +540,7 @@ $('#network-tabs a[href="#network-tab-'+$("#method").val()+'"]').tab('show');
     <div class="row">
         <div class="col-sm-6 col-sm-offset-3 well">
             {% if form.select_gpu.choices|length > 2 and not multi_gpu %}
-            <div class="form-group{{' has-error' if form.select_gpu.errors}}">
+            <div class="form-group{{mark_errors([form.select_gpu])}}">
                 <b>{{form.select_gpu.label.text}}</b><br>
                 {% for choice in form.select_gpu %}
                 <div class="radio">
@@ -552,12 +553,12 @@ $('#network-tabs a[href="#network-tab-'+$("#method").val()+'"]').tab('show');
             </div>
             {% endif %}
             {% if form.select_gpus.choices| length > 1 and multi_gpu %}
-            <div class="form-group{{' has-error' if form.select_gpu_count.errors}}">
+            <div class="form-group{{mark_errors([form.select_gpu_count])}}">
                 {{form.select_gpu_count.label}}
                 {{form.select_gpu_count(class='form-control')}}
             </div>
             <p class="text-center"><i>or</i></p>
-            <div class="form-group{{' has-error' if form.select_gpus.errors}}">
+            <div class="form-group{{mark_errors([form.select_gpus])}}">
                 {{form.select_gpus.label}}
                 {{form.select_gpus.tooltip}}
                 {{form.select_gpus(class='form-control', size=4)}}
@@ -568,7 +569,7 @@ $('#network-tabs a[href="#network-tab-'+$("#method").val()+'"]').tab('show');
                 $("#select_gpu_count").change(function(){ $("#select_gpus").val(null);});
             </script>
             {% endif %}
-            <div class="form-group{{' has-error' if form.model_name.errors}}">
+            <div class="form-group{{mark_errors([form.model_name])}}">
                 {{form.model_name.label}}
                 {{form.model_name.tooltip}}
                 {{form.model_name(class='form-control')}}

--- a/digits/utils/routing.py
+++ b/digits/utils/routing.py
@@ -10,11 +10,8 @@ def job_from_request():
     """
     from digits.webapp import scheduler
 
-    if 'job_id' in flask.request.args:
-        job_id = flask.request.args['job_id']
-    elif 'job_id' in flask.request.form:
-        job_id = flask.request.form['job_id']
-    else:
+    job_id = get_request_arg('job_id')
+    if job_id is None:
         raise werkzeug.exceptions.BadRequest('job_id is a required field')
 
     job = scheduler.get_job(job_id)
@@ -37,3 +34,11 @@ def request_wants_json():
         flask.request.accept_mimetypes[best] > \
         flask.request.accept_mimetypes['text/html']
 
+# check for arguments pass to url
+def get_request_arg(key):
+    value = None
+    if key in flask.request.args:
+        value = flask.request.args[key]
+    elif key in flask.request.form:
+        value = flask.request.form[key]
+    return value

--- a/digits/views.py
+++ b/digits/views.py
@@ -218,6 +218,30 @@ def abort_job(job_id):
     else:
         raise werkzeug.exceptions.Forbidden('Job not aborted')
 
+@app.route('/clone/<clone>', methods=['POST', 'GET'])
+@autodoc('jobs')
+def clone_job(clone):
+    """
+    Clones a job with the id <clone>, populating the creation page with data saved in <clone>
+    """
+
+    ## <clone> is the job_id to clone
+
+    job = scheduler.get_job(clone)
+    if job is None:
+        raise werkzeug.exceptions.NotFound('Job not found')
+
+    if isinstance(job, dataset.ImageClassificationDatasetJob):
+        return flask.redirect(flask.url_for('image_classification_dataset_new') + '?clone=' + clone)
+    if isinstance(job, dataset.GenericImageDatasetJob):
+        return flask.redirect(flask.url_for('generic_image_dataset_new') + '?clone=' + clone)
+    if isinstance(job, model.ImageClassificationModelJob):
+        return flask.redirect(flask.url_for('image_classification_model_new') + '?clone=' + clone)
+    if isinstance(job, model.GenericImageModelJob):
+        return flask.redirect(flask.url_for('generic_image_model_new') + '?clone=' + clone)
+    else:
+        raise werkzeug.exceptions.BadRequest('Invalid job type')
+
 ### Error handling
 
 @app.errorhandler(Exception)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # REST API
 
-*Generated Oct 04, 2015*
+*Generated Oct 09, 2015*
 
 DIGITS exposes its internal functionality through a REST API. You can access these endpoints by performing a GET or POST on the route, and a JSON object will be returned.
 

--- a/docs/FlaskRoutes.md
+++ b/docs/FlaskRoutes.md
@@ -1,6 +1,6 @@
 # Flask Routes
 
-*Generated Oct 04, 2015*
+*Generated Oct 09, 2015*
 
 Documentation on the various routes used internally for the web application.
 
@@ -39,6 +39,16 @@ Methods: **GET**
 Location: [`digits/views.py`](../digits/views.py)
 
 ## Jobs
+
+### `/clone/<clone>`
+
+> Clones a job with the id <clone>, populating the creation page with data saved in <clone>
+
+Methods: **GET**, **POST**
+
+Arguments: `clone`
+
+Location: [`digits/views.py`](../digits/views.py)
 
 ### `/datasets/<job_id>`
 


### PR DESCRIPTION
A 'Clone Job' button has been added to the Job pages.  

The approach I took was to save the form settings when a job starts for each Field (except SubmitField and FileField in a dict() on the job called form_data.

When a job is cloned, the form is created and populated with the saved form_data from the source job.  If a field in the form can not be populated with saved form_data, a warning is presented at the head of the document.

I put the 'Clone Job' button to the left of the 'Abort Job' button.  
![clone](https://cloud.githubusercontent.com/assets/13259615/10174888/e1e14004-66a0-11e5-96e3-2410efd1198f.png)
I'd don't love this. When the Job completes, the 'Abort Job' disappears and the Clone moves to where the Abort Job had been, and could fire a Clone when the user means to Abort.  Also, if the source job does not have form_data, the 'Clone Job' button is disabled rather then hidden.  I'm not sure I feel is better.

I need to make a test for the suite, but prefer to get this out as is for comment.

I changed the print_errors macro to also print warnings and added a hl_errors macro to add has-error and has-warning classes.

-                <div class="form-group{{ ' has-error' if form.resize_channels.errors else '' }}">
+                <div class="form-group{{hl_errors([form.resize_channels])}}">
