### PR TITLE
Enable shared serialization in Torch

### DIFF
--- a/tools/torch/data.lua
+++ b/tools/torch/data.lua
@@ -11,6 +11,9 @@ package.path = debug.getinfo(1, "S").source:match[[^@?(.*[\/])[^\/]-$]] .."?.lua
 require 'logmessage'
 local ffi = require 'ffi'
 
+-- enable shared serialization to speed up Tensor passing between threads
+threads.Threads.serialization('threads.sharedserialize')
+
 ----------------------------------------------------------------------
 
 function copy (t) -- shallow-copy a table


### PR DESCRIPTION
This allows passing tensors between threads by
reference. This speeds up training for all models,
particulary when data are comparatively large
v.s. compute time.

Alexnet on CIFAR10 (2 epochs): 10m35s -> 9m28s
GoogleNet on CIFAR10 (1 epoch): 45m5s -> 44m52s
LeNet on MNIST (30 epochs): 2m17s -> 2m15s