### PR TITLE
Fix handling of unencoded LMDB in Torch

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -847,6 +847,11 @@ class TestTorchCreated(BaseTestCreated):
     FRAMEWORK = 'torch'
     TRAIN_EPOCHS = 10
 
+class TestTorchCreatedUnencoded(BaseTestCreated):
+    FRAMEWORK = 'torch'
+    ENCODING = 'none'
+    TRAIN_EPOCHS = 10
+
 class TestTorchCreatedShuffle(TestTorchCreated):
     SHUFFLE = True
 

--- a/tools/torch/data.lua
+++ b/tools/torch/data.lua
@@ -377,7 +377,13 @@ function DBSource:lmdb_getSample(shuffle, idx)
     if msg.encoded==true then
         y = image.decompress(x,msg.channels,'byte'):float()
     else
-        y = x:narrow(1,1,total):view(msg.channels,msg.height,msg.width):float() -- using narrow() returning the reference to x tensor with the size exactly equal to total image byte size, so that view() works fine without issues
+        x = x:narrow(1,1,total):view(msg.channels,msg.height,msg.width):float() -- using narrow() returning the reference to x tensor with the size exactly equal to total image byte size, so that view() works fine without issues
+        y = x -- make y see x's storage
+        if self.ImageChannels == 3 then
+            -- unencoded color images are stored in BGR order => we need to swap blue and red channels (BGR->RGB)
+            y[1] = x[3]
+            y[3] = x[1]
+        end
     end
 
     return y, label


### PR DESCRIPTION
Unencoded LMDB data are stored in BGR format so a
channel swap is required to have a consistent
representation of data across inputs, mean files,
etc.

close #477