### PR TITLE
Speedup generic tests

### DIFF
--- a/digits/dataset/images/generic/test_views.py
+++ b/digits/dataset/images/generic/test_views.py
@@ -61,9 +61,10 @@ class BaseViewsTestWithImageset(BaseViewsTest):
     @classmethod
     def setUpClass(cls):
         super(BaseViewsTestWithImageset, cls).setUpClass()
-        cls.imageset_folder = tempfile.mkdtemp()
-        # create imageset
-        cls.test_image = create_lmdbs(cls.imageset_folder)
+        if not hasattr(BaseViewsTestWithImageset, 'imageset_folder'):
+            # Create folder and LMDBs for all test classes
+            BaseViewsTestWithImageset.imageset_folder = tempfile.mkdtemp()
+            BaseViewsTestWithImageset.test_image = create_lmdbs(BaseViewsTestWithImageset.imageset_folder)
         cls.created_datasets = []
 
     @classmethod
@@ -71,8 +72,6 @@ class BaseViewsTestWithImageset(BaseViewsTest):
         # delete any created datasets
         for job_id in cls.created_datasets:
             cls.delete_dataset(job_id)
-        # delete imageset
-        shutil.rmtree(cls.imageset_folder)
         super(BaseViewsTestWithImageset, cls).tearDownClass()
 
     @classmethod


### PR DESCRIPTION
Since the generic test suite all uses the same LMDBs, we can just create them once rather than re-creating them for each test class.

Command:
```sh
./digits-test digits/*/images/generic/ -s -v
```
Before:
```
153 tests run in 223.1 seconds.
3 skipped (150 tests passed)
```
After:
```
153 tests run in 156.3 seconds.
3 skipped (150 tests passed)
```