### PR TITLE
Fix typo in template

### DIFF
--- a/digits/templates/job_row.html
+++ b/digits/templates/job_row.html
@@ -52,7 +52,7 @@
         <div class="pull-right">
             <a id="abort" class="btn btn-xs btn-warning" {{ ' style=display:none;' if not job.status.is_running() }} onClick="return abortJob('{{job.id()}}', '{{ abort_url }}');">Abort
             </a>
-            <a id="delete" class="btn btn-xs btn-danger" {{ ' style=display:none;' if job.status.is_running() }} onClick="return deleteJob('{{job.id()}}');");">Delete
+            <a id="delete" class="btn btn-xs btn-danger" {{ ' style=display:none;' if job.status.is_running() }} onClick="return deleteJob('{{job.id()}}');">Delete
             </a>
         </div>
     </td>


### PR DESCRIPTION
Apparently HTML has no problem with unmatched parentheses - I only noticed because it messed up the syntax highlighting in my editor.

Looks like this is coming from #240. @jmancewicz please confirm and merge if this look OK.