### PR TITLE
Set linear weights to zero in automatic tests

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -73,7 +73,12 @@ return function(p)
     if p.inputShape then p.inputShape:apply(function(x) nDim=nDim*x end) end
     local model = nn.Sequential()
     model:add(nn.View(-1):setNumInputDims(3)) -- c*h*w -> chw (flattened)
-    model:add(nn.Linear(nDim, 3)) -- chw -> 3
+    -- set all weights and biases to zero as this speeds learning up
+    -- for the type of problem we're trying to solve in this test
+    local linearLayer = nn.Linear(nDim, 3)
+    linearLayer.weight:fill(0)
+    linearLayer.bias:fill(0)
+    model:add(linearLayer) -- chw -> 3
     model:add(nn.LogSoftMax())
     return {
         model = model
@@ -799,7 +804,10 @@ return function(p)
     if p.inputShape then channels=p.inputShape[1] else channels=1 end
     local model = nn.Sequential()
     model:add(nn.View(-1):setNumInputDims(3)) -- flatten
-    model:add(nn.Linear(channels*croplen*croplen, 3)) -- chw -> 3
+    local linLayer = nn.Linear(channels*croplen*croplen, 3)
+    linLayer.weight:fill(0)
+    linLayer.bias:fill(0)
+    model:add(linLayer) -- chw -> 3
     model:add(nn.LogSoftMax())
     return {
         model = model,
@@ -841,11 +849,9 @@ class TestTorchViews(BaseTestViews):
 
 class TestTorchCreation(BaseTestCreation):
     FRAMEWORK = 'torch'
-    TRAIN_EPOCHS = 10
 
 class TestTorchCreated(BaseTestCreated):
     FRAMEWORK = 'torch'
-    TRAIN_EPOCHS = 10
 
 class TestTorchCreatedShuffle(TestTorchCreated):
     SHUFFLE = True
@@ -871,19 +877,15 @@ class TestCaffeLeNet(TestCaffeCreated):
 
 class TestTorchCreatedCropInForm(BaseTestCreatedCropInForm):
     FRAMEWORK = 'torch'
-    TRAIN_EPOCHS = 10
 
 class TestTorchCreatedCropInNetwork(BaseTestCreatedCropInNetwork):
     FRAMEWORK = 'torch'
-    TRAIN_EPOCHS = 10
 
 class TestTorchCreatedWide(BaseTestCreatedWide):
     FRAMEWORK = 'torch'
-    TRAIN_EPOCHS = 10
 
 class TestTorchCreatedTall(BaseTestCreatedTall):
     FRAMEWORK = 'torch'
-    TRAIN_EPOCHS = 10
 
 class TestTorchLeNet(TestTorchCreated):
     IMAGE_WIDTH = 28

--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -74,7 +74,12 @@ return function(p)
     local net = nn.Sequential()
     net:add(nn.MulConstant(0.004))
     net:add(nn.View(-1):setNumInputDims(3))  -- flatten
-    net:add(nn.Linear(nDim,2)) -- c*h*w -> 2
+    -- set all weights and biases to zero as this speeds learning up
+    -- for the type of problem we're trying to solve in this test
+    local linearLayer = nn.Linear(nDim, 2)
+    linearLayer.weight:fill(0)
+    linearLayer.bias:fill(0)
+    net:add(linearLayer) -- c*h*w -> 2
     return {
         model = net,
         loss = nn.MSECriterion(),
@@ -697,7 +702,12 @@ return function(p)
     local net = nn.Sequential()
     net:add(nn.MulConstant(0.004))
     net:add(nn.View(-1):setNumInputDims(3))  -- flatten
-    net:add(nn.Linear(channels*croplen*croplen,2)) -- c*croplen*croplen -> 2
+    -- set all weights and biases to zero as this speeds learning up
+    -- for the type of problem we're trying to solve in this test
+    local linearLayer = nn.Linear(channels*croplen*croplen, 2)
+    linearLayer.weight:fill(0)
+    linearLayer.bias:fill(0)
+    net:add(linearLayer) -- c*croplen*croplen -> 2
     return {
         model = net,
         loss = nn.MSECriterion(),
@@ -738,18 +748,12 @@ class TestTorchCreation(BaseTestCreation):
     FRAMEWORK = 'torch'
 
 class TestTorchCreated(BaseTestCreated):
-    LR_POLICY = 'fixed'
-    TRAIN_EPOCHS = 10
     FRAMEWORK = 'torch'
 
 class TestTorchCreatedCropInNetwork(BaseTestCreatedCropInNetwork):
-    LR_POLICY = 'fixed'
-    TRAIN_EPOCHS = 10
     FRAMEWORK = 'torch'
 
 class TestTorchCreatedCropInForm(BaseTestCreatedCropInForm):
-    LR_POLICY = 'fixed'
-    TRAIN_EPOCHS = 10
     FRAMEWORK = 'torch'
 
 class TestTorchDatasetModelInteractions(BaseTestDatasetModelInteractions):


### PR DESCRIPTION
By default Caffe zero-initialises weights and biases for linear
layers (http://caffe.berkeleyvision.org/tutorial/layers.html).
Torch on the other hand initializes linear layer parameters by
picking from a uniform distribution.
For the problem that we are trying to solve in the automatic
tests it is quicker to train from zero-initialised weights
as we only really need to learn the sign of those parameters.