### PR TITLE
Reduce Torch7 install verbosity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - ./scripts/travis/install-caffe.sh $(pwd)/deps/caffe
 
     # Torch
-    - ./scripts/travis/install-torch.sh $(pwd)/deps/torch
+    - ./scripts/travis/install-torch.sh $(pwd)/deps/torch &> $(pwd)/torch-install-log.txt || (cat $(pwd)/torch-install-log.txt && false)
 
     # DIGITS
     - sudo apt-get install graphviz


### PR DESCRIPTION
On DIGITS ToT, Travis logs are close to 4MB in size, which is the
hard limit for log size on Travis. Longer logs would yield an error.

This change causes the Torch7 install log to only be printed on an
install error.

This reduces the size of a typical log down to 250kB and 4000 lines,
meaning that the full log can be displayed in real time since it is
less than 10,000 lines.