### PR TITLE
Fix infer_many for Caffe

### DIFF
--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -1180,7 +1180,7 @@ class CaffeTrainTask(TrainTask):
                         'data', image)
             output = net.forward()[net.outputs[-1]]
             if scores is None:
-                scores = output
+                scores = np.copy(output)
             else:
                 scores = np.vstack((scores, output))
             print 'Processed %s/%s images' % (len(scores), len(caffe_images))


### PR DESCRIPTION
*Fix #255, Fix #349*

Previously, `scores = output` performed a shallow copy that was
overwritten when the next output was calculated. Now, we're using
`np.copy` to do a deep copy and avoid the error.