### PR TITLE
Export number of classes to Torch models

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -68,6 +68,8 @@ layer {
     TORCH_NETWORK = \
 """
 return function(p)
+    -- adjust to number of classes
+    local nclasses = p.nclasses or 1
     -- model should adjust to any 3D input
     local nDim = 1
     if p.inputShape then p.inputShape:apply(function(x) nDim=nDim*x end) end
@@ -75,10 +77,10 @@ return function(p)
     model:add(nn.View(-1):setNumInputDims(3)) -- c*h*w -> chw (flattened)
     -- set all weights and biases to zero as this speeds learning up
     -- for the type of problem we're trying to solve in this test
-    local linearLayer = nn.Linear(nDim, 3)
+    local linearLayer = nn.Linear(nDim, nclasses)
     linearLayer.weight:fill(0)
     linearLayer.bias:fill(0)
-    model:add(linearLayer) -- chw -> 3
+    model:add(linearLayer) -- chw -> nclasses
     model:add(nn.LogSoftMax())
     return {
         model = model
@@ -800,14 +802,15 @@ layer {
     TORCH_NETWORK = \
 """
 return function(p)
+    local nclasses = p.nclasses or 1
     local croplen = 8, channels
     if p.inputShape then channels=p.inputShape[1] else channels=1 end
     local model = nn.Sequential()
     model:add(nn.View(-1):setNumInputDims(3)) -- flatten
-    local linLayer = nn.Linear(channels*croplen*croplen, 3)
+    local linLayer = nn.Linear(channels*croplen*croplen, nclasses)
     linLayer.weight:fill(0)
     linLayer.bias:fill(0)
-    model:add(linLayer) -- chw -> 3
+    model:add(linLayer) -- chw -> nclasses
     model:add(nn.LogSoftMax())
     return {
         model = model,

--- a/digits/standard-networks/torch/lenet.lua
+++ b/digits/standard-networks/torch/lenet.lua
@@ -3,6 +3,10 @@
 return function(params)
     assert(params.ngpus<=1, 'Model supports only CPU or single-GPU')
 
+    -- get number of classes from external parameters
+    local nclasses = params.nclasses or 1
+
+    -- get number of channels from external parameters
     local channels = 1
     -- params.inputShape may be nil during visualization
     if params.inputShape then
@@ -10,11 +14,6 @@ return function(params)
         assert(params.inputShape[2]==28 and params.inputShape[3]==28, 'Network expects 28x28 images')
     end
 
-    -- adjust to number of channels in input images - default to 1 channel
-    -- during model visualization
-    local channels = (params.inputShape and params.inputShape[1]) or 1
-
-    require 'nn'
     if pcall(function() require('cudnn') end) then
        print('Using CuDNN backend')
        backend = cudnn
@@ -44,7 +43,7 @@ return function(params)
     lenet:add(nn.View(-1):setNumInputDims(3))  -- 50*4*4 -> 800
     lenet:add(nn.Linear(800,500))  -- 800 -> 500
     lenet:add(backend.ReLU())
-    lenet:add(nn.Linear(500, 10))  -- 500 -> 10
+    lenet:add(nn.Linear(500, nclasses))  -- 500 -> nclasses
     lenet:add(nn.LogSoftMax())
 
     return {

--- a/docs/GettingStartedTorch.md
+++ b/docs/GettingStartedTorch.md
@@ -10,7 +10,7 @@ Table of Contents
     * [Internal Parameters](#internal-parameters)
     * [Tensors](#tensors)
 * [Examples](#examples)
-    * [Adjusting Model To Inputs Dimensions](#adjusting-model-to-input-dimensions)
+    * [Adjusting model to inputs dimensions and number of classes](#adjusting-model-to-input-dimensions-and-number-of-classes)
     * [Selecting the NN Backend](#selecting-the-nn-backend)
     * [Supervised Regression Learning](#supervised-regression-learning)
     * [Command Line Inference](#command-line-inference)
@@ -87,6 +87,7 @@ External parameters are provided by DIGITS:
 Parameter name  | Type     | Description
 --------------- | -------- | --------
 ngpus           | number   | Tells how many GPUs are available (0 means CPU)
+nclasses        | number   | Number of classes (for classification datasets). For other datasets this is undefined.
 inputShape      | Tensor   | Shape (1D Tensor) of first input Tensor. For image data this is set to {channels, height, width}. Note: this parameter is undefined during model visualization.
 
 ### Internal parameters
@@ -108,17 +109,18 @@ Networks are fed with Torch Tensor objects in the NxCxHxW format (index in batch
 
 ## Examples
 
-### Adjusting model to input dimensions
+### Adjusting model to input dimensions and number of classes
 
-The following network defines a linear network that takes any 3D-tensor as input and produces three categorical outputs:
+The following network defines a linear network that takes any 3D-tensor as input and produces one categorical output per class:
 ```lua
 return function(p)
     -- model should adjust to any 3D-input
-    nDim = 1
+    local nClasses = p.nclasses or 1
+    local nDim = 1
     if p.inputShape then p.inputShape:apply(function(x) nDim=nDim*x end) end
     local model = nn.Sequential()
     model:add(nn.View(-1):setNumInputDims(3)) -- c*h*w -> chw (flattened)
-    model:add(nn.Linear(nDim, 3)) -- chw -> 3
+    model:add(nn.Linear(nDim, nclasses)) -- chw -> nClasses
     model:add(nn.LogSoftMax())
     return {
         model = model

--- a/tools/torch/main.lua
+++ b/tools/torch/main.lua
@@ -266,6 +266,7 @@ local network_func = require (opt.network)
 assert(type(network_func)=='function', "Network definition should return a Lua function - see documentation")
 local parameters = {
         ngpus = (opt.type == 'cuda') and 1 or 0,
+        nclasses = (classes ~= nil) and #classes or nil,
         inputShape = inputTensorShape,
     }
 network = network_func(parameters)
@@ -336,12 +337,6 @@ if opt.retrain ~= '' then
         logmessage.display(2,'Pretrained model not found: ' .. opt.retrain)
         os.exit(-1)
     end
-end
-
-if classes then
-    -- for classification networks, and for the user's convenience, adjust
-    -- last layer to match number of classes
-    utils.correctFinalOutputDim(model, #classes)
 end
 
 logmessage.display(0,'Network definition: \n' .. model:__tostring__())

--- a/tools/torch/test.lua
+++ b/tools/torch/test.lua
@@ -139,14 +139,11 @@ function loadNetwork(dir, name, labels, weightsFile, tensorType, inputTensorShap
     logmessage.display(0,'Loading network definition from ' .. paths.concat(dir, name))
     local parameters = {
         ngpus = (tensorType =='cuda') and 1 or 0,
+        nclasses = (labels ~= nil) and #labels or nil,
         inputShape = inputTensorShape,
     }
     local network = require (name)(parameters)
     local model = network.model
-    -- fix final output dimension of network
-    if labels then
-        utils.correctFinalOutputDim(model, #labels)
-    end
 
     -- load parameters from snapshot
     local weights, gradients = model:getParameters()

--- a/tools/torch/utils.lua
+++ b/tools/torch/utils.lua
@@ -194,35 +194,6 @@ function utilsClass.resizeImage(img, height, width, channels,resize_mode)
     end
 end
 
--- This module corrects the final output dimension of the model to match with total number of classes. This follows Reverse Depth First Search approach i.e., modules of the model are checked from last to first, and internally for each module same procedure was followed to find the module with weights. If the module has weights, it indicates the input and output sizes. If the first dimension of weight is not same as total classes count, then corrects the dimension to match with classes count.
--- TODO: currently this module supports only Linear module and for all other modules it will just display a warning message.
-function correctFinalOutputDim(node, outputSize)
-    if (node.modules ~= nil) then
-        if (type(node.modules) == 'table') then
-            for i=#node.modules,1,-1 do
-                local child = node.modules[i]
-                if correctFinalOutputDim(child, outputSize) then
-                    return true
-                end
-            end
-        end
-    end
-    if node.weight then
-        if node.weight:size(1) ~= outputSize then
-            if torch.type(node) == "nn.Linear" then
-		local oldOutputSize = node.weight:size(1)
-                node:__init(node.weight:size(2),outputSize)
-                logmessage.display(0,'changed output size for ' .. torch.type(node) .. ', from ' .. oldOutputSize .. ' to ' .. outputSize)
-            else
-                logmessage.display(1,'output size for last ' .. torch.type(node) .. ' layer is ' .. node.weight:size(1) .. ', which is different from total number of classes i.e., ' .. outputSize)
-            end
-            --logmessage.display(0,model:__tostring__())
-        end
-        return true
-    end
-    return false
-end
-
 -- return whether a Luarocks module is available
 function isModuleAvailable(name)
   if package.loaded[name] then


### PR DESCRIPTION
Allow networks to select desired number of outputs depending on
number of classes in (classification) dataset.

Stop automatically adjusting number of outputs in Lua wrappers.
This is less confusing and this will make it easier to enable
multi-GPU training with Torch in DIGITS.