### PR TITLE
Use fixed seed in model tests

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -156,6 +156,7 @@ class BaseViewsTestWithDataset(BaseViewsTest,
                 'batch_size':       10,
                 'train_epochs':     cls.TRAIN_EPOCHS,
                 'framework' :       cls.FRAMEWORK,
+                'random_seed':      0xCAFEBABE,
                 'shuffle':          'true' if cls.SHUFFLE else 'false'
                 }
         if cls.CROP_SIZE is not None:

--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -73,8 +73,6 @@ local net = nn.Sequential()
 net:add(nn.MulConstant(0.004))
 net:add(nn.View(-1):setNumInputDims(3))  -- 1*10*10 -> 100
 net:add(nn.Linear(100,2))
--- remove any non determinism
-net:apply(function(layer) if layer.weight then layer.weight:fill(0) end if layer.bias then layer.bias:fill(0) end end)
 return function(params)
     return {
         model = net,
@@ -159,6 +157,7 @@ class BaseViewsTestWithDataset(BaseViewsTest,
                 'custom_network':   cls.network(),
                 'batch_size':       10,
                 'train_epochs':     cls.TRAIN_EPOCHS,
+                'random_seed':      0xCAFEBABE,
                 'framework':        cls.FRAMEWORK,
                 }
         if cls.CROP_SIZE is not None:


### PR DESCRIPTION
Setting weights and biases to zero initially. This applies to the
model used in all Torch classification tests except those that use
the standard LeNet model.

Tested with:
./digits-test -v --with-coverage --cover-package=digits -s --tests=digits.model.images.classification

Without patch:
10 failures / 128 iterations

With patch:
1 failure / 160 iterations
Note: the one failure was on a test that uses the LeNet model,
which isn't modified by this patch. That failure has to do with
the pretty aggressive learning rate policy, which is set to 'fixed'
for this test. Log shows model learning up to 100% validation
accuracy then regressing to 66% accuracy on last epoch.

see bug #346