### PR TITLE
Fixup imports

### DIFF
--- a/digits-devserver
+++ b/digits-devserver
@@ -1,12 +1,11 @@
 #!/usr/bin/env python2
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import sys
 import argparse
-import digits
-
-# Only required if using SocketIO.run() and app.debug = False
 from gevent import monkey; monkey.patch_all()
+import sys
+
+import digits
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run the DIGITS development server')

--- a/digits-walkthrough
+++ b/digits-walkthrough
@@ -1,18 +1,18 @@
 #!/usr/bin/env python2
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
+import argparse
+import json
 import os
+import requests
+import socket
 import sys
 import time
 from urlparse import urlparse
-import requests
-import json
-import argparse
-import socket
 
 from selenium import webdriver
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
 
 wait_time = 2
 def wait(s=wait_time):

--- a/digits/config/__init__.py
+++ b/digits/config/__init__.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 
 # These are the only two functions that the rest of DIGITS needs to use
-from load import load_config
-from current_config import config_value
+from .load import load_config
+from .current_config import config_value
 
 if 'DIGITS_MODE_TEST' in os.environ:
     # load the config automatically during testing

--- a/digits/config/__init__.py
+++ b/digits/config/__init__.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import
 import os
 
 # These are the only two functions that the rest of DIGITS needs to use
-from .load import load_config
 from .current_config import config_value
+from .load import load_config
 
 if 'DIGITS_MODE_TEST' in os.environ:
     # load the config automatically during testing

--- a/digits/config/caffe_option.py
+++ b/digits/config/caffe_option.py
@@ -1,17 +1,17 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os
-import re
-import sys
 import imp
+import os
 import platform
+import re
 import subprocess
+import sys
 
-from digits import device_query
-from digits.utils import parse_version
 from . import config_option
 from . import prompt
+from digits import device_query
+from digits.utils import parse_version
 
 class CaffeOption(config_option.FrameworkOption):
     @staticmethod

--- a/digits/config/caffe_option.py
+++ b/digits/config/caffe_option.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import re
@@ -9,8 +10,8 @@ import subprocess
 
 from digits import device_query
 from digits.utils import parse_version
-import config_option
-import prompt
+from . import config_option
+from . import prompt
 
 class CaffeOption(config_option.FrameworkOption):
     @staticmethod

--- a/digits/config/config_file.py
+++ b/digits/config/config_file.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import platform

--- a/digits/config/config_file.py
+++ b/digits/config/config_file.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+from collections import OrderedDict
+import ConfigParser
 import os
 import platform
-import ConfigParser
-from collections import OrderedDict
 
 import digits
 

--- a/digits/config/current_config.py
+++ b/digits/config/current_config.py
@@ -1,13 +1,14 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from jobs_dir import JobsDirOption
-from gpu_list import GpuListOption
-from log_file import LogFileOption
-from log_level import LogLevelOption
-from server_name import ServerNameOption
-from secret_key import SecretKeyOption
-from caffe_option import CaffeOption
-from torch_option import TorchOption
+from .jobs_dir import JobsDirOption
+from .gpu_list import GpuListOption
+from .log_file import LogFileOption
+from .log_level import LogLevelOption
+from .server_name import ServerNameOption
+from .secret_key import SecretKeyOption
+from .caffe_option import CaffeOption
+from .torch_option import TorchOption
 
 option_list = None
 

--- a/digits/config/current_config.py
+++ b/digits/config/current_config.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .jobs_dir import JobsDirOption
+from .caffe_option import CaffeOption
 from .gpu_list import GpuListOption
+from .jobs_dir import JobsDirOption
 from .log_file import LogFileOption
 from .log_level import LogLevelOption
+from .torch_option import TorchOption
 from .server_name import ServerNameOption
 from .secret_key import SecretKeyOption
-from .caffe_option import CaffeOption
-from .torch_option import TorchOption
 
 option_list = None
 

--- a/digits/config/edit.py
+++ b/digits/config/edit.py
@@ -2,13 +2,13 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os
 import argparse
+import os
 
-import config_option
-import config_file
-import prompt
-import current_config
+from . import config_file
+from . import config_option
+from . import current_config
+from . import prompt
 
 def print_config(verbose=False):
     """

--- a/digits/config/edit.py
+++ b/digits/config/edit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import argparse

--- a/digits/config/gpu_list.py
+++ b/digits/config/gpu_list.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import math
 
-import config_option
-import prompt
+from . import config_option
+from . import prompt
 import digits.device_query
 
 class GpuListOption(config_option.Option):

--- a/digits/config/jobs_dir.py
+++ b/digits/config/jobs_dir.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import
 import os
 import tempfile
 
-import digits
 from . import config_option
 from . import prompt
+import digits
 
 class JobsDirOption(config_option.Option):
     @staticmethod

--- a/digits/config/jobs_dir.py
+++ b/digits/config/jobs_dir.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import tempfile
 
 import digits
-import config_option
-import prompt
+from . import config_option
+from . import prompt
 
 class JobsDirOption(config_option.Option):
     @staticmethod

--- a/digits/config/load.py
+++ b/digits/config/load.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 
-import config_option
-import config_file
-import prompt
-import current_config
+from . import config_option
+from . import config_file
+from . import prompt
+from . import current_config
 
 def load_option(option, mode, newConfig,
         instanceConfig  =None,

--- a/digits/config/load.py
+++ b/digits/config/load.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import
 
 import os
 
-from . import config_option
 from . import config_file
-from . import prompt
+from . import config_option
 from . import current_config
+from . import prompt
 
 def load_option(option, mode, newConfig,
         instanceConfig  =None,

--- a/digits/config/log_file.py
+++ b/digits/config/log_file.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 
 import digits
-import config_option
-import prompt
+from . import config_option
+from . import prompt
 
 class LogFileOption(config_option.Option):
     @staticmethod

--- a/digits/config/log_file.py
+++ b/digits/config/log_file.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 
 import os
 
-import digits
 from . import config_option
 from . import prompt
+import digits
 
 class LogFileOption(config_option.Option):
     @staticmethod

--- a/digits/config/log_level.py
+++ b/digits/config/log_level.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-import config_option
-import prompt
+from . import config_option
+from . import prompt
 
 class LogLevelOption(config_option.Option):
     @staticmethod

--- a/digits/config/prompt.py
+++ b/digits/config/prompt.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
-
 """
 Classes and functions relating to prompting a user for configuration options
 """
+from __future__ import absolute_import
 
 import sys
 import os.path
 import readline
 
-import config_option
+from . import config_option
 
 def print_section_header(title):
     """

--- a/digits/config/prompt.py
+++ b/digits/config/prompt.py
@@ -4,9 +4,9 @@ Classes and functions relating to prompting a user for configuration options
 """
 from __future__ import absolute_import
 
-import sys
 import os.path
 import readline
+import sys
 
 from . import config_option
 

--- a/digits/config/secret_key.py
+++ b/digits/config/secret_key.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 
-import config_option
-import prompt
+from . import config_option
+from . import prompt
 
 class SecretKeyOption(config_option.Option):
     @staticmethod

--- a/digits/config/server_name.py
+++ b/digits/config/server_name.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import platform
 
-import config_option
-import prompt
+from . import config_option
+from . import prompt
 
 class ServerNameOption(config_option.Option):
     @staticmethod

--- a/digits/config/test_config_file.py
+++ b/digits/config/test_config_file.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import tempfile
 

--- a/digits/config/test_prompt.py
+++ b/digits/config/test_prompt.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import sys
 from contextlib import contextmanager

--- a/digits/config/test_prompt.py
+++ b/digits/config/test_prompt.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import sys
 from contextlib import contextmanager
 from StringIO import StringIO
+import sys
 
 import mock
 from nose.tools import raises

--- a/digits/config/torch_option.py
+++ b/digits/config/torch_option.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 
-import config_option
-import prompt
+from . import config_option
+from . import prompt
 
 class TorchOption(config_option.FrameworkOption):
     @staticmethod

--- a/digits/dataset/__init__.py
+++ b/digits/dataset/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from job import DatasetJob
-from images import *
+from .job import DatasetJob
+from .images import *

--- a/digits/dataset/__init__.py
+++ b/digits/dataset/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .job import DatasetJob
 from .images import *
+from .job import DatasetJob

--- a/digits/dataset/forms.py
+++ b/digits/dataset/forms.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from flask.ext.wtf import Form
 from wtforms.validators import DataRequired

--- a/digits/dataset/forms.py
+++ b/digits/dataset/forms.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 from flask.ext.wtf import Form
 from wtforms.validators import DataRequired
+
 from digits import utils
 
 class DatasetForm(Form):

--- a/digits/dataset/images/__init__.py
+++ b/digits/dataset/images/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .job import ImageDatasetJob
 from .classification import *
 from .generic import *
+from .job import ImageDatasetJob

--- a/digits/dataset/images/__init__.py
+++ b/digits/dataset/images/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from job import ImageDatasetJob
-from classification import *
-from generic import *
+from .job import ImageDatasetJob
+from .classification import *
+from .generic import *

--- a/digits/dataset/images/classification/__init__.py
+++ b/digits/dataset/images/classification/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from job import ImageClassificationDatasetJob
+from .job import ImageClassificationDatasetJob

--- a/digits/dataset/images/classification/forms.py
+++ b/digits/dataset/images/classification/forms.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os.path
 import requests

--- a/digits/dataset/images/classification/job.py
+++ b/digits/dataset/images/classification/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from digits.utils import subclass, override
 from digits.status import Status

--- a/digits/dataset/images/classification/job.py
+++ b/digits/dataset/images/classification/job.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from digits.utils import subclass, override
-from digits.status import Status
 from ..job import ImageDatasetJob
 from digits.dataset import tasks
+from digits.status import Status
+from digits.utils import subclass, override
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 2

--- a/digits/dataset/images/classification/test_imageset_creator.py
+++ b/digits/dataset/images/classification/test_imageset_creator.py
@@ -4,6 +4,7 @@
 Functions for creating temporary datasets
 Used in test_views
 """
+from __future__ import absolute_import
 
 import os
 import time

--- a/digits/dataset/images/classification/test_imageset_creator.py
+++ b/digits/dataset/images/classification/test_imageset_creator.py
@@ -6,10 +6,10 @@ Used in test_views
 """
 from __future__ import absolute_import
 
-import os
-import time
 import argparse
 from collections import defaultdict
+import os
+import time
 
 import numpy as np
 import PIL.Image

--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import json
 import os
@@ -17,7 +18,7 @@ from urlparse import urlparse
 from cStringIO import StringIO
 
 import digits.test_views
-from test_imageset_creator import create_classification_imageset, IMAGE_SIZE as DUMMY_IMAGE_SIZE, IMAGE_COUNT as DUMMY_IMAGE_COUNT
+from .test_imageset_creator import create_classification_imageset, IMAGE_SIZE as DUMMY_IMAGE_SIZE, IMAGE_COUNT as DUMMY_IMAGE_COUNT
 
 # May be too short on a slow system
 TIMEOUT_DATASET = 45

--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -1,24 +1,23 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+import itertools
 import json
 import os
 import shutil
 import tempfile
 import time
 import unittest
-import itertools
 import urllib
 
-from gevent import monkey
-monkey.patch_all()
 from bs4 import BeautifulSoup
+from cStringIO import StringIO
+from gevent import monkey; monkey.patch_all()
 import PIL.Image
 from urlparse import urlparse
-from cStringIO import StringIO
 
-import digits.test_views
 from .test_imageset_creator import create_classification_imageset, IMAGE_SIZE as DUMMY_IMAGE_SIZE, IMAGE_COUNT as DUMMY_IMAGE_COUNT
+import digits.test_views
 
 # May be too short on a slow system
 TIMEOUT_DATASET = 45

--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 
@@ -9,8 +10,8 @@ from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler
 from digits.dataset import tasks
-from forms import ImageClassificationDatasetForm
-from job import ImageClassificationDatasetJob
+from .forms import ImageClassificationDatasetForm
+from .job import ImageClassificationDatasetJob
 
 import lmdb
 import PIL.Image

--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -3,20 +3,20 @@ from __future__ import absolute_import
 
 import os
 
+import caffe_pb2
 import flask
-
-from digits import utils
-from digits.utils.forms import fill_form_if_cloned, save_form_to_job
-from digits.utils.routing import request_wants_json, job_from_request
-from digits.webapp import app, scheduler
-from digits.dataset import tasks
-from .forms import ImageClassificationDatasetForm
-from .job import ImageClassificationDatasetJob
-
 import lmdb
 import PIL.Image
 from StringIO import StringIO
-import caffe_pb2
+
+from .forms import ImageClassificationDatasetForm
+from .job import ImageClassificationDatasetJob
+from digits import utils
+from digits.dataset import tasks
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job
+from digits.utils.routing import request_wants_json, job_from_request
+from digits.webapp import app, scheduler
+
 
 NAMESPACE = '/datasets/images/classification'
 

--- a/digits/dataset/images/forms.py
+++ b/digits/dataset/images/forms.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import wtforms
 from wtforms import validators
 
 from ..forms import DatasetForm
-from job import ImageDatasetJob
+from .job import ImageDatasetJob
 from digits import utils
 
 class ImageDatasetForm(DatasetForm):

--- a/digits/dataset/images/generic/__init__.py
+++ b/digits/dataset/images/generic/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from job import GenericImageDatasetJob
+from .job import GenericImageDatasetJob

--- a/digits/dataset/images/generic/forms.py
+++ b/digits/dataset/images/generic/forms.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os.path
 

--- a/digits/dataset/images/generic/forms.py
+++ b/digits/dataset/images/generic/forms.py
@@ -7,8 +7,8 @@ import wtforms
 from wtforms import validators
 
 from ..forms import ImageDatasetForm
-from digits.utils.forms import validate_required_iff
 from digits import utils
+from digits.utils.forms import validate_required_iff
 
 class GenericImageDatasetForm(ImageDatasetForm):
     """

--- a/digits/dataset/images/generic/job.py
+++ b/digits/dataset/images/generic/job.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from digits.utils import subclass, override
 from ..job import ImageDatasetJob
 from digits.dataset import tasks
+from digits.utils import subclass, override
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 1

--- a/digits/dataset/images/generic/job.py
+++ b/digits/dataset/images/generic/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from digits.utils import subclass, override
 from ..job import ImageDatasetJob

--- a/digits/dataset/images/generic/test_lmdb_creator.py
+++ b/digits/dataset/images/generic/test_lmdb_creator.py
@@ -4,6 +4,7 @@
 Functions for creating temporary LMDBs
 Used in test_views
 """
+from __future__ import absolute_import
 
 import os
 import sys

--- a/digits/dataset/images/generic/test_lmdb_creator.py
+++ b/digits/dataset/images/generic/test_lmdb_creator.py
@@ -6,16 +6,16 @@ Used in test_views
 """
 from __future__ import absolute_import
 
-import os
-import sys
-import time
 import argparse
 from collections import defaultdict
 from cStringIO import StringIO
+import os
+import sys
+import time
 
+import lmdb
 import numpy as np
 import PIL.Image
-import lmdb
 
 if __name__ == '__main__':
     dirname = os.path.dirname(os.path.realpath(__file__))

--- a/digits/dataset/images/generic/test_views.py
+++ b/digits/dataset/images/generic/test_views.py
@@ -1,24 +1,23 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+import itertools
 import json
 import os
 import shutil
 import tempfile
 import time
 import unittest
-import itertools
 import urllib
 
-from gevent import monkey
-monkey.patch_all()
 from bs4 import BeautifulSoup
+from cStringIO import StringIO
+from gevent import monkey; monkey.patch_all()
 import PIL.Image
 from urlparse import urlparse
-from cStringIO import StringIO
 
-import digits.test_views
 from .test_lmdb_creator import create_lmdbs
+import digits.test_views
 
 # May be too short on a slow system
 TIMEOUT_DATASET = 45

--- a/digits/dataset/images/generic/test_views.py
+++ b/digits/dataset/images/generic/test_views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import json
 import os
@@ -17,7 +18,7 @@ from urlparse import urlparse
 from cStringIO import StringIO
 
 import digits.test_views
-from test_lmdb_creator import create_lmdbs
+from .test_lmdb_creator import create_lmdbs
 
 # May be too short on a slow system
 TIMEOUT_DATASET = 45

--- a/digits/dataset/images/generic/views.py
+++ b/digits/dataset/images/generic/views.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import
 
 import flask
 
-from digits import utils
-from digits.utils.forms import fill_form_if_cloned, save_form_to_job
-from digits.utils.routing import request_wants_json, job_from_request
-from digits.webapp import app, scheduler
-from digits.dataset import tasks
 from .forms import GenericImageDatasetForm
 from .job import GenericImageDatasetJob
+from digits import utils
+from digits.dataset import tasks
+from digits.webapp import app, scheduler
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job
+from digits.utils.routing import request_wants_json, job_from_request
 
 NAMESPACE = '/datasets/images/generic'
 

--- a/digits/dataset/images/generic/views.py
+++ b/digits/dataset/images/generic/views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import flask
 
@@ -7,8 +8,8 @@ from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler
 from digits.dataset import tasks
-from forms import GenericImageDatasetForm
-from job import GenericImageDatasetJob
+from .forms import GenericImageDatasetForm
+from .job import GenericImageDatasetJob
 
 NAMESPACE = '/datasets/images/generic'
 

--- a/digits/dataset/images/job.py
+++ b/digits/dataset/images/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from ..job import DatasetJob
 

--- a/digits/dataset/images/views.py
+++ b/digits/dataset/images/views.py
@@ -1,17 +1,17 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os.path
 from cStringIO import StringIO
+import os.path
 
 import flask
 import PIL.Image
 
+from .classification import views as _
+from .generic import views as _
 import digits
 from digits import utils
 from digits.webapp import app
-from .classification import views as _
-from .generic import views as _
 
 NAMESPACE = '/datasets/images'
 

--- a/digits/dataset/images/views.py
+++ b/digits/dataset/images/views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os.path
 from cStringIO import StringIO
@@ -9,8 +10,8 @@ import PIL.Image
 import digits
 from digits import utils
 from digits.webapp import app
-import classification.views
-import generic.views
+from .classification import views as _
+from .generic import views as _
 
 NAMESPACE = '/datasets/images'
 

--- a/digits/dataset/job.py
+++ b/digits/dataset/job.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+from . import tasks
 from digits.job import Job
 from digits.utils import subclass, override
-from . import tasks
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 1

--- a/digits/dataset/job.py
+++ b/digits/dataset/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from digits.job import Job
 from digits.utils import subclass, override

--- a/digits/dataset/tasks/__init__.py
+++ b/digits/dataset/tasks/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .parse_folder import ParseFolderTask
-from .create_db import CreateDbTask
 from .analyze_db import AnalyzeDbTask
+from .create_db import CreateDbTask
+from .parse_folder import ParseFolderTask

--- a/digits/dataset/tasks/__init__.py
+++ b/digits/dataset/tasks/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from parse_folder import ParseFolderTask
-from create_db import CreateDbTask
-from analyze_db import AnalyzeDbTask
+from .parse_folder import ParseFolderTask
+from .create_db import CreateDbTask
+from .analyze_db import AnalyzeDbTask

--- a/digits/dataset/tasks/analyze_db.py
+++ b/digits/dataset/tasks/analyze_db.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import sys
 import os.path
 import re
+import sys
 
 import digits
-from digits.utils import subclass, override
 from digits.task import Task
+from digits.utils import subclass, override
 
 # NOTE: Increment this everytime the pickled object
 PICKLE_VERSION = 1

--- a/digits/dataset/tasks/analyze_db.py
+++ b/digits/dataset/tasks/analyze_db.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import sys
 import os.path

--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import sys
 import os.path

--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import sys
+import operator
 import os.path
 import re
-import operator
+import sys
 
 import digits
 from digits import utils
-from digits.utils import subclass, override
 from digits.task import Task
+from digits.utils import subclass, override
 
 # NOTE: Increment this everytime the pickled version changes
 PICKLE_VERSION = 3

--- a/digits/dataset/tasks/parse_folder.py
+++ b/digits/dataset/tasks/parse_folder.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import sys
 import os.path

--- a/digits/dataset/tasks/parse_folder.py
+++ b/digits/dataset/tasks/parse_folder.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import sys
 import os.path
 import re
+import sys
 
 import digits
 from digits import utils
-from digits.utils import subclass, override
 from digits.task import Task
+from digits.utils import subclass, override
 
 # NOTE: Increment this everytime the pickled object
 PICKLE_VERSION = 1

--- a/digits/dataset/views.py
+++ b/digits/dataset/views.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import flask
 import werkzeug.exceptions
 
 from digits.webapp import app, scheduler
 from digits.utils.routing import request_wants_json
-import images.views
-import images as dataset_images
+from .images import views
+from . import images as dataset_images
 
 NAMESPACE = '/datasets/'
 

--- a/digits/dataset/views.py
+++ b/digits/dataset/views.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import
 import flask
 import werkzeug.exceptions
 
-from digits.webapp import app, scheduler
-from digits.utils.routing import request_wants_json
-from .images import views
 from . import images as dataset_images
+from .images import views
+from digits.utils.routing import request_wants_json
+from digits.webapp import app, scheduler
 
 NAMESPACE = '/datasets/'
 

--- a/digits/device_query.py
+++ b/digits/device_query.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import argparse
 import ctypes

--- a/digits/frameworks/__init__.py
+++ b/digits/frameworks/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .framework import Framework
 from .caffe_framework import CaffeFramework
+from .framework import Framework
 from .torch_framework import TorchFramework
 from digits.config import config_value
 

--- a/digits/frameworks/__init__.py
+++ b/digits/frameworks/__init__.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from framework import Framework
-from caffe_framework import CaffeFramework
-from torch_framework import TorchFramework
+from .framework import Framework
+from .caffe_framework import CaffeFramework
+from .torch_framework import TorchFramework
 from digits.config import config_value
 
 #

--- a/digits/frameworks/caffe_framework.py
+++ b/digits/frameworks/caffe_framework.py
@@ -4,15 +4,15 @@ from __future__ import absolute_import
 import os
 import re
 
-import digits
-from .errors import BadNetworkError
-from .framework import Framework
-from digits.model.tasks import CaffeTrainTask
-from digits.utils import subclass, override
-
-from google.protobuf import text_format
 import caffe.draw
 import caffe_pb2
+from google.protobuf import text_format
+
+from .errors import BadNetworkError
+from .framework import Framework
+import digits
+from digits.model.tasks import CaffeTrainTask
+from digits.utils import subclass, override
 
 @subclass
 class CaffeFramework(Framework):

--- a/digits/frameworks/caffe_framework.py
+++ b/digits/frameworks/caffe_framework.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import re
 
 import digits
-from errors import BadNetworkError
-from framework import Framework
+from .errors import BadNetworkError
+from .framework import Framework
 from digits.model.tasks import CaffeTrainTask
 from digits.utils import subclass, override
 

--- a/digits/frameworks/errors.py
+++ b/digits/frameworks/errors.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from digits.utils import subclass
 

--- a/digits/frameworks/torch_framework.py
+++ b/digits/frameworks/torch_framework.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import digits
@@ -8,12 +9,12 @@ import time
 import tempfile
 import flask
 
-from framework import Framework
+from .framework import Framework
 from digits import utils
 from digits.config import config_value
 from digits.model.tasks import TorchTrainTask
 from digits.utils import subclass, override
-from errors import Error, NetworkVisualizationError, BadNetworkError
+from .errors import Error, NetworkVisualizationError, BadNetworkError
 
 @subclass
 class TorchFramework(Framework):

--- a/digits/frameworks/torch_framework.py
+++ b/digits/frameworks/torch_framework.py
@@ -2,19 +2,20 @@
 from __future__ import absolute_import
 
 import os
-import digits
 import re
 import subprocess
 import time
 import tempfile
+
 import flask
 
+from .errors import Error, NetworkVisualizationError, BadNetworkError
 from .framework import Framework
+import digits
 from digits import utils
 from digits.config import config_value
 from digits.model.tasks import TorchTrainTask
 from digits.utils import subclass, override
-from .errors import Error, NetworkVisualizationError, BadNetworkError
 
 @subclass
 class TorchFramework(Framework):

--- a/digits/job.py
+++ b/digits/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import time
@@ -10,7 +11,7 @@ import flask
 
 from digits.config import config_value
 from digits.utils import sizeof_fmt, filesystem as fs
-from status import Status, StatusCls
+from .status import Status, StatusCls
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 1

--- a/digits/job.py
+++ b/digits/job.py
@@ -2,16 +2,16 @@
 from __future__ import absolute_import
 
 import os
-import time
 import os.path
 import pickle
 import shutil
+import time
 
 import flask
 
+from .status import Status, StatusCls
 from digits.config import config_value
 from digits.utils import sizeof_fmt, filesystem as fs
-from .status import Status, StatusCls
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 1

--- a/digits/log.py
+++ b/digits/log.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import sys
 import logging
 import logging.handlers
+import sys
 
 from digits.config import config_value
 

--- a/digits/log.py
+++ b/digits/log.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import sys
 import logging

--- a/digits/model/__init__.py
+++ b/digits/model/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from job import ModelJob
-from images import *
+from .job import ModelJob
+from .images import *

--- a/digits/model/__init__.py
+++ b/digits/model/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .job import ModelJob
 from .images import *
+from .job import ModelJob

--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -8,12 +8,12 @@ from flask.ext.wtf import Form
 import wtforms
 from wtforms import validators
 
+from digits import frameworks
+from digits import utils
 from digits.config import config_value
 from digits.device_query import get_device, get_nvml_info
-from digits import utils
 from digits.utils import sizeof_fmt
 from digits.utils.forms import validate_required_iff
-from digits import frameworks
 
 class ModelForm(Form):
 

--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 

--- a/digits/model/images/__init__.py
+++ b/digits/model/images/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from job import ImageModelJob
-from classification import *
-from generic import *
+from .job import ImageModelJob
+from .classification import *
+from .generic import *

--- a/digits/model/images/__init__.py
+++ b/digits/model/images/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .job import ImageModelJob
 from .classification import *
 from .generic import *
+from .job import ImageModelJob

--- a/digits/model/images/classification/__init__.py
+++ b/digits/model/images/classification/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from job import ImageClassificationModelJob
+from .job import ImageClassificationModelJob

--- a/digits/model/images/classification/forms.py
+++ b/digits/model/images/classification/forms.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import wtforms
 from wtforms import validators

--- a/digits/model/images/classification/job.py
+++ b/digits/model/images/classification/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os.path
 

--- a/digits/model/images/classification/job.py
+++ b/digits/model/images/classification/job.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 
 import os.path
 
-from digits.utils import subclass, override
 from ..job import ImageModelJob
+from digits.utils import subclass, override
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 1

--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import re
 import os

--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -1,31 +1,29 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import re
-import os
+import itertools
 import json
+import os
+import re
 import shutil
 import tempfile
 import time
 import unittest
-import itertools
 import urllib
-import tempfile
 
-import mock
-import flask
-from gevent import monkey
-monkey.patch_all()
 from bs4 import BeautifulSoup
+import caffe_pb2
+from cStringIO import StringIO
+import flask
+from gevent import monkey; monkey.patch_all()
+import mock
 import PIL.Image
 from urlparse import urlparse
-from cStringIO import StringIO
-import caffe_pb2
 
-import digits.webapp
-import digits.test_views
-import digits.dataset.images.classification.test_views
 from digits.config import config_value
+import digits.dataset.images.classification.test_views
+import digits.test_views
+import digits.webapp
 
 # May be too short on a slow system
 TIMEOUT_DATASET = 45

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -2,25 +2,26 @@
 from __future__ import absolute_import
 
 import os
+import random
 import re
 import tempfile
-import random
-import flask
-import werkzeug.exceptions
-import numpy as np
 
-import digits
-from digits.config import config_value
-from digits import utils
-from digits.utils.routing import request_wants_json, job_from_request
-from digits.webapp import app, scheduler
-from digits.dataset import ImageClassificationDatasetJob
-from digits import frameworks
+import flask
+import numpy as np
+import werkzeug.exceptions
+
 from .forms import ImageClassificationModelForm
 from .job import ImageClassificationModelJob
+import digits
+from digits import frameworks
+from digits import utils
+from digits.config import config_value
+from digits.dataset import ImageClassificationDatasetJob
 from digits.status import Status
-from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils import filesystem as fs
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job
+from digits.utils.routing import request_wants_json, job_from_request
+from digits.webapp import app, scheduler
 
 NAMESPACE   = '/models/images/classification'
 

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import re
@@ -15,8 +16,8 @@ from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler
 from digits.dataset import ImageClassificationDatasetJob
 from digits import frameworks
-from forms import ImageClassificationModelForm
-from job import ImageClassificationModelJob
+from .forms import ImageClassificationModelForm
+from .job import ImageClassificationModelJob
 from digits.status import Status
 from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils import filesystem as fs

--- a/digits/model/images/forms.py
+++ b/digits/model/images/forms.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import wtforms
 from wtforms import validators

--- a/digits/model/images/generic/__init__.py
+++ b/digits/model/images/generic/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from job import GenericImageModelJob
+from .job import GenericImageModelJob

--- a/digits/model/images/generic/forms.py
+++ b/digits/model/images/generic/forms.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import wtforms
 from wtforms import validators

--- a/digits/model/images/generic/job.py
+++ b/digits/model/images/generic/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os.path
 

--- a/digits/model/images/generic/job.py
+++ b/digits/model/images/generic/job.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 
 import os.path
 
-from digits.utils import subclass, override
 from ..job import ImageModelJob
+from digits.utils import subclass, override
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 1

--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import re
 import os

--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -1,30 +1,29 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import re
-import os
+import itertools
 import json
+import os
+import re
 import shutil
 import tempfile
 import time
 import unittest
-import itertools
 import urllib
 
-import mock
-import flask
-from gevent import monkey
-monkey.patch_all()
 from bs4 import BeautifulSoup
+import caffe_pb2
+from cStringIO import StringIO
+import flask
+from gevent import monkey; monkey.patch_all()
+import mock
 import PIL.Image
 from urlparse import urlparse
-from cStringIO import StringIO
-import caffe_pb2
 
-import digits.webapp
-import digits.test_views
-import digits.dataset.images.generic.test_views
 from digits.config import config_value
+import digits.dataset.images.generic.test_views
+import digits.test_views
+import digits.webapp
 
 # May be too short on a slow system
 TIMEOUT_DATASET = 45

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -8,17 +8,17 @@ import tempfile
 import flask
 import werkzeug.exceptions
 
-from digits import frameworks
-from digits.config import config_value
-from digits import utils
-from digits.utils.routing import request_wants_json, job_from_request
-from digits.utils.forms import fill_form_if_cloned, save_form_to_job
-from digits.webapp import app, scheduler
-from digits.dataset import GenericImageDatasetJob
 from .forms import GenericImageModelForm
 from .job import GenericImageModelJob
+from digits import frameworks
+from digits import utils
+from digits.config import config_value
+from digits.dataset import GenericImageDatasetJob
 from digits.status import Status
 from digits.utils import filesystem as fs
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job
+from digits.utils.routing import request_wants_json, job_from_request
+from digits.webapp import app, scheduler
 
 NAMESPACE   = '/models/images/generic'
 

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import re
@@ -14,8 +15,8 @@ from digits.utils.routing import request_wants_json, job_from_request
 from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.webapp import app, scheduler
 from digits.dataset import GenericImageDatasetJob
-from forms import GenericImageModelForm
-from job import GenericImageModelJob
+from .forms import GenericImageModelForm
+from .job import GenericImageModelJob
 from digits.status import Status
 from digits.utils import filesystem as fs
 

--- a/digits/model/images/job.py
+++ b/digits/model/images/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from ..job import ModelJob
 

--- a/digits/model/images/views.py
+++ b/digits/model/images/views.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from digits.webapp import app
 from .classification import views as _
 from .generic import views as _
+from digits.webapp import app
 
 NAMESPACE = '/models/images'
 

--- a/digits/model/images/views.py
+++ b/digits/model/images/views.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from digits.webapp import app
-import classification.views
-import generic.views
+from .classification import views as _
+from .generic import views as _
 
 NAMESPACE = '/models/images'
 

--- a/digits/model/job.py
+++ b/digits/model/job.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from digits.job import Job
 from . import tasks
-
+from digits.job import Job
 from digits.utils import override
 
 # NOTE: Increment this everytime the pickled object changes

--- a/digits/model/job.py
+++ b/digits/model/job.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from digits.job import Job
 from . import tasks

--- a/digits/model/tasks/__init__.py
+++ b/digits/model/tasks/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .train import TrainTask
 from .caffe_train import CaffeTrainTask
 from .torch_train import TorchTrainTask
+from .train import TrainTask

--- a/digits/model/tasks/__init__.py
+++ b/digits/model/tasks/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
-from train import TrainTask
-from caffe_train import CaffeTrainTask
-from torch_train import TorchTrainTask
+from .train import TrainTask
+from .caffe_train import CaffeTrainTask
+from .torch_train import TorchTrainTask

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -1,24 +1,24 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+import math
+import operator
 import os
 import re
-import time
-import math
 import subprocess
-import operator
 import sys
+import time
 
-import numpy as np
-import scipy
-from google.protobuf import text_format
 import caffe
 import caffe_pb2
+from google.protobuf import text_format
+import numpy as np
+import scipy
 
 from .train import TrainTask
+from digits import utils, dataset
 from digits.config import config_value
 from digits.status import Status
-from digits import utils, dataset
 from digits.utils import subclass, override, constants
 
 # NOTE: Increment this everytime the pickled object changes

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import re
@@ -14,7 +15,7 @@ from google.protobuf import text_format
 import caffe
 import caffe_pb2
 
-from train import TrainTask
+from .train import TrainTask
 from digits.config import config_value
 from digits.status import Status
 from digits import utils, dataset

--- a/digits/model/tasks/test_caffe_train.py
+++ b/digits/model/tasks/test_caffe_train.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from . import caffe_train as _
 

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import re
@@ -13,7 +14,7 @@ import h5py
 import PIL.Image
 
 import digits
-from train import TrainTask
+from .train import TrainTask
 from digits.config import config_value
 from digits import utils, dataset
 from digits.utils import subclass, override, constants

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -1,27 +1,25 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+import operator
 import os
 import re
-import time
-import subprocess
-import operator
 import shutil
+import subprocess
 import tempfile
+import time
 
-import numpy as np
+import caffe_pb2
 import h5py
+import numpy as np
 import PIL.Image
 
-import digits
 from .train import TrainTask
-from digits.config import config_value
+import digits
 from digits import utils, dataset
-from digits.utils import subclass, override, constants
+from digits.config import config_value
 from digits.dataset import ImageClassificationDatasetJob
-
-# to read mean file in .binaryproto format
-import caffe_pb2
+from digits.utils import subclass, override, constants
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 1

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import time
-import os.path
 from collections import OrderedDict, namedtuple
+import os.path
+import time
 
-import gevent
 import flask
+import gevent
 
 from digits import device_query
 from digits.task import Task

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import time
 import os.path

--- a/digits/model/views.py
+++ b/digits/model/views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import io
 import json
@@ -16,9 +17,9 @@ from digits.webapp import app, scheduler
 from digits.utils import time_filters
 from digits.utils.routing import request_wants_json
 from . import ModelJob
-import forms
-import images.views
-import images as model_images
+from . import forms
+from .images import views as _
+from . import images as model_images
 
 from digits import frameworks
 

--- a/digits/model/views.py
+++ b/digits/model/views.py
@@ -1,27 +1,25 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+from datetime import timedelta
 import io
 import json
 import math
 import tarfile
 import zipfile
-from datetime import timedelta
 
 import flask
 import werkzeug.exceptions
 
-
+from . import forms
+from . import images as model_images
+from . import ModelJob
+from .images import views as _
 import digits
-from digits.webapp import app, scheduler
+from digits import frameworks
 from digits.utils import time_filters
 from digits.utils.routing import request_wants_json
-from . import ModelJob
-from . import forms
-from .images import views as _
-from . import images as model_images
-
-from digits import frameworks
+from digits.webapp import app, scheduler
 
 NAMESPACE = '/models/'
 

--- a/digits/scheduler.py
+++ b/digits/scheduler.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import time
@@ -13,14 +14,14 @@ import gevent
 import gevent.event
 import gevent.queue
 
-from config import config_value
+from .config import config_value
 from . import utils
-from status import Status
-from job import Job
-from dataset import DatasetJob
-from model import ModelJob
+from .status import Status
+from .job import Job
+from .dataset import DatasetJob
+from .model import ModelJob
 from digits.utils import errors
-from log import logger
+from .log import logger
 
 class Resource(object):
     """

--- a/digits/scheduler.py
+++ b/digits/scheduler.py
@@ -1,27 +1,27 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os
-import time
-import shutil
-import traceback
-import signal
 from collections import OrderedDict
+import os
 import re
+import shutil
+import signal
+import time
+import traceback
 
 import flask
 import gevent
 import gevent.event
 import gevent.queue
 
-from .config import config_value
 from . import utils
-from .status import Status
-from .job import Job
+from .config import config_value
 from .dataset import DatasetJob
-from .model import ModelJob
-from digits.utils import errors
+from .job import Job
 from .log import logger
+from .model import ModelJob
+from .status import Status
+from digits.utils import errors
 
 class Resource(object):
     """

--- a/digits/status.py
+++ b/digits/status.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import time
 

--- a/digits/task.py
+++ b/digits/task.py
@@ -1,22 +1,21 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os.path
-import re
-import time
 import logging
-import subprocess
+import os.path
+import platform
+import re
 import signal
+import subprocess
+import time
 
 import flask
 import gevent.event
 
 from . import utils
-import digits.log
 from .config import config_value
 from .status import Status, StatusCls
-
-import platform
+import digits.log
 
 # NOTE: Increment this everytime the pickled version changes
 PICKLE_VERSION = 1

--- a/digits/task.py
+++ b/digits/task.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os.path
 import re
@@ -12,8 +13,8 @@ import gevent.event
 
 from . import utils
 import digits.log
-from config import config_value
-from status import Status, StatusCls
+from .config import config_value
+from .status import Status, StatusCls
 
 import platform
 

--- a/digits/test_device_query.py
+++ b/digits/test_device_query.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import mock

--- a/digits/test_device_query.py
+++ b/digits/test_device_query.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os
 import mock
-import unittest
+import os
 import platform
+import unittest
 
 from . import device_query as _
 

--- a/digits/test_scheduler.py
+++ b/digits/test_scheduler.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from gevent import monkey; monkey.patch_all()
 from nose.tools import assert_raises
 import mock
 
 from . import scheduler as _
-from config import config_value
-from job import Job
+from .config import config_value
+from .job import Job
 from digits.utils import subclass, override
 
 class TestScheduler():

--- a/digits/test_scheduler.py
+++ b/digits/test_scheduler.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import
 
 from gevent import monkey; monkey.patch_all()
-from nose.tools import assert_raises
 import mock
+from nose.tools import assert_raises
 
 from . import scheduler as _
 from .config import config_value

--- a/digits/test_status.py
+++ b/digits/test_status.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import pickle
 import tempfile
 
-from status import Status
-from job import Job
+from .status import Status
+from .job import Job
 
 class TestStatus():
 

--- a/digits/test_status.py
+++ b/digits/test_status.py
@@ -5,8 +5,8 @@ import os
 import pickle
 import tempfile
 
-from .status import Status
 from .job import Job
+from .status import Status
 
 class TestStatus():
 

--- a/digits/test_views.py
+++ b/digits/test_views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import time
 import json
@@ -7,7 +8,7 @@ import urllib
 from gevent import monkey; monkey.patch_all()
 from urlparse import urlparse
 
-import webapp
+from . import webapp
 
 ################################################################################
 # Base classes (they don't start with "Test" so nose won't run them)

--- a/digits/test_views.py
+++ b/digits/test_views.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import time
 import json
+import time
 import urllib
 
 from gevent import monkey; monkey.patch_all()

--- a/digits/utils/__init__.py
+++ b/digits/utils/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os
-import math
-import locale
-from random import uniform
-from urlparse import urlparse
-from io import BlockingIOError
 import inspect
+from io import BlockingIOError
+import locale
+import math
+import os
 import pkg_resources
 import platform
-
+from random import uniform
+from urlparse import urlparse
 
 if not platform.system() == 'Windows':
     import fcntl

--- a/digits/utils/__init__.py
+++ b/digits/utils/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os
 import math

--- a/digits/utils/auth.py
+++ b/digits/utils/auth.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import flask
 import functools

--- a/digits/utils/filesystem.py
+++ b/digits/utils/filesystem.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os.path, shutil
 

--- a/digits/utils/filesystem.py
+++ b/digits/utils/filesystem.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os.path, shutil
+import os.path
+import shutil
 
 def get_tree_size(start_path):
     """

--- a/digits/utils/forms.py
+++ b/digits/utils/forms.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from wtforms import validators
 from werkzeug.datastructures import FileStorage
 import wtforms
 from wtforms import SubmitField
+from wtforms import validators
+
 from digits.utils.routing import get_request_arg
 
 def validate_required_iff(**kwargs):

--- a/digits/utils/forms.py
+++ b/digits/utils/forms.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from wtforms import validators
 from werkzeug.datastructures import FileStorage

--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import os.path
-
-import requests
 import cStringIO
-import PIL.Image
-import numpy as np
-import scipy.misc
 import math
+import os.path
+import requests
+
+import numpy as np
+import PIL.Image
+import scipy.misc
 
 from . import is_url, HTTP_TIMEOUT, errors
 

--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import os.path
 

--- a/digits/utils/routing.py
+++ b/digits/utils/routing.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import flask
 import werkzeug.exceptions

--- a/digits/utils/test_filesystem.py
+++ b/digits/utils/test_filesystem.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import tempfile
-from nose.tools import assert_raises
 import os
-import shutil
-from . import filesystem as fs
 import random
+import shutil
+import tempfile
+
+from nose.tools import assert_raises
+
+from . import filesystem as fs
 
 class TestTreeSize():
 

--- a/digits/utils/test_filesystem.py
+++ b/digits/utils/test_filesystem.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import tempfile
 from nose.tools import assert_raises

--- a/digits/utils/test_image.py
+++ b/digits/utils/test_image.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import tempfile
 import StringIO

--- a/digits/utils/test_image.py
+++ b/digits/utils/test_image.py
@@ -1,17 +1,18 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import tempfile
-import StringIO
-
-from nose.tools import assert_raises
-import mock
-import PIL.Image
-import numpy as np
 import os
 import platform
+import StringIO
+import tempfile
 
-from . import image as _, errors
+import mock
+from nose.tools import assert_raises
+import numpy as np
+import PIL.Image
+
+from . import errors
+from . import image as _
 
 class TestLoadImage():
 

--- a/digits/utils/test_time_filters.py
+++ b/digits/utils/test_time_filters.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from digits import utils
-import time, re
+import re
+import time
 
 from nose.tools import assert_raises
+
+from digits import utils
 
 class TestTimeFilters():
     def test_print_time(self):

--- a/digits/utils/test_time_filters.py
+++ b/digits/utils/test_time_filters.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 from digits import utils
 import time, re

--- a/digits/utils/test_utils.py
+++ b/digits/utils/test_utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import nose
 import pkg_resources

--- a/digits/utils/test_utils.py
+++ b/digits/utils/test_utils.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import nose
 import pkg_resources
 import unittest
+
+import nose
 
 from . import parse_version
 

--- a/digits/utils/time_filters.py
+++ b/digits/utils/time_filters.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import time
 

--- a/digits/views.py
+++ b/digits/views.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import json
 import traceback
@@ -12,10 +13,10 @@ from flask.ext.socketio import join_room, leave_room
 
 import digits
 from digits import dataset, model, utils
-from config import config_value
-from webapp import app, socketio, scheduler
-import dataset.views
-import model.views
+from .config import config_value
+from .webapp import app, socketio, scheduler
+from .dataset import views as _
+from .model import views as _
 from digits.utils.routing import request_wants_json
 from digits.log import logger
 

--- a/digits/views.py
+++ b/digits/views.py
@@ -1,24 +1,24 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import json
-import traceback
 import glob
+import json
 import platform
+import traceback
 
 import flask
+from flask.ext.socketio import join_room, leave_room
 from werkzeug import HTTP_STATUS_CODES
 import werkzeug.exceptions
-from flask.ext.socketio import join_room, leave_room
 
-import digits
-from digits import dataset, model, utils
 from .config import config_value
-from .webapp import app, socketio, scheduler
 from .dataset import views as _
 from .model import views as _
-from digits.utils.routing import request_wants_json
+from .webapp import app, socketio, scheduler
+import digits
+from digits import dataset, model, utils
 from digits.log import logger
+from digits.utils.routing import request_wants_json
 
 @app.route('/index.json', methods=['GET'])
 @app.route('/', methods=['GET'])

--- a/digits/webapp.py
+++ b/digits/webapp.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
 
 import flask
 from flask.ext.socketio import SocketIO
 
 from digits import utils
-from config import config_value
+from .config import config_value
 import digits.scheduler
 
 ### Create Flask, Scheduler and SocketIO objects

--- a/digits/webapp.py
+++ b/digits/webapp.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import
 import flask
 from flask.ext.socketio import SocketIO
 
-from digits import utils
 from .config import config_value
+from digits import utils
 import digits.scheduler
 
 ### Create Flask, Scheduler and SocketIO objects

--- a/examples/classification/example.py
+++ b/examples/classification/example.py
@@ -11,10 +11,10 @@ import argparse
 import os
 import time
 
-import PIL.Image
-import numpy as np
-import scipy.misc
 from google.protobuf import text_format
+import numpy as np
+import PIL.Image
+import scipy.misc
 
 os.environ['GLOG_minloglevel'] = '2' # Suppress most caffe output
 import caffe

--- a/examples/classification/use_archive.py
+++ b/examples/classification/use_archive.py
@@ -7,10 +7,10 @@ Classify an image using a model archive file
 
 import argparse
 import os
-import time
-import zipfile
 import tarfile
 import tempfile
+import time
+import zipfile
 
 from example import classify
 

--- a/examples/siamese/create_db.py
+++ b/examples/siamese/create_db.py
@@ -5,18 +5,18 @@ Functions for creating temporary LMDBs
 Used in test_views
 """
 
-import os
-import sys
-import time
 import argparse
 from collections import defaultdict
 from cStringIO import StringIO
-import re
+import os
 import random
+import re
+import sys
+import time
 
+import lmdb
 import numpy as np
 import PIL.Image
-import lmdb
 
 if __name__ == '__main__':
     dirname = os.path.dirname(os.path.realpath(__file__))

--- a/tools/analyze_db.py
+++ b/tools/analyze_db.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python2
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import sys
-import os.path
-import time
 import argparse
+from collections import Counter
 import logging
 import operator
-from collections import Counter
+import os.path
+import sys
+import time
 
 import lmdb
 

--- a/tools/create_db.py
+++ b/tools/create_db.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python2
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import sys
-import os
-import time
 import argparse
+from collections import Counter
+from cStringIO import StringIO
 import logging
+import math
+import os
+import Queue
+import random
 import re
 import shutil
-import math
-import random
-from collections import Counter
+import sys
 import threading
-import Queue
+import time
+
+import h5py
+import lmdb
+import numpy as np
+import PIL.Image
 
 # Add path for DIGITS package
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -20,11 +26,6 @@ import digits.config
 digits.config.load_config()
 from digits import utils, log
 
-import numpy as np
-import PIL.Image
-import lmdb
-import h5py
-from cStringIO import StringIO
 # must call digits.config.load_config() before caffe to set the path
 import caffe.io
 import caffe_pb2

--- a/tools/download_data/cifar10.py
+++ b/tools/download_data/cifar10.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
+import cPickle
 import os
 import tarfile
-import cPickle
+
 import PIL.Image
 
 from downloader import DataDownloader

--- a/tools/download_data/cifar100.py
+++ b/tools/download_data/cifar100.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
+import cPickle
 import os
 import tarfile
-import cPickle
+
 import PIL.Image
 
 from downloader import DataDownloader

--- a/tools/download_data/main.py
+++ b/tools/download_data/main.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python2
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
+import argparse
 import sys
 import time
-import argparse
 
-from mnist import MnistDownloader
 from cifar10 import Cifar10Downloader
 from cifar100 import Cifar100Downloader
+from mnist import MnistDownloader
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Download-Data tool - DIGITS')

--- a/tools/download_data/mnist.py
+++ b/tools/download_data/mnist.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import os
 import gzip
+import os
 import struct
+
 import numpy as np
 import PIL.Image
 

--- a/tools/parse_folder.py
+++ b/tools/parse_folder.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python2
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import sys
-import os
-import re
 import argparse
-import time
 import logging
+import os
 import random
-import urllib
-
 import requests
+import re
+import sys
+import time
+import urllib
 
 # Add path for DIGITS package
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tools/resize_image.py
+++ b/tools/resize_image.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python2
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import sys
-import os
 import argparse
 import logging
+import os
+import sys
 
 import PIL.Image
 

--- a/tools/test_analyze_db.py
+++ b/tools/test_analyze_db.py
@@ -4,13 +4,12 @@ import os.path
 import shutil
 import tempfile
 
+import caffe.io
+import caffe_pb2
 import lmdb
 import numpy as np
 
 from . import analyze_db as _
-
-import caffe.io
-import caffe_pb2
 
 
 class BaseTestWithDB(object):

--- a/tools/test_create_db.py
+++ b/tools/test_create_db.py
@@ -1,19 +1,18 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import os.path
-import tempfile
-import shutil
-from cStringIO import StringIO
-import unittest
-import platform
-import Queue
 from collections import Counter
+from cStringIO import StringIO
+import os.path
+import platform
 import shutil
+import tempfile
+import unittest
+import Queue
 
-import nose.tools
 import mock
-import PIL.Image
+import nose.tools
 import numpy as np
+import PIL.Image
 
 from . import create_db as _
 

--- a/tools/test_parse_folder.py
+++ b/tools/test_parse_folder.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import os
-import tempfile
-import shutil
 import itertools
+import os
 import platform
+import shutil
+import tempfile
 
-from nose.tools import raises, assert_raises
 import mock
+from nose.tools import raises, assert_raises
 import numpy as np
 import PIL.Image
 

--- a/tools/test_resize_image.py
+++ b/tools/test_resize_image.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
-import os
 import mock
+import os
 import stat
 import tempfile
 


### PR DESCRIPTION
This is a noop change. It simply improves the coding style, which should make development a bit easier.

1. Use `absolute_import` - [PEP 328](https://www.python.org/dev/peps/pep-0328/#rationale-for-absolute-imports)
  * Improves readability of imports
  * Allows us to name files with standard library names if we want (like `utils.logging`, for example)
  * Required if we ever want to upgrade to Python3

2. Alphabetize and re-order imports - [PEP 8](https://www.python.org/dev/peps/pep-0008/#imports)
  * Each import in its own, rightful place (as far as possible)
  * Should minimize merge conflicts 