### PR TITLE
Don't crop image before feeding to DL framework

### DIFF
--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -265,9 +265,6 @@ def image_classification_model_classify_one():
     db_task = job.train_task().dataset.train_db_task()
     height = db_task.image_dims[0]
     width = db_task.image_dims[1]
-    if job.train_task().crop_size:
-        height = job.train_task().crop_size
-        width = job.train_task().crop_size
     image = utils.image.resize_image(image, height, width,
             channels = db_task.image_dims[2],
             resize_mode = db_task.resize_mode,

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -246,9 +246,6 @@ def generic_image_model_infer_one():
     db_task = job.train_task().dataset.analyze_db_tasks()[0]
     height = db_task.image_height
     width = db_task.image_width
-    if job.train_task().crop_size:
-        height = job.train_task().crop_size
-        width = job.train_task().crop_size
     image = utils.image.resize_image(image, height, width,
             channels = db_task.image_channels,
             resize_mode = 'squash',
@@ -298,9 +295,6 @@ def generic_image_model_infer_many():
     db_task = job.train_task().dataset.analyze_db_tasks()[0]
     height = db_task.image_height
     width = db_task.image_width
-    if job.train_task().crop_size:
-        height = job.train_task().crop_size
-        width = job.train_task().crop_size
     channels = db_task.image_channels
 
     for line in image_list.readlines():


### PR DESCRIPTION
When using 'crop in form' method, images are cropped in Python
code before 'classify one'. This is slightly inconsistent as
this operation is not performed during training or in the
context of 'classify many'. Besides, this is problematic for
Torch (at least) since the mean image is not cropped and this
makes it difficult to perform mean subtraction during 'classify
one' as the input and mean image have different sizes.

Caffe uses the 'crop_size' option in the data layer transformations.
Similarly, for Torch the crop command-line flag may be used to
crop the image within Torch. Either way, it is not necessary
to crop the image in Python code.