### PR TITLE
Fix the upgrade path for TrainTask.use_mean

### DIFF
--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -101,6 +101,12 @@ class TrainTask(Task):
                 if va:
                     state['val_outputs']['accuracy'] = NetworkOutput('Accuracy', [x[1]/100 for x in va])
                 state['val_outputs']['loss'] = NetworkOutput('SoftmaxWithLoss', [x[1] for x in vl])
+
+        if state['use_mean'] == True:
+            state['use_mean'] = 'pixel'
+        elif state['use_mean'] == False:
+            state['use_mean'] = 'none'
+
         state['pickver_task_train'] = PICKLE_VERSION
         super(TrainTask, self).__setstate__(state)
 


### PR DESCRIPTION
*Fixes a bug from #321*

When upgrading `TrainTasks` from before #321, we need to update the `use_mean` field accordingly.

To reproduce the bug:

1. `git checkout v2.2.1` and start up the server
2. Create a new classification model job
3. Verify that classifying an image works correctly
4. Shut down the server, `git checkout v3.0.0-rc.1` and start up the server again
5. Try classifying an image with the same model