### PR TITLE
Torch - report error on job summary

### DIFF
--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -125,7 +125,8 @@ class TorchTrainTask(TrainTask):
         assert dataset_backend=='lmdb' or dataset_backend=='hdf5'
 
         args = [torch_bin,
-                os.path.join(os.path.dirname(os.path.dirname(digits.__file__)),'tools','torch','main.lua'),
+                os.path.join(os.path.dirname(os.path.dirname(digits.__file__)),'tools','torch','wrapper.lua'),
+                'main.lua',
                 '--network=%s' % self.model_file.split(".")[0],
                 '--epoch=%d' % int(self.train_epochs),
                 '--networkDirectory=%s' % self.job_dir,
@@ -503,7 +504,8 @@ class TorchTrainTask(TrainTask):
             torch_bin = os.path.join(config_value('torch_root'), 'bin', 'th')
 
         args = [torch_bin,
-                os.path.join(os.path.dirname(os.path.dirname(digits.__file__)),'tools','torch','test.lua'),
+                os.path.join(os.path.dirname(os.path.dirname(digits.__file__)),'tools','torch','wrapper.lua'),
+                'test.lua',
                 '--image=%s' % temp_image_path,
                 '--network=%s' % self.model_file.split(".")[0],
                 '--networkDirectory=%s' % self.job_dir,
@@ -802,7 +804,8 @@ class TorchTrainTask(TrainTask):
                 torch_bin = os.path.join(config_value('torch_root'), 'bin', 'th')
 
             args = [torch_bin,
-                    os.path.join(os.path.dirname(os.path.dirname(digits.__file__)),'tools','torch','test.lua'),
+                    os.path.join(os.path.dirname(os.path.dirname(digits.__file__)),'tools','torch','wrapper.lua'),
+                    'test.lua',
                     '--testMany=yes',
                     '--allPredictions=yes',   #all predictions are grabbed and formatted as required by DIGITS
                     '--image=%s' % str(temp_imglist_path),

--- a/tools/torch/logmessage.lua
+++ b/tools/torch/logmessage.lua
@@ -9,9 +9,9 @@ local logmessage = torch.class('logmessage')
 -- levelcode              number           specifies the severity of message i.e., 0=info, 1=warn, 2=error.
 -- message                string           message to be displayed
 
--- Usage: 
+-- Usage:
 -- require 'logmessage'
--- logmessage.display(0,'This is informational message as the levelcode is 0') 
+-- logmessage.display(0,'This is informational message as the levelcode is 0')
 -------------------------------------------------------------------------------------------------------------
 function logmessage.display(levelcode, message)
   local levelname=nil
@@ -21,6 +21,8 @@ function logmessage.display(levelcode, message)
     levelname="WARNING"
   elseif levelcode == 2 then
     levelname="ERROR"
+  elseif levelcode == 3 then
+    levelname="FAIL"
   end
   print(os.date("%Y-%m-%d %H:%M:%S") .. ' [' .. levelname .. '] ' .. message)
 end

--- a/tools/torch/wrapper.lua
+++ b/tools/torch/wrapper.lua
@@ -1,0 +1,33 @@
+-- Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
+
+-- retrieve path to this script so we can import and invoke scripts that
+-- are in the same directory
+local path = debug.getinfo(1,"S").source
+local dir_path = path:match[[^@?(.*[\/])[^\/]-$]]
+assert(dir_path ~= nil)
+package.path = dir_path .."?.lua;".. package.path
+
+require 'logmessage'
+
+-- custom error handler prints error using logmessage API
+function err (x)
+    logmessage.display(3, x)
+    print(debug.traceback('DIGITS Lua Error',2))
+    return "DIGITS error"
+end -- err
+
+if #arg < 1 then
+    logmessage.display(3, 'Usage: ' .. path .. ' script.lua [args]')
+    os.exit(1)
+end
+
+-- invoke script within xpcall() to catch errors
+if xpcall(function() dofile(dir_path .. arg[1]) end, err) then
+    -- OK
+    os.exit(0)
+else
+    -- an error occurred
+    os.exit(1)
+end
+
+


### PR DESCRIPTION
Introduce a wrapper script to catch and report errors
in a more straightforward way. The main error is now
shown on the job summary window, in big, red letters.