### PR TITLE
Allow DIGITS to parse NVcaffe version strings

### DIFF
--- a/digits/config/caffe_option.py
+++ b/digits/config/caffe_option.py
@@ -6,6 +6,7 @@ import sys
 import imp
 import platform
 import subprocess
+import pkg_resources
 
 from digits import device_query
 import config_option
@@ -123,7 +124,7 @@ class CaffeOption(config_option.FrameworkOption):
         Arguments:
         executable -- path to a caffe executable
         """
-        minimum_version = (0,11)
+        minimum_version = pkg_resources.parse_version("0.11")
 
         version = cls.get_version(executable)
         if version is None:
@@ -178,11 +179,11 @@ class CaffeOption(config_option.FrameworkOption):
                             % (filename, NVIDIA_SUFFIX))
 
                 # parse the version string
-                match = re.match(r'%s%s\.so\.((\d|\.)+)$'
+                match = re.match(r'%s%s\.so\.(\S+)$'
                         % (libname, NVIDIA_SUFFIX), filename)
                 if match:
                     version_str = match.group(1)
-                    return tuple(int(n) for n in version_str.split('.'))
+                    return pkg_resources.parse_version(version_str)
                 else:
                     return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ gevent>=1.0
 Flask>=0.10.1
 Flask-WTF>=0.11
 gunicorn==17.5
+setuptools>=3.3
 lmdb>=0.87
 h5py>=2.2.1
 pydot2


### PR DESCRIPTION
Previously, it totally failed to parse "0.14.0-alpha", which is valid semantic versioning.

This PR uses `pkg_resources` from `setuptools` to do the comparison.

\<rant>

Technically, `setuptools` adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) and not [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html), but I can't find any package/tool which (1) actually follows Semantic Versioning correctly when the version is correct, and (2) still does something useful when it's a little bit off.

Things I tried which don't work quite right:
* raw string comparisons
* git built-in (`git tag`)
* GitHub
* `distutils.version.LooseVersion`
* `semantic_version.Version`
* `pkg_resources.parse_version` (close enough)

https://gist.github.com/lukeyeager/9922a2229f7a03d1463c

\</rant>