### PR TITLE
Trim whitespaces off of labels file

### DIFF
--- a/tools/torch/data.lua
+++ b/tools/torch/data.lua
@@ -70,7 +70,10 @@ local loadLabels = function(labels_file)
     if file then
         for line in file:lines() do
             i=i+1
-            Classes[i] = line
+            -- labels file might contain Windows line endings
+            -- or other whitespaces => trim leading and trailing
+            -- spaces here
+            Classes[i] = trim(line)
         end
         return Classes
     else

--- a/tools/torch/utils.lua
+++ b/tools/torch/utils.lua
@@ -248,6 +248,11 @@ function check_require(name)
     end
 end
 
+-- trim leading and trailing white spaces and line breaks
+function trim(s)
+  return (s:gsub("^%s*(.-)%s*$", "%1"))
+end
+
 utilsClass.correctFinalOutputDim = correctFinalOutputDim
 return utilsClass
 


### PR DESCRIPTION
The labels.txt file used to map class names to class IDs might
contain line endings that could confuse the parser during inference.