### PR TITLE
Reduce Torch install verbosity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - ./scripts/travis/install-caffe.sh $(pwd)/deps/caffe
 
     # Torch
-    - ./scripts/travis/install-torch.sh $(pwd)/deps/torch
+    - travis_wait ./scripts/travis/install-torch-wrapper.sh $(pwd)/deps/torch $(pwd)/torch-install-log.txt
 
     # DIGITS
     - sudo apt-get install graphviz

--- a/scripts/travis/install-torch-wrapper.sh
+++ b/scripts/travis/install-torch-wrapper.sh
@@ -1,0 +1,15 @@
+#/usr/bin/env bash
+# Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
+
+set -e
+set -x
+
+if [ "$#" -ne 2 ];
+then
+    echo "Usage: $0 INSTALL_DIR LOG_FILE"
+    exit 1
+fi
+INSTALL_DIR=$1
+LOG_FILE=$2
+
+(./scripts/travis/install-torch.sh $INSTALL_DIR &> $LOG_FILE) || (cat $LOG_FILE && false)


### PR DESCRIPTION
As suggested by @lukeyeager prepending the install command
with `travis_wait` will print a log message every minute
for 20 minutes, allowing Torch install to take a little more
than the usual <10 minutes.