### PR TITLE
Torch7/LeNet: use cudnn when available

### DIFF
--- a/digits/standard-networks/torch/lenet.lua
+++ b/digits/standard-networks/torch/lenet.lua
@@ -1,16 +1,33 @@
 require 'nn'
+if pcall(function() require('cudnn') end) then
+   print('Using CuDNN backend')
+   backend = cudnn
+   convLayer = cudnn.SpatialConvolution
+   convLayerName = 'cudnn.SpatialConvolution'
+else
+   print('Failed to load cudnn backend (is libcudnn.so in your library path?)')
+   if pcall(function() require('cunn') end) then
+       print('Falling back to legacy cunn backend')
+   else
+       print('Failed to load cunn backend (is CUDA installed?)')
+       print('Falling back to legacy nn backend')
+   end
+   backend = nn -- works with cunn or nn
+   convLayer = nn.SpatialConvolutionMM
+   convLayerName = 'nn.SpatialConvolutionMM'
+end
 
 -- -- This is a LeNet model. For more information: http://yann.lecun.com/exdb/lenet/
 
 local lenet = nn.Sequential()
 lenet:add(nn.MulConstant(0.00390625))
-lenet:add(nn.SpatialConvolution(1,20,5,5,1,1,0)) -- 1*28*28 -> 20*24*24
-lenet:add(nn.SpatialMaxPooling(2, 2, 2, 2)) -- 20*24*24 -> 20*12*12
-lenet:add(nn.SpatialConvolution(20,50,5,5,1,1,0)) -- 20*12*12 -> 50*8*8
-lenet:add(nn.SpatialMaxPooling(2,2,2,2)) --  50*8*8 -> 50*4*4
+lenet:add(backend.SpatialConvolution(1,20,5,5,1,1,0)) -- 1*28*28 -> 20*24*24
+lenet:add(backend.SpatialMaxPooling(2, 2, 2, 2)) -- 20*24*24 -> 20*12*12
+lenet:add(backend.SpatialConvolution(20,50,5,5,1,1,0)) -- 20*12*12 -> 50*8*8
+lenet:add(backend.SpatialMaxPooling(2,2,2,2)) --  50*8*8 -> 50*4*4
 lenet:add(nn.View(-1):setNumInputDims(3))  -- 50*4*4 -> 800
 lenet:add(nn.Linear(800,500))  -- 800 -> 500
-lenet:add(nn.ReLU())
+lenet:add(backend.ReLU())
 lenet:add(nn.Linear(500, 10))  -- 500 -> 10
 lenet:add(nn.LogSoftMax())
 
@@ -22,5 +39,4 @@ return function(params)
         loss = nn.ClassNLLCriterion()
     }
 end
-
 


### PR DESCRIPTION
On MNIST (1x28x28, 45k training images, 15k validation images),
with batch size of 64.

Training time for 20 epochs:

Original: 8m26s
With CuDNN: 3m7s