### PR TITLE
Update list of requirements to force Flask-SocketIO==0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ requests>=2.2.1
 gevent>=1.0
 Flask>=0.10.1
 Flask-WTF>=0.11
+Flask-SocketIO==0.6.0
 gunicorn==17.5
 setuptools>=3.3
 lmdb>=0.87
 h5py>=2.2.1
 pydot2
-Flask-SocketIO


### PR DESCRIPTION
https://groups.google.com/d/msg/digits-users/_6xGrd_FmHA/YYrG4AVFAQAJ
```
$ ./digits-server
Error: class uri 'socketio.sgunicorn.GeventSocketIOWorker' invalid or not found: 

[Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/util.py", line 132, in load_class
    mod = __import__('.'.join(components))
ImportError: No module named socketio.sgunicorn
]
```

Somebody upgraded their pip package on PyPI and now the standard DIGITS install instructions don't work.

I suspect the culprit is Flask-SocketIO v0.6 -> v1.0.


The fix in this pull request worked for that specific user and for me, but I haven't had the time to debug this properly yet.