### PR TITLE
Torch Multi-GPU support

### DIFF
--- a/digits/frameworks/torch_framework.py
+++ b/digits/frameworks/torch_framework.py
@@ -110,7 +110,8 @@ class TorchFramework(Framework):
                     '--network=%s' % os.path.splitext(os.path.basename(temp_network_path))[0],
                     '--networkDirectory=%s' % os.path.dirname(temp_network_path),
                     '--subtractMean=none', # we are not providing a mean image
-                    '--visualizeModel=yes'
+                    '--visualizeModel=yes',
+                    '--type=float'
                     ]
 
             # execute command

--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -320,8 +320,6 @@ class BaseTestCreation(BaseViewsTestWithDataset):
         gpu_list = config_value('gpu_list').split(',')
         for i in xrange(len(gpu_list)):
             for combination in itertools.combinations(gpu_list, i+1):
-                if self.FRAMEWORK=='torch' and len(combination)>1:
-                    raise unittest.SkipTest('Torch not tested with multi-GPU')
                 yield self.check_select_gpus, combination
 
     def check_select_gpus(self, gpu_list):

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -411,8 +411,7 @@ function setFramework(fwid)
             <div id="torch-warning" class="alert alert-warning" style="display:none;">
                 <b>NOTE:</b> Torch7 is currently supported as an experimental feature in DIGITS. The following limitations apply:
                 <ul>
-                    <li>Multi-GPU training is not supported</li>
-                    <li>Models don't automatically adjust to images with different sizes/channels</li>
+                    <li>Models don't automatically adjust to images with different sizes</li>
                     <li>Model fine tuning is not supported</li>
                 </ul>
             </div>

--- a/docs/BuildTorch.md
+++ b/docs/BuildTorch.md
@@ -17,6 +17,7 @@ Table of Contents
 * [Torch installer](#torch-installer)
 * [Luarocks dependencies](#luarocks-dependencies)
 * [LMDB support](#lmdb-support)
+* [NCCL support](#nccl-support)
 * [Getting Started With Torch7 in DIGITS](#getting-started-with-torch7-in-digits)
 
 ## Prerequisites
@@ -66,6 +67,58 @@ Install extra Lua packages:
 
 Follow these instructions if you wish to use Torch7 to train networks using LMDB-encoded datasets in DIGITS. You may skip this section if you wish to only use HDF5-encoded datasets:
 [LMDB installation instructions](BuildTorchLMDB.md)
+
+## NCCL support
+
+[NCCL](https://github.com/NVIDIA/nccl) is a library of primitives for multi-GPU communication.
+You may consider installing the [nccl.torch](https://github.com/ngimel/nccl.torch) module if you wish to speed up
+multi-GPU training, although this module is not stictly required to enable multi-GPU training in Torch7.
+
+Download and build NCCL:
+```sh
+% git clone https://github.com/NVIDIA/nccl.git
+% cd nccl
+% make CUDA_HOME=/usr/local/cuda test
+```
+
+> NOTE: if the above command fails due to missing libraries you may explicitly point the makefile to the location of your NVidia driver. For example:
+
+```sh
+% make CUDA_HOME=/usr/local/cuda LIBRARY_PATH=/usr/lib/nvidia-352 test
+```
+
+Add the path to the NCCL library to your library path:
+```sh
+% export LD_LIBRARY_PATH=.../nccl/build/lib:$LD_LIBRARY_PATH
+```
+
+Download and build the nccl.torch module:
+```sh
+% git clone https://github.com/ngimel/nccl.torch.git
+% cd nccl.torch
+% luarocks make nccl-scm-1.rockspec
+```
+
+Verify your installation of nccl.torch:
+```sh
+gheinrich@ubuntu:~/ws/nccl.torch$ th
+  ______             __   |  Torch7
+ /_  __/__  ________/ /   |  Scientific computing for Lua.
+  / / / _ \/ __/ __/ _ \  |  Type ? for help
+ /_/  \___/_/  \__/_//_/  |  https://github.com/torch
+                          |  http://torch.ch
+th> require('nccl')
+{
+  createCommunicators : function: 0x41084588
+  reduceScatter : function: 0x41084888
+  allGather : function: 0x41084860
+  C : userdata: 0x410844a8
+  bcast : function: 0x41084830
+  communicators : {...}
+  allReduce : function: 0x410844c0
+  reduce : function: 0x41084718
+}
+```
 
 ## Getting Started With Torch7 in DIGITS
 

--- a/docs/GettingStartedTorch.md
+++ b/docs/GettingStartedTorch.md
@@ -14,6 +14,7 @@ Table of Contents
     * [Selecting the NN Backend](#selecting-the-nn-backend)
     * [Supervised Regression Learning](#supervised-regression-learning)
     * [Command Line Inference](#command-line-inference)
+    * [Multi-GPU training](#multi-gpu-training)
 * [Tutorials](#tutorials)
     * [Training an autoencoder](#training-an-autoencoder)
     * [Training a regression model](#training-a-regression-model)
@@ -182,6 +183,28 @@ th /fast-scratch/gheinrich/ws/digits/tools/torch/test.lua --image=/path/to/image
 2015-09-22 15:21:55 [INFO ] For image 1, predicted class 3: 8 (7) 1.6892548943146e-05
 2015-09-22 15:21:55 [INFO ] For image 1, predicted class 4: 4 (3) 2.9689886060496e-06
 2015-09-22 15:21:55 [INFO ] For image 1, predicted class 5: 5 (4) 9.7695222396362e-07
+```
+
+### Multi-GPU training
+
+Data parallelism is supported in Torch7 by cunn through the [DataParallelTable](https://github.com/torch/cunn/blob/master/doc/cunnmodules.md#nn.DataParallelTable)
+module. DIGITS provides the number of available GPUs through the `ngpus` external parameter.
+
+Assuming `net` is a container that encapsulates the definition of a network, the following snippet may be used
+to enable data parallelism into a container called `model`:
+
+```lua
+local model
+if ngpus>1 then
+   model = nn.DataParallelTable(1)  -- Split along first (batch) dimension
+   for i = 1, ngpus do
+      cutorch.setDevice(i)
+      model:add(net:clone(), i)  -- Use the ith GPU
+   end
+   cutorch.setDevice(1)  -- This is the 'primary' GPU
+else
+   model = net
+end
 ```
 
 ## Tutorials

--- a/tools/torch/Optimizer.lua
+++ b/tools/torch/Optimizer.lua
@@ -46,7 +46,7 @@ end
 
 function Optimizer:optimize(x,yt)
     local f_eval = function()
-        self.Gradients:zero()
+        self.Model:zeroGradParameters()
         local y = self.Model:forward(x)
         -- get label
         label = self.LabelFunction(x,yt)
@@ -65,5 +65,6 @@ function Optimizer:optimize(x,yt)
     end
 
     return value, self.OptState.learningRate, self.OptFunction(f_eval, self.Weights, self.OptState)
+
 end
 


### PR DESCRIPTION
*Close #138*

This commit enables data parallelism, i.e. train
batches are evenly spread across selected GPUs.

Strong scaling is applied by default, i.e. batch
size is unchanged and each GPU receives its share
during training.

For better performance, installation of the NCCL
module is recommended.

On a 2xTitanX machine (with NCCL):
- GoogleNet: 51m4s (1 GPU) -> 34m3s (2 GPUs)
- Alexnet: 12m31s (1 GPU) -> 10m38s (2 GPUs)
- LeNet*: 53s (1GPU) -> 1m30s (2 GPUs)

* the overhead of inter-GPU communication seems to
outweigh the compute gain on LeNet