### PR TITLE
Fix some of the open file issues with Torch

### DIFF
--- a/digits/frameworks/torch_framework.py
+++ b/digits/frameworks/torch_framework.py
@@ -94,9 +94,9 @@ class TorchFramework(Framework):
         return visualization of network
         """
         # save network description to temporary file
-        _, temp_network_path = tempfile.mkstemp(suffix='.lua')
-        with open(temp_network_path, "w") as outfile:
-            outfile.write(desc)
+        temp_network_handle, temp_network_path = tempfile.mkstemp(suffix='.lua')
+        os.write(temp_network_handle, desc)
+        os.close(temp_network_handle)
 
         try: # do this in a try..finally clause to make sure we delete the temp file
             # build command line

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -784,7 +784,8 @@ class TorchTrainTask(TrainTask):
             _, temp_imgfile_path = tempfile.mkstemp(dir=temp_dir_path, suffix='.txt')
             temp_imgfile = open(temp_imgfile_path, "w")
             for image in images:
-                _, temp_image_path = tempfile.mkstemp(dir=temp_dir_path, suffix='.jpeg')
+                temp_image_handle, temp_image_path = tempfile.mkstemp(
+                        dir=temp_dir_path, suffix='.jpeg')
                 image = PIL.Image.fromarray(image)
                 try:
                     image.save(temp_image_path, format='jpeg')
@@ -793,6 +794,7 @@ class TorchTrainTask(TrainTask):
                     self.logger.error(error_message)
                     raise digits.frameworks.errors.InferenceError(error_message)
                 temp_imgfile.write("%s\n" % temp_image_path)
+                os.close(temp_image_handle)
             temp_imgfile.close()
 
             if config_value('torch_root') == '<PATHS>':

--- a/digits/utils/test_filesystem.py
+++ b/digits/utils/test_filesystem.py
@@ -39,11 +39,12 @@ class TestTreeSize():
             for i in range(n_files):
                 # create file with random size of up to 1MB
                 size = random.randint(1,2**20)
-                _,name = tempfile.mkstemp(dir=dir)
+                fd,name = tempfile.mkstemp(dir=dir)
                 f = open(name,"w")
                 f.seek(size-1)
                 f.write("\0")
                 f.close()
+                os.close(fd)
                 total_size += size
             tree_size = fs.get_tree_size(dir)
             assert tree_size == total_size, "Expected size=%d, got %d" % (total_size, tree_size)


### PR DESCRIPTION
When running the image classification model tests like this:

    ./digits-test digits/model/images/classification/test_views.py

the number of open files for the test suite grows to > 900. You can verify this with:

    while :; do lsof -p $PID | grep tmp | wc -l; sleep 1; done

where PID is the process ID of the test suite.

This patch brings the number of open files down from > 900 to ~90. There's more work to be done to fix this completely, but this takes a big step in the right direction.

NOTE: I can't actually run the whole testsuite or I get a bunch of these OSErrors:

    OSError: [Errno 24] Too many open files