### PR TITLE
Reorder apt-get packages into logical progression

### DIFF
--- a/docs/InstallCaffe.md
+++ b/docs/InstallCaffe.md
@@ -20,7 +20,13 @@ Set an environment variable so DIGITS knows where Caffe is installed (optional):
 If you are not on Ubuntu 14.04, you can try [Caffe's installation instructions](http://caffe.berkeleyvision.org/installation.html).
 If you are, simply install these aptitude packages:
 
-    % sudo apt-get install libprotobuf-dev libleveldb-dev libsnappy-dev libopencv-dev libhdf5-serial-dev libgflags-dev libgoogle-glog-dev liblmdb-dev protobuf-compiler libatlas-base-dev python-dev python-pip python-numpy gfortran
+    % sudo apt-get install \
+        libgflags-dev libgoogle-glog-dev \
+        libopencv-dev \
+        libleveldb-dev libsnappy-dev liblmdb-dev libhdf5-serial-dev \
+        libprotobuf-dev protobuf-compiler \
+        libatlas-base-dev \
+        python-dev python-pip python-numpy gfortran
     % sudo apt-get install --no-install-recommends libboost-all-dev
 
 ### Python dependencies


### PR DESCRIPTION
You can still copy+paste the command. But now you can see it all in one line and follow the list of packages in their logical progression.