### PR TITLE
Revert "Remove icon for Landscape.io"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/NVIDIA/DIGITS.svg?branch=master)](https://travis-ci.org/NVIDIA/DIGITS)
 [![Coverage Status](https://coveralls.io/repos/NVIDIA/DIGITS/badge.svg?branch=master)](https://coveralls.io/r/NVIDIA/DIGITS?branch=master)
+[![Code Health](https://landscape.io/github/NVIDIA/DIGITS/master/landscape.svg?style=flat)](https://landscape.io/github/NVIDIA/DIGITS/master)
 
 DIGITS (the **D**eep Learning **G**PU **T**raining **S**ystem) is is a webapp for training deep learning models.
 


### PR DESCRIPTION
*Reverts commit 4bb2c4e7cb917ffc2b27bac94b33843f0d759604 from https://github.com/NVIDIA/DIGITS/pull/276.*

Now that https://github.com/landscapeio/landscape-issues/issues/179 is fixed, let's turn the badge back on.

I'm also going to look into turning the GitHub integration back on now that https://github.com/landscapeio/landscape-issues/issues/160 is fixed.