### PR TITLE
Display InferenceErrors like all other exceptions

### DIFF
--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -272,10 +272,7 @@ def image_classification_model_classify_one():
         layers = 'all'
 
     predictions, visualizations = None, None
-    try:
-        predictions, visualizations = job.train_task().infer_one(image, snapshot_epoch=epoch, layers=layers)
-    except frameworks.errors.InferenceError as e:
-        return e.__str__(), 403
+    predictions, visualizations = job.train_task().infer_one(image, snapshot_epoch=epoch, layers=layers)
 
     # take top 5
     if predictions:


### PR DESCRIPTION
@gheinrich in #249 you added this try/except block for `InferenceError`s. Why?

Current behavior for errors:
![inference-error-before](https://cloud.githubusercontent.com/assets/687269/10496454/bb1808a0-7275-11e5-8935-eb498a1cbdee.jpg)

After this change, it matches the format for other exceptions:
![inference-error-after](https://cloud.githubusercontent.com/assets/687269/10496458/c3300e48-7275-11e5-8c29-2032baed780c.jpg)

In debug mode, you get more information:
![inference-error-after-debug](https://cloud.githubusercontent.com/assets/687269/10496465/c9f24138-7275-11e5-94c0-8042ff74d019.jpg)

