### PR TITLE
Suppress annoying BeautifulSoup warning

### DIFF
--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -125,7 +125,7 @@ class BaseViewsTestWithImageset(BaseViewsTest):
 
         # expect a redirect
         if not 300 <= rv.status_code <= 310:
-            s = BeautifulSoup(rv.data)
+            s = BeautifulSoup(rv.data, 'html.parser')
             div = s.select('div.alert-danger')
             if div:
                 raise RuntimeError(div[0])

--- a/digits/dataset/images/generic/test_views.py
+++ b/digits/dataset/images/generic/test_views.py
@@ -112,7 +112,7 @@ class BaseViewsTestWithImageset(BaseViewsTest):
 
         # expect a redirect
         if not 300 <= rv.status_code <= 310:
-            s = BeautifulSoup(rv.data)
+            s = BeautifulSoup(rv.data, 'html.parser')
             div = s.select('div.alert-danger')
             if div:
                 raise RuntimeError(div[0])

--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -182,7 +182,7 @@ class BaseViewsTestWithDataset(BaseViewsTest,
         # expect a redirect
         if not 300 <= rv.status_code <= 310:
             print 'Status code:', rv.status_code
-            s = BeautifulSoup(rv.data)
+            s = BeautifulSoup(rv.data, 'html.parser')
             div = s.select('div.alert-danger')
             if div:
                 raise RuntimeError(div[0])
@@ -222,7 +222,7 @@ class BaseTestViews(BaseViewsTest):
         rv = self.app.post('/models/visualize-network?framework='+self.FRAMEWORK,
                 data = {'custom_network': self.network()}
                 )
-        s = BeautifulSoup(rv.data)
+        s = BeautifulSoup(rv.data, 'html.parser')
         body = s.select('body')
         assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
         image = s.select('img')
@@ -230,7 +230,7 @@ class BaseTestViews(BaseViewsTest):
 
     def test_customize(self):
         rv = self.app.post('/models/customize?network=lenet&framework='+self.FRAMEWORK)
-        s = BeautifulSoup(rv.data)
+        s = BeautifulSoup(rv.data, 'html.parser')
         body = s.select('body')
         assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
 
@@ -456,7 +456,7 @@ class BaseTestCreated(BaseViewsTestWithModel):
                     'show_visualizations': 'y',
                     }
                 )
-        s = BeautifulSoup(rv.data)
+        s = BeautifulSoup(rv.data, 'html.parser')
         body = s.select('body')
         assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
         # gets an array of arrays [[confidence, label],...]
@@ -499,7 +499,7 @@ class BaseTestCreated(BaseViewsTestWithModel):
                 '/models/images/classification/classify_many?job_id=%s' % self.model_id,
                 data = {'image_list': file_upload}
                 )
-        s = BeautifulSoup(rv.data)
+        s = BeautifulSoup(rv.data, 'html.parser')
         body = s.select('body')
         assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
 
@@ -541,7 +541,7 @@ class BaseTestCreated(BaseViewsTestWithModel):
                 '/models/images/classification/top_n?job_id=%s' % self.model_id,
                 data = {'image_list': file_upload}
                 )
-        s = BeautifulSoup(rv.data)
+        s = BeautifulSoup(rv.data, 'html.parser')
         body = s.select('body')
         assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
         keys = self.imageset_paths.keys()

--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -166,7 +166,7 @@ class BaseViewsTestWithDataset(BaseViewsTest,
         # expect a redirect
         if not 300 <= rv.status_code <= 310:
             print 'Status code:', rv.status_code
-            s = BeautifulSoup(rv.data)
+            s = BeautifulSoup(rv.data, 'html.parser')
             div = s.select('div.alert-danger')
             if div:
                 raise RuntimeError(div[0])
@@ -206,7 +206,7 @@ class BaseTestViews(BaseViewsTest):
         rv = self.app.post('/models/visualize-network?framework='+self.FRAMEWORK,
                 data = {'custom_network': self.network()}
                 )
-        s = BeautifulSoup(rv.data)
+        s = BeautifulSoup(rv.data, 'html.parser')
         body = s.select('body')
         assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
         image = s.select('img')
@@ -399,7 +399,7 @@ class BaseTestCreated(BaseViewsTestWithModel):
                     'show_visualizations': 'y',
                     }
                 )
-        s = BeautifulSoup(rv.data)
+        s = BeautifulSoup(rv.data, 'html.parser')
         body = s.select('body')
         assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
 
@@ -431,7 +431,7 @@ class BaseTestCreated(BaseViewsTestWithModel):
                 '/models/images/generic/infer_many?job_id=%s' % self.model_id,
                 data = {'image_list': file_upload}
                 )
-        s = BeautifulSoup(rv.data)
+        s = BeautifulSoup(rv.data, 'html.parser')
         body = s.select('body')
         assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
         headers = s.select('table.table th')

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 nose>=1.3.1
 mock>=1.0.1
-beautifulsoup4>=4.2.1
+beautifulsoup4>=4.4.0
 Flask-Autodoc>=0.1.2
 selenium>=2.25.0
 coverage>=3.7.1


### PR DESCRIPTION
There were a lot of warnings like this in the build logs:

    /home/travis/miniconda/lib/python2.7/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

    To get rid of this warning, change this:
        BeautifulSoup([your markup])
    to this:
        BeautifulSoup([your markup], "html.parser")
            markup_type=markup_type))
    ok