### PR TITLE
Revert "Reduce Torch7 install verbosity"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - ./scripts/travis/install-caffe.sh $(pwd)/deps/caffe
 
     # Torch
-    - ./scripts/travis/install-torch.sh $(pwd)/deps/torch &> $(pwd)/torch-install-log.txt || (cat $(pwd)/torch-install-log.txt && false)
+    - ./scripts/travis/install-torch.sh $(pwd)/deps/torch
 
     # DIGITS
     - sudo apt-get install graphviz


### PR DESCRIPTION
This reverts commit a25e13acd0c24178a18012a706505f57eaeb894d (#394).

We may redo it differently with #396, but we need to just revert it for now.