### PR TITLE
Add log message when aborting a job

### DIFF
--- a/digits/scheduler.py
+++ b/digits/scheduler.py
@@ -216,6 +216,7 @@ class Scheduler:
             return False
 
         job.abort()
+        logger.info('Job aborted.', job_id=job_id)
         return True
 
     def delete_job(self, job):


### PR DESCRIPTION
Matches what we do [when deleting a job](https://github.com/NVIDIA/DIGITS/blob/v3.0.0-rc.3/digits/scheduler.py#L269).

You ought to be able to grep the log for all relevant events for a job like this:
```sh
$ cat digits/digits.log | grep 20151228-131316-6a72
2015-12-28 13:13:18 [20151228-131316-6a72] [INFO ] Train Caffe Model task started.
2015-12-28 13:13:21 [20151228-131316-6a72] [INFO ] Job aborted.
2015-12-28 13:13:24 [20151228-131316-6a72] [INFO ] Job deleted.
```