### PR TITLE
Make python layers work for inference

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -952,7 +952,7 @@ layer {
     bottom: "output"
     top: "py_test"
     python_param {
-        module: "py_test"
+        module: "digits_python_layers"
         layer: "PythonLayer"
     }
 }

--- a/digits/utils/filesystem.py
+++ b/digits/utils/filesystem.py
@@ -21,7 +21,7 @@ def get_python_file_dst(dirname, basename):
     (root, ext) = os.path.splitext(basename)
     if ext != '.py' and ext != '.pyc':
         ValueError('Python file, %s, needs .py or .pyc extension.' % basename)
-    filename = os.path.join(dirname, basename)
+    filename = os.path.join(dirname, 'digits_python_layers' + ext)
     if os.path.isfile(filename):
         ValueError('Python file, %s, already exists.' % filename)
     return filename


### PR DESCRIPTION
This addresses a bug from https://github.com/NVIDIA/DIGITS/pull/329. Without this fix, you can train a model with a PythonLayer, but you can't test it.
```
SystemError
NULL result without error in PyObject_Call

Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/lyeager/digits/digits/model/images/classification/views.py", line 291, in image_classification_model_classify_one
    predictions, visualizations = job.train_task().infer_one(image, snapshot_epoch=epoch, layers=layers)
  File "/home/lyeager/digits/digits/model/tasks/caffe_train.py", line 1017, in infer_one
    layers=layers,
  File "/home/lyeager/digits/digits/model/tasks/caffe_train.py", line 1042, in classify_one
    net = self.get_net(snapshot_epoch)
  File "/home/lyeager/digits/digits/model/tasks/caffe_train.py", line 1368, in get_net
    caffe.TEST)
SystemError: NULL result without error in PyObject_Call
```
The message in the console output is much more informative:
```
ImportError: No module named python-layer
```
This requires two changes:

1. Add `job_dir` to the path before loading a new Caffe model so that the python file can be found

2. Force a reload of any modules that were loaded by a previous model (see comments)