### PR TITLE
Use port 34448 (DIGIT) for digits-server, not 8080

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 worker_class = 'socketio.sgunicorn.GeventSocketIOWorker'
-bind = '0.0.0.0:8080'
+bind = '0.0.0.0:34448' # DIGIT
 loglevel = 'debug'
 
 def on_starting(server):

--- a/nginx.site
+++ b/nginx.site
@@ -5,7 +5,7 @@ server {
 
     # Gunicorn server
     location / {
-        proxy_pass http://127.0.0.1:8080;
+        proxy_pass http://127.0.0.1:34448;
         proxy_redirect off;
 
         proxy_set_header Host $host;
@@ -17,7 +17,7 @@ server {
 
     # Socketio
     location /socket.io {
-        proxy_pass http://127.0.0.1:8080/socket.io;
+        proxy_pass http://127.0.0.1:34448/socket.io;
         proxy_redirect off;
         proxy_buffering off;
 


### PR DESCRIPTION
Port 8080 is a fairly common debugging port. Switch to using 34448 instead (that's "DIGIT" on an old-school phone).

The user shouldn't need to be aware of the port at all, since digits-server is intended to run behind an nginx reverse proxy (see nginx.site).