### PR TITLE
Use python2 in shebang lines - PEP 394

### DIFF
--- a/digits-devserver
+++ b/digits-devserver
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/digits-server
+++ b/digits-server
@@ -17,7 +17,7 @@ function set_exe {
 }
 
 # Some hacking necessary to respect virtualenv installations
-set_exe PYTHON_EXE python
+set_exe PYTHON_EXE python2
 set_exe GUNICORN_EXE gunicorn
 
 $PYTHON_EXE $GUNICORN_EXE \

--- a/digits-test
+++ b/digits-test
@@ -17,7 +17,7 @@ function set_exe {
 }
 
 # Some hacking necessary to respect virtualenv installations
-set_exe PYTHON_EXE python
+set_exe PYTHON_EXE python2
 set_exe NOSE_EXE nosetests
 
 DIGITS_MODE_TEST=1 $PYTHON_EXE $NOSE_EXE \

--- a/digits/config/edit.py
+++ b/digits/config/edit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 
 import os

--- a/digits/dataset/images/classification/test_imageset_creator.py
+++ b/digits/dataset/images/classification/test_imageset_creator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Functions for creating temporary datasets
 Used in test_views

--- a/digits/dataset/images/generic/test_lmdb_creator.py
+++ b/digits/dataset/images/generic/test_lmdb_creator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 """
 Functions for creating temporary LMDBs

--- a/digits/device_query.py
+++ b/digits/device_query.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import ctypes

--- a/examples/classification/example.py
+++ b/examples/classification/example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 
 """

--- a/examples/classification/use_archive.py
+++ b/examples/classification/use_archive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 
 """

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/tools/analyze_db.py
+++ b/tools/analyze_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/tools/create_db.py
+++ b/tools/create_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/tools/download_data/main.py
+++ b/tools/download_data/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/tools/parse_folder.py
+++ b/tools/parse_folder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/tools/resize_image.py
+++ b/tools/resize_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2014-2015, NVIDIA CORPORATION.  All rights reserved.
 
 import sys

--- a/tools/test_resize_image.py
+++ b/tools/test_resize_image.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
 
 import os


### PR DESCRIPTION
> in preparation for an eventual change in the default version of Python, Python 2 only scripts should either be updated to be source compatible with Python 3 or else to use python2 in the shebang line.
https://www.python.org/dev/peps/pep-0394/