### PR TITLE
Print torch output for failed tests

### DIFF
--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -426,6 +426,9 @@ class TorchTrainTask(TrainTask):
             else:
                 self.traceback = traceback
 
+            if 'DIGITS_MODE_TEST' in os.environ:
+                print output
+
     @override
     def detect_snapshots(self):
         self.snapshots = []


### PR DESCRIPTION
Same as #383, but now for Torch.

Helps with debugging failed tests.