### PR TITLE
Show job_dir on all job pages

### DIFF
--- a/digits/templates/datasets/images/generic/show.html
+++ b/digits/templates/datasets/images/generic/show.html
@@ -46,6 +46,8 @@
             </div>
             <div class="panel-body">
                 <dl>
+                    <dt>Job Directory</td>
+                    <dd>{{job.dir()}}</dd>
                     <dt>Dataset size</dt>
                     <dd>{{job.disk_size_fmt()}}</dd>
                 </dl>

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -12,6 +12,8 @@
     <div class="col-sm-6">
         <div class="well">
             <dl>
+                <dt>Job Directory</dt>
+                <dd>{{ job.dir() }}</dd>
                 <dt>Disk Size</dt>
                 <dd>{{job.disk_size_fmt()}}</dd>
                 {% for key,value in task.get_model_files().items() %}

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -12,6 +12,8 @@
     <div class="col-sm-6">
         <div class="well">
             <dl>
+                <dt>Job Directory</dt>
+                <dd>{{ job.dir() }}</dd>
                 <dt>Disk Size</dt>
                 <dd>{{job.disk_size_fmt()}}</dd>
                 {% for key,value in task.get_model_files().items() %}


### PR DESCRIPTION
*Close #467*

As suggested by @GiuliaP, show the job directory for all job types, not just `ImageClassificationModelJobs`.