### PR TITLE
Mark the expected TravisCI distro explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 
+sudo: required
+dist: precise
+
 language: python
 python:
     2.7
 compiler: gcc   # for Caffe
-sudo: required  # for Caffe
 env:
     global:
         # Make


### PR DESCRIPTION
TravisCI is migrating to Ubuntu 14.04 (trusty) from 12.04 (precise) - https://github.com/NVIDIA/DIGITS/issues/213#issuecomment-141532763. Let's be explicit about which version we're expecting.

> https://gist.github.com/meatballhat/d0c8aab9e3bd8a8bcacd

I've opened a related PR for Caffe at https://github.com/BVLC/caffe/pull/3407.

We'll wait for NVcaffe to transition to `trusty` before trying it with DIGITS.