### PR TITLE
Set default HDF5 filesize limit in create_db tool

### DIFF
--- a/tools/create_db.py
+++ b/tools/create_db.py
@@ -741,6 +741,7 @@ if __name__ == '__main__':
             help = 'The initial map size for LMDB (in MB)')
     parser.add_argument('--hdf5_dset_limit',
             type=int,
+            default=2**31,
             help = 'The size limit for HDF5 datasets')
 
     args = vars(parser.parse_args())


### PR DESCRIPTION
Before this fix, you had to explicitly specify `--hdf5_dset_limit=2147483648` to avoid this error:
```sh
$ tools/create_db.py train.txt train_db 28 28 -b hdf5
2015-12-09 09:18:40 [WARNING] removing existing database
2015-12-09 09:18:40 [DEBUG] 7502 total lines in file
2015-12-09 09:18:40 [INFO ] 7502 valid lines in file
2015-12-09 09:18:40 [DEBUG] Category 0 has 735 images.
2015-12-09 09:18:40 [DEBUG] Category 1 has 851 images.
2015-12-09 09:18:40 [DEBUG] Category 2 has 774 images.
2015-12-09 09:18:40 [DEBUG] Category 3 has 758 images.
2015-12-09 09:18:40 [DEBUG] Category 4 has 737 images.
2015-12-09 09:18:40 [DEBUG] Category 5 has 669 images.
2015-12-09 09:18:40 [DEBUG] Category 6 has 719 images.
2015-12-09 09:18:40 [DEBUG] Category 7 has 771 images.
2015-12-09 09:18:40 [DEBUG] Category 8 has 731 images.
2015-12-09 09:18:40 [DEBUG] Category 9 has 757 images.
2015-12-09 09:18:41 [INFO ] Creating HDF5 database at "0.h5" ...
2015-12-09 09:18:41 [ERROR] TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
Traceback (most recent call last):
  File "tools/create_db.py", line 763, in <module>
    hdf5_dset_limit = args['hdf5_dset_limit'],
  File "tools/create_db.py", line 286, in create_db
    mean_files, **kwargs)
  File "tools/create_db.py", line 425, in _create_hdf5
    writer.write_batch(batch)
  File "tools/create_db.py", line 137, in write_batch
    split = self._max_count - current_count
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```