### PR TITLE
Stop tools from importing global DIGITS install

### DIFF
--- a/digits/dataset/images/generic/test_lmdb_creator.py
+++ b/digits/dataset/images/generic/test_lmdb_creator.py
@@ -18,7 +18,7 @@ import lmdb
 
 if __name__ == '__main__':
     dirname = os.path.dirname(os.path.realpath(__file__))
-    sys.path.append(os.path.join(dirname,'..','..','..','..'))
+    sys.path.insert(0, os.path.join(dirname,'..','..','..','..'))
     from digits.config.load  import load_config
     load_config()
 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -10,11 +10,8 @@ from collections import defaultdict
 #   pip install git+https://github.com/lukeyeager/flask-autodoc.git
 from flask.ext.autodoc import Autodoc
 
-try:
-    import digits
-except ImportError:
-    # Add path for DIGITS package
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add path for DIGITS package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import digits.config; digits.config.load_config()
 from digits.webapp import app, _doc as doc
 

--- a/scripts/test_generate_docs.py
+++ b/scripts/test_generate_docs.py
@@ -12,11 +12,8 @@ try:
 except ImportError as e:
     raise unittest.SkipTest('Flask-Autodoc not installed')
 
-try:
-    import digits
-except ImportError:
-    # Add path for DIGITS package
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add path for DIGITS package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import digits.config; digits.config.load_config()
 from digits.webapp import app, _doc as doc

--- a/tools/analyze_db.py
+++ b/tools/analyze_db.py
@@ -11,11 +11,8 @@ from collections import Counter
 
 import lmdb
 
-try:
-    import digits
-except ImportError:
-    # Add path for DIGITS package
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add path for DIGITS package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import digits.config
 digits.config.load_config()
 from digits import log

--- a/tools/create_db.py
+++ b/tools/create_db.py
@@ -14,11 +14,8 @@ from collections import Counter
 import threading
 import Queue
 
-try:
-    import digits
-except ImportError:
-    # Add path for DIGITS package
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add path for DIGITS package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import digits.config
 digits.config.load_config()
 from digits import utils, log

--- a/tools/parse_folder.py
+++ b/tools/parse_folder.py
@@ -12,11 +12,8 @@ import urllib
 
 import requests
 
-try:
-    import digits
-except ImportError:
-    # Add path for DIGITS package
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add path for DIGITS package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import digits.config
 digits.config.load_config()
 from digits import utils, log

--- a/tools/resize_image.py
+++ b/tools/resize_image.py
@@ -8,11 +8,8 @@ import logging
 
 import PIL.Image
 
-try:
-    import digits
-except ImportError:
-    # Add path for DIGITS package
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add path for DIGITS package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import digits.config
 digits.config.load_config()
 from digits import utils, log


### PR DESCRIPTION
If you have the digits package installed globally (on your PYTHONPATH)
and you try to run a local DIGITS instance, the tools pick up the global
installation instead of the local one when you start them in a new
process. This patch fixes the issue.

NOTE: in the future, this should be handled by moving the tools scripts
inside the digits package. This is a short-term solution.