### PR TITLE
Add option to use multiple pretrained networks

### DIFF
--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -256,7 +256,7 @@ class ModelForm(Form):
         if form.method.data == 'custom':
             snapshot = field.data.strip()
             if snapshot:
-                if not os.path.exists(snapshot):
+                if not all(map(lambda x: os.path.exists(x), snapshot.split(';'))):
                     raise validators.ValidationError('File does not exist')
 
     # Select one of several GPUs

--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -248,7 +248,7 @@ class ModelForm(Form):
             )
 
     custom_network_snapshot = utils.forms.TextField('Pretrained model(s)',
-                tooltip = "Semicolon delimited paths to pretrained model files. Only edit this field if you understand how fine-tuning works in caffe."
+                tooltip = "Colon delimited paths to pretrained model files. Only edit this field if you understand how fine-tuning works in caffe."
             )
 
 

--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -254,9 +254,9 @@ class ModelForm(Form):
 
     def validate_custom_network_snapshot(form, field):
         if form.method.data == 'custom':
-            snapshot = field.data.strip()
+            snapshot = ':'.join(map(lambda x: x.strip(), field.data.split(':')))
             if snapshot:
-                if not all(map(lambda x: os.path.exists(x.strip()), snapshot.split(':'))):
+                if not all(map(lambda x: os.path.exists(x), snapshot.split(':'))):
                     raise validators.ValidationError('File does not exist')
 
     # Select one of several GPUs

--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -247,8 +247,8 @@ class ModelForm(Form):
                 ],
             )
 
-    custom_network_snapshot = utils.forms.TextField('Pretrained model',
-                tooltip = "Path to pretrained model file. Only edit this field if you understand how fine-tuning works in caffe"
+    custom_network_snapshot = utils.forms.TextField('Pretrained model(s)',
+                tooltip = "Semicolon delimited paths to pretrained model files. Only edit this field if you understand how fine-tuning works in caffe."
             )
 
 

--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -256,7 +256,7 @@ class ModelForm(Form):
         if form.method.data == 'custom':
             snapshot = field.data.strip()
             if snapshot:
-                if not all(map(lambda x: os.path.exists(x), snapshot.split(';'))):
+                if not all(map(lambda x: os.path.exists(x.strip()), snapshot.split(':'))):
                     raise validators.ValidationError('File does not exist')
 
     # Select one of several GPUs

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -798,7 +798,7 @@ class CaffeTrainTask(TrainTask):
                 else:
                     args.append('--gpu=%s' % ','.join(identifiers))
         if self.pretrained_model:
-            args.append('--weights=%s' % self.path(self.pretrained_model))
+            args.append('--weights=%s' % ','.join(map(lambda x: self.path(x), self.pretrained_model.split(';'))))
 
         return args
 

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -798,7 +798,7 @@ class CaffeTrainTask(TrainTask):
                 else:
                     args.append('--gpu=%s' % ','.join(identifiers))
         if self.pretrained_model:
-            args.append('--weights=%s' % ','.join(map(lambda x: self.path(x), self.pretrained_model.split(';'))))
+            args.append('--weights=%s' % ','.join(map(lambda x: self.path(x), self.pretrained_model.split(':'))))
 
         return args
 


### PR DESCRIPTION
I've added an option to copy weights from multiple pretrained networks so that ensembles can be built easily. Multiple pretrained networks can be added as semicolon delimited paths.