### PR TITLE
Torch: support batch size specification in model file

### DIFF
--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -122,9 +122,6 @@ class TorchTrainTask(TrainTask):
         else:
             torch_bin = os.path.join(config_value('torch_root'), 'bin', 'th')
 
-        if self.batch_size is None:
-            self.batch_size = constants.DEFAULT_BATCH_SIZE
-
         dataset_backend = self.dataset.train_db_task().backend
         assert dataset_backend=='lmdb' or dataset_backend=='hdf5'
 
@@ -136,11 +133,13 @@ class TorchTrainTask(TrainTask):
                 '--save=%s' % self.job_dir,
                 '--snapshotPrefix=%s' % self.snapshot_prefix,
                 '--snapshotInterval=%s' % self.snapshot_interval,
-                '--batchSize=%d' % self.batch_size,
                 '--learningRate=%s' % self.learning_rate,
                 '--policy=%s' % str(self.lr_policy['policy']),
                 '--dbbackend=%s' % dataset_backend
                 ]
+
+        if self.batch_size is not None:
+            args.append('--batchSize=%d' % self.batch_size)
 
         if isinstance(self.dataset, ImageClassificationDatasetJob):
             args.append('--train=%s' % self.dataset.path(constants.TRAIN_DB))

--- a/digits/standard-networks/torch/ImageNet-Training/alexnet.lua
+++ b/digits/standard-networks/torch/ImageNet-Training/alexnet.lua
@@ -74,7 +74,9 @@ return function(params)
     assert(params.ngpus<=1, 'Model supports only one GPU')
     return {
         model = createModel(1),
-        croplen = 224
+        croplen = 224,
+        trainBatchSize = 100,
+        validationBatchSize = 100,
     }
 end
 

--- a/digits/standard-networks/torch/ImageNet-Training/googlenet.lua
+++ b/digits/standard-networks/torch/ImageNet-Training/googlenet.lua
@@ -121,7 +121,9 @@ return function(params)
     assert(params.ngpus<=1, 'Model supports only one GPU')
     return {
         model = createModel(1),
-        croplen = 224
+        croplen = 224,
+        trainBatchSize = 24,
+        validationBatchSize = 24,
     }
 end
 

--- a/digits/standard-networks/torch/lenet.lua
+++ b/digits/standard-networks/torch/lenet.lua
@@ -36,7 +36,9 @@ return function(params)
     assert(params.ngpus<=1, 'Model supports only CPU or single-GPU')
     return {
         model = lenet,
-        loss = nn.ClassNLLCriterion()
+        loss = nn.ClassNLLCriterion(),
+        trainBatchSize = 64,
+        validationBatchSize = 100,
     }
 end
 

--- a/docs/InstallTorch.md
+++ b/docs/InstallTorch.md
@@ -82,12 +82,14 @@ ngpus           | number   | Tells how many GPUs are available (0 means CPU)
 
 Those parameters are returned by the user-defined function:
 
-Parameter name  | Type         | Mandatory | Description
---------------- | ------------ | --------- | -------------
-model           | nn.module    | Yes       | A nn.module container that defines the model to use
-loss            | nn.criterion | No        | A nn.criterion to use during training. Defaults to nn.ClassNLLCriterion.
-croplen         | number       | No        | If specified, inputs images will be cropped randomly to a square of the specified size
-labelHook       | function     | No        | A function(input,dblabel) that returns the intended label(target) for the current batch given the provided input and label in database. By default the database label is used.
+Parameter name        | Type         | Mandatory | Description
+-----------------     | ------------ | --------- | -------------
+model                 | nn.module    | Yes       | A nn.module container that defines the model to use.
+loss                  | nn.criterion | No        | A nn.criterion to use during training. Defaults to nn.ClassNLLCriterion.
+croplen               | number       | No        | If specified, inputs images will be cropped randomly to a square of the specified size.
+labelHook             | function     | No        | A function(input,dblabel) that returns the intended label(target) for the current batch given the provided input and label in database. By default the database label is used.
+trainBatchSize        | number       | No        | If specified, sets train batch size. May be overridden by user in DIGITS UI.
+validationBatchSize   | number       | No        | If specified, sets validation batch size. May be overridden by user in DIGITS UI.
 
 ### Tensors
 


### PR DESCRIPTION
The default batch size in the DIGITS is 16. This change allows specification of different batch sizes from Torch model descriptions for the training and validation phases.

Also align batch sizes of Torch standard networks with Caffe standard networks.

Using MNIST (45k training samples, 15k validation samples) and LeNet (20 epochs):
default batch size (16): 190s
default batch size from model (training: 64, validation: 100): 118s

Using CIFAR10 (images upscaled to 256x256):
Alexnet (2 epochs) default batch size (16): 1230s
Alexnet (2 epochs) batch size from model (100): 948s
GoogLenet (2 epochs) default batch size (16): 5340s
GoogLenet (2 epochs) batch size from model (24): 5280s