### PR TITLE
Use flask blueprints to cleanup routing code

### DIFF
--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -15,10 +15,10 @@ from digits import utils
 from digits.dataset import tasks
 from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import request_wants_json, job_from_request
-from digits.webapp import app, scheduler
+from digits.webapp import scheduler
 
 
-NAMESPACE = '/datasets/images/classification'
+blueprint = flask.Blueprint(__name__, __name__)
 
 def from_folders(job, form):
     """
@@ -254,9 +254,9 @@ def from_files(job, form):
                 )
 
 
-@app.route(NAMESPACE + '/new', methods=['GET'])
+@blueprint.route('/new', methods=['GET'])
 @utils.auth.requires_login
-def image_classification_dataset_new():
+def new():
     """
     Returns a form for a new ImageClassificationDatasetJob
     """
@@ -267,10 +267,10 @@ def image_classification_dataset_new():
 
     return flask.render_template('datasets/images/classification/new.html', form=form)
 
-@app.route(NAMESPACE + '.json', methods=['POST'])
-@app.route(NAMESPACE, methods=['POST'])
+@blueprint.route('.json', methods=['POST'])
+@blueprint.route('', methods=['POST'], strict_slashes=False)
 @utils.auth.requires_login(redirect=False)
-def image_classification_dataset_create():
+def create():
     """
     Creates a new ImageClassificationDatasetJob
 
@@ -316,7 +316,7 @@ def image_classification_dataset_create():
         if request_wants_json():
             return flask.jsonify(job.json_dict())
         else:
-            return flask.redirect(flask.url_for('datasets_show', job_id=job.id()))
+            return flask.redirect(flask.url_for('digits.dataset.views.show', job_id=job.id()))
 
     except:
         if job:
@@ -329,8 +329,8 @@ def show(job):
     """
     return flask.render_template('datasets/images/classification/show.html', job=job)
 
-@app.route(NAMESPACE + '/summary', methods=['GET'])
-def image_classification_dataset_summary():
+@blueprint.route('/summary', methods=['GET'])
+def summary():
     """
     Return a short HTML summary of a DatasetJob
     """
@@ -364,8 +364,8 @@ class DbReader(object):
             for item in cursor:
                 yield item
 
-@app.route(NAMESPACE + '/explore', methods=['GET'])
-def image_classification_dataset_explore():
+@blueprint.route('/explore', methods=['GET'])
+def explore():
     """
     Returns a gallery consisting of the images of one of the dbs
     """

--- a/digits/dataset/images/generic/views.py
+++ b/digits/dataset/images/generic/views.py
@@ -11,11 +11,11 @@ from digits.webapp import app, scheduler
 from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import request_wants_json, job_from_request
 
-NAMESPACE = '/datasets/images/generic'
+blueprint = flask.Blueprint(__name__, __name__)
 
-@app.route(NAMESPACE + '/new', methods=['GET'])
+@blueprint.route('/new', methods=['GET'])
 @utils.auth.requires_login
-def generic_image_dataset_new():
+def new():
     """
     Returns a form for a new GenericImageDatasetJob
     """
@@ -26,10 +26,10 @@ def generic_image_dataset_new():
 
     return flask.render_template('datasets/images/generic/new.html', form=form)
 
-@app.route(NAMESPACE + '.json', methods=['POST'])
-@app.route(NAMESPACE, methods=['POST'])
+@blueprint.route('.json', methods=['POST'])
+@blueprint.route('', methods=['POST'], strict_slashes=False)
 @utils.auth.requires_login(redirect=False)
-def generic_image_dataset_create():
+def create():
     """
     Creates a new GenericImageDatasetJob
 
@@ -107,7 +107,7 @@ def generic_image_dataset_create():
         if request_wants_json():
             return flask.jsonify(job.json_dict())
         else:
-            return flask.redirect(flask.url_for('datasets_show', job_id=job.id()))
+            return flask.redirect(flask.url_for('digits.dataset.views.show', job_id=job.id()))
 
     except:
         if job:
@@ -120,8 +120,8 @@ def show(job):
     """
     return flask.render_template('datasets/images/generic/show.html', job=job)
 
-@app.route(NAMESPACE + '/summary', methods=['GET'])
-def generic_image_dataset_summary():
+@blueprint.route('/summary', methods=['GET'])
+def summary():
     """
     Return a short HTML summary of a DatasetJob
     """

--- a/digits/dataset/images/views.py
+++ b/digits/dataset/images/views.py
@@ -7,16 +7,14 @@ import os.path
 import flask
 import PIL.Image
 
-from .classification import views as _
-from .generic import views as _
 import digits
 from digits import utils
 from digits.webapp import app
 
-NAMESPACE = '/datasets/images'
+blueprint = flask.Blueprint(__name__, __name__)
 
-@app.route(NAMESPACE + '/resize-example', methods=['POST'])
-def image_dataset_resize_example():
+@blueprint.route('/resize-example', methods=['POST'])
+def resize_example():
     """
     Resizes the example image, and returns it as a string of png data
     """

--- a/digits/dataset/views.py
+++ b/digits/dataset/views.py
@@ -5,15 +5,14 @@ import flask
 import werkzeug.exceptions
 
 from . import images as dataset_images
-from .images import views
 from digits.utils.routing import request_wants_json
 from digits.webapp import app, scheduler
 
-NAMESPACE = '/datasets/'
+blueprint = flask.Blueprint(__name__, __name__)
 
-@app.route(NAMESPACE + '<job_id>.json', methods=['GET'])
-@app.route(NAMESPACE + '<job_id>', methods=['GET'])
-def datasets_show(job_id):
+@blueprint.route('/<job_id>.json', methods=['GET'])
+@blueprint.route('/<job_id>', methods=['GET'])
+def show(job_id):
     """
     Show a DatasetJob
 

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -23,11 +23,11 @@ from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler
 
-NAMESPACE   = '/models/images/classification'
+blueprint = flask.Blueprint(__name__, __name__)
 
-@app.route(NAMESPACE + '/new', methods=['GET'])
+@blueprint.route('/new', methods=['GET'])
 @utils.auth.requires_login
-def image_classification_model_new():
+def new():
     """
     Return a form for a new ImageClassificationModelJob
     """
@@ -50,10 +50,10 @@ def image_classification_model_new():
             multi_gpu = config_value('caffe_root')['multi_gpu'],
             )
 
-@app.route(NAMESPACE + '.json', methods=['POST'])
-@app.route(NAMESPACE, methods=['POST'])
+@blueprint.route('.json', methods=['POST'])
+@blueprint.route('', methods=['POST'], strict_slashes=False)
 @utils.auth.requires_login(redirect=False)
-def image_classification_model_create():
+def create():
     """
     Create a new ImageClassificationModelJob
 
@@ -224,7 +224,7 @@ def image_classification_model_create():
         if request_wants_json():
             return flask.jsonify(job.json_dict())
         else:
-            return flask.redirect(flask.url_for('models_show', job_id=job.id()))
+            return flask.redirect(flask.url_for('digits.model.views.show', job_id=job.id()))
 
     except:
         if job:
@@ -237,8 +237,8 @@ def show(job):
     """
     return flask.render_template('models/images/classification/show.html', job=job, framework_ids = [fw.get_id() for fw in frameworks.get_frameworks()])
 
-@app.route(NAMESPACE + '/large_graph', methods=['GET'])
-def image_classification_model_large_graph():
+@blueprint.route('/large_graph', methods=['GET'])
+def large_graph():
     """
     Show the loss/accuracy graph, but bigger
     """
@@ -246,9 +246,9 @@ def image_classification_model_large_graph():
 
     return flask.render_template('models/images/classification/large_graph.html', job=job)
 
-@app.route(NAMESPACE + '/classify_one.json', methods=['POST'])
-@app.route(NAMESPACE + '/classify_one', methods=['POST', 'GET'])
-def image_classification_model_classify_one():
+@blueprint.route('/classify_one.json', methods=['POST'])
+@blueprint.route('/classify_one', methods=['POST', 'GET'])
+def classify_one():
     """
     Classify one image and return the top 5 classifications
 
@@ -303,9 +303,9 @@ def image_classification_model_classify_one():
                 total_parameters= sum(v['param_count'] for v in visualizations if v['vis_type'] == 'Weights'),
                 )
 
-@app.route(NAMESPACE + '/classify_many.json', methods=['POST'])
-@app.route(NAMESPACE + '/classify_many', methods=['POST', 'GET'])
-def image_classification_model_classify_many():
+@blueprint.route('/classify_many.json', methods=['POST'])
+@blueprint.route('/classify_many', methods=['POST', 'GET'])
+def classify_many():
     """
     Classify many images and return the top 5 classifications for each
 
@@ -388,8 +388,8 @@ def image_classification_model_classify_many():
                 ground_truths   = ground_truths
                 )
 
-@app.route(NAMESPACE + '/top_n', methods=['POST'])
-def image_classification_model_top_n():
+@blueprint.route('/top_n', methods=['POST'])
+def top_n():
     """
     Classify many images and show the top N images per category by confidence
     """

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -20,11 +20,11 @@ from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import app, scheduler
 
-NAMESPACE   = '/models/images/generic'
+blueprint = flask.Blueprint(__name__, __name__)
 
-@app.route(NAMESPACE + '/new', methods=['GET'])
+@blueprint.route('/new', methods=['GET'])
 @utils.auth.requires_login
-def generic_image_model_new():
+def new():
     """
     Return a form for a new GenericImageModelJob
     """
@@ -46,10 +46,10 @@ def generic_image_model_new():
             multi_gpu = config_value('caffe_root')['multi_gpu'],
             )
 
-@app.route(NAMESPACE + '.json', methods=['POST'])
-@app.route(NAMESPACE, methods=['POST'])
+@blueprint.route('.json', methods=['POST'])
+@blueprint.route('', methods=['POST'], strict_slashes=False)
 @utils.auth.requires_login(redirect=False)
-def generic_image_model_create():
+def create():
     """
     Create a new GenericImageModelJob
 
@@ -206,7 +206,7 @@ def generic_image_model_create():
         if request_wants_json():
             return flask.jsonify(job.json_dict())
         else:
-            return flask.redirect(flask.url_for('models_show', job_id=job.id()))
+            return flask.redirect(flask.url_for('digits.model.views.show', job_id=job.id()))
 
     except:
         if job:
@@ -219,8 +219,8 @@ def show(job):
     """
     return flask.render_template('models/images/generic/show.html', job=job)
 
-@app.route(NAMESPACE + '/large_graph', methods=['GET'])
-def generic_image_model_large_graph():
+@blueprint.route('/large_graph', methods=['GET'])
+def large_graph():
     """
     Show the loss/accuracy graph, but bigger
     """
@@ -228,9 +228,9 @@ def generic_image_model_large_graph():
 
     return flask.render_template('models/images/generic/large_graph.html', job=job)
 
-@app.route(NAMESPACE + '/infer_one.json', methods=['POST'])
-@app.route(NAMESPACE + '/infer_one', methods=['POST', 'GET'])
-def generic_image_model_infer_one():
+@blueprint.route('/infer_one.json', methods=['POST'])
+@blueprint.route('/infer_one', methods=['POST', 'GET'])
+def infer_one():
     """
     Infer one image
     """
@@ -278,9 +278,9 @@ def generic_image_model_infer_one():
                 total_parameters= sum(v['param_count'] for v in visualizations if v['vis_type'] == 'Weights'),
                 )
 
-@app.route(NAMESPACE + '/infer_many.json', methods=['POST'])
-@app.route(NAMESPACE + '/infer_many', methods=['POST', 'GET'])
-def generic_image_model_infer_many():
+@blueprint.route('/infer_many.json', methods=['POST'])
+@blueprint.route('/infer_many', methods=['POST', 'GET'])
+def infer_many():
     """
     Infer many images
     """

--- a/digits/model/images/views.py
+++ b/digits/model/images/views.py
@@ -1,9 +1,6 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .classification import views as _
-from .generic import views as _
-from digits.webapp import app
+import flask
 
-NAMESPACE = '/models/images'
-
+blueprint = flask.Blueprint(__name__, __name__)

--- a/digits/model/views.py
+++ b/digits/model/views.py
@@ -14,17 +14,16 @@ import werkzeug.exceptions
 from . import forms
 from . import images as model_images
 from . import ModelJob
-from .images import views as _
 import digits
 from digits import frameworks
 from digits.utils import time_filters
 from digits.utils.routing import request_wants_json
 from digits.webapp import app, scheduler
 
-NAMESPACE = '/models/'
+blueprint = flask.Blueprint(__name__, __name__)
 
-@app.route(NAMESPACE, methods=['GET'])
-def models_index():
+@blueprint.route('', methods=['GET'])
+def index():
     column_attrs = list(get_column_attrs())
     raw_jobs = [j for j in scheduler.jobs.values() if isinstance(j, ModelJob)]
 
@@ -78,9 +77,9 @@ def models_index():
         jobs=jobs,
         attrs_and_labels=attrs_and_labels)
 
-@app.route(NAMESPACE + '<job_id>.json', methods=['GET'])
-@app.route(NAMESPACE + '<job_id>', methods=['GET'])
-def models_show(job_id):
+@blueprint.route('/<job_id>.json', methods=['GET'])
+@blueprint.route('/<job_id>', methods=['GET'])
+def show(job_id):
     """
     Show a ModelJob
 
@@ -102,8 +101,8 @@ def models_show(job_id):
             raise werkzeug.exceptions.BadRequest(
                     'Invalid job type')
 
-@app.route(NAMESPACE + 'customize', methods=['POST'])
-def models_customize():
+@blueprint.route('/customize', methods=['POST'])
+def customize():
     """
     Returns a customized file for the ModelJob based on completed form fields
     """
@@ -142,8 +141,8 @@ def models_customize():
             'snapshot': snapshot
             })
 
-@app.route(NAMESPACE + 'visualize-network', methods=['POST'])
-def models_visualize_network():
+@blueprint.route('/visualize-network', methods=['POST'])
+def visualize_network():
     """
     Returns a visualization of the custom network as a string of PNG data
     """
@@ -156,8 +155,8 @@ def models_visualize_network():
 
     return ret
 
-@app.route(NAMESPACE + 'visualize-lr', methods=['POST'])
-def models_visualize_lr():
+@blueprint.route('/visualize-lr', methods=['POST'])
+def visualize_lr():
     """
     Returns a JSON object of data used to create the learning rate graph
     """
@@ -206,12 +205,12 @@ def models_visualize_lr():
 
     return json.dumps({'data': {'columns': [data]}})
 
-@app.route(NAMESPACE + '<job_id>/download',
+@blueprint.route('/<job_id>/download',
         methods=['GET', 'POST'],
         defaults={'extension': 'tar.gz'})
-@app.route(NAMESPACE + '<job_id>/download.<extension>',
+@blueprint.route('/<job_id>/download.<extension>',
         methods=['GET', 'POST'])
-def models_download(job_id, extension):
+def download(job_id, extension):
     """
     Return a tarball of all files required to run the model
     """

--- a/digits/templates/datasets/images/classification/explore.html
+++ b/digits/templates/datasets/images/classification/explore.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{ url_for('show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
+<li class="active"><a href="{{ url_for('digits.views.show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
 {% endblock %}
 
 {% block content %}

--- a/digits/templates/datasets/images/classification/new.html
+++ b/digits/templates/datasets/images/classification/new.html
@@ -11,7 +11,7 @@ New Image Classification Dataset
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{url_for('image_classification_dataset_new')}}">New Dataset</a></li>
+<li class="active"><a href="{{url_for('digits.dataset.images.classification.views.new')}}">New Dataset</a></li>
 {% endblock %}
 
 {% block content %}
@@ -20,7 +20,7 @@ New Image Classification Dataset
     <h1>New Image Classification Dataset</h1>
 </div>
 
-<form action="{{url_for('image_classification_dataset_create')}}" enctype="multipart/form-data" method="post">
+<form action="{{url_for('digits.dataset.images.classification.views.create')}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
     {{ print_errors(form) }}
@@ -68,7 +68,7 @@ New Image Classification Dataset
 function showResizeExample()
 {
     $.post(
-            "{{url_for('image_dataset_resize_example')}}",
+            "{{url_for('digits.dataset.images.views.resize_example')}}",
             {
                 "channels": $("#resize_channels").val(),
                 "width":    $("#resize_width").val(),

--- a/digits/templates/datasets/images/classification/show.html
+++ b/digits/templates/datasets/images/classification/show.html
@@ -78,10 +78,10 @@
 <div class="panel-body">
     <dl>
         <dt>Input File{{' (before shuffling)' if task.shuffle }}</dt>
-        <dd><a href="{{url_for('serve_file', path=task.path(task.input_file, relative=True))}}">{{task.input_file}}</a></dd>
+        <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.input_file, relative=True))}}">{{task.input_file}}</a></dd>
         {% if task.create_db_log_file %}
         <dt>DB Creation log file</dt>
-        <dd><a href="{{url_for('serve_file', path=task.path(task.create_db_log_file, relative=True))}}">{{task.create_db_log_file}}</a></dd>
+        <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.create_db_log_file, relative=True))}}">{{task.create_db_log_file}}</a></dd>
         {% endif %}
         {% if task.entries_count %}
         <dt>DB Entries</dt>
@@ -109,14 +109,14 @@
     {% if task.status=='D' and task.mean_file %}
         <script>
             displayMeanImage("{{task.html_id()}}",
-                "{{url_for('serve_file', path=task.path('mean.jpg', relative=True))}}");
+                "{{url_for('digits.views.serve_file', path=task.path('mean.jpg', relative=True))}}");
         </script>
     {% endif %}
 
     {# Exploration #}
     {% if task.backend=='lmdb' %}
         <div class="exploration" style="display:none;">
-            <a href="{{url_for('image_classification_dataset_explore', job_id=job.id(), db=task.db_name.lower())}}" class="btn btn-primary">Explore the db</a>
+            <a href="{{url_for('digits.dataset.images.classification.views.explore', job_id=job.id(), db=task.db_name.lower())}}" class="btn btn-primary">Explore the db</a>
         </div>
         {% if task.status=='D' %}
             <script>

--- a/digits/templates/datasets/images/classification/summary.html
+++ b/digits/templates/datasets/images/classification/summary.html
@@ -1,7 +1,7 @@
 {# Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
 <h4>
-    <a href="{{url_for('show_job', job_id=dataset.id())}}" target="_blank">
+    <a href="{{url_for('digits.views.show_job', job_id=dataset.id())}}" target="_blank">
         {{dataset.name()}}
     </a>
 </h4>

--- a/digits/templates/datasets/images/generic/new.html
+++ b/digits/templates/datasets/images/generic/new.html
@@ -11,7 +11,7 @@ New Image Dataset
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{url_for('generic_image_dataset_new')}}">New Dataset</a></li>
+<li class="active"><a href="{{url_for('digits.dataset.images.generic.views.new')}}">New Dataset</a></li>
 {% endblock %}
 
 {% block content %}
@@ -19,7 +19,7 @@ New Image Dataset
     <h1>New Image Dataset</h1>
 </div>
 
-<form action="{{url_for('generic_image_dataset_create')}}" enctype="multipart/form-data" method="post">
+<form action="{{url_for('digits.dataset.images.generic.views.create')}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
     {{ print_errors(form) }}

--- a/digits/templates/datasets/images/generic/show.html
+++ b/digits/templates/datasets/images/generic/show.html
@@ -30,7 +30,7 @@
         </dd>
         {% if task.analyze_db_log_file %}
         <dt>DB analysis log file</dt>
-        <dd><a href="{{url_for('serve_file', path=task.path(task.analyze_db_log_file, relative=True))}}">{{task.analyze_db_log_file}}</a></dd>
+        <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.analyze_db_log_file, relative=True))}}">{{task.analyze_db_log_file}}</a></dd>
         {% endif %}
     </dl>
 </div>

--- a/digits/templates/datasets/images/generic/summary.html
+++ b/digits/templates/datasets/images/generic/summary.html
@@ -1,7 +1,7 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
 <h4>
-    <a href="{{url_for('show_job', job_id=dataset.id())}}" target="_blank">
+    <a href="{{url_for('digits.views.show_job', job_id=dataset.id())}}" target="_blank">
         {{dataset.name()}}
     </a>
 </h4>

--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -66,7 +66,7 @@ function deleteJob(job_id) {
     <div class="tab-pane{{' active' if loop.index==1}}" id="completed-datasets-page-{{loop.index}}">
         <ul class="list-group" id="datasets">
             {% for job in batch %}
-            {% set show_func = 'datasets_show' %}
+            {% set show_func = 'digits.dataset.views.show' %}
             {% set badge = job.train_db_task().backend %}
             {% include 'job_item.html' %}
             {% else %}
@@ -114,7 +114,7 @@ function deleteJob(job_id) {
 <h2>
     Models
     <small>
-        <a href="{{ url_for('models_index') }}">View details</a>
+        <a href="{{ url_for('digits.model.views.index') }}">View details</a>
     </small>
 </h2>
 
@@ -123,7 +123,7 @@ function deleteJob(job_id) {
     <div class="tab-pane{{' active' if loop.index==1}}" id="completed-models-page-{{loop.index}}">
     <ul class="list-group" id="models">
         {% for job in batch %}
-        {% set show_func = 'models_show' %}
+        {% set show_func = 'digits.model.views.show' %}
         {% set badge = job.train_task().get_framework_id() %}
         {% include 'job_item.html' %}
         {% else %}

--- a/digits/templates/job.html
+++ b/digits/templates/job.html
@@ -82,7 +82,7 @@ socket.on('task update', function (msg) {
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{ url_for('show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
+<li class="active"><a href="{{ url_for('digits.views.show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
 {% endblock %}
 
 {% block content %}
@@ -99,7 +99,7 @@ socket.on('task update', function (msg) {
                 <script>
 function updateJobName() {
     var newName = $("input[name=job-name]").val();
-    $.ajax("{{url_for('edit_job', job_id=job.id())}}",
+    $.ajax("{{url_for('digits.views.edit_job', job_id=job.id())}}",
             {
                 type: "PUT",
                 data: {"job_name": newName}
@@ -123,7 +123,7 @@ function updateJobName() {
         {% endif %}
         <div class="pull-right">
             {% if job.form_data is defined %}
-            <a id="clone-job" class="btn btn-info" href="{{url_for('clone_job', clone=job.id())}}">Clone Job</a>
+            <a id="clone-job" class="btn btn-info" href="{{url_for('digits.views.clone_job', clone=job.id())}}">Clone Job</a>
             {% else %}
             <a id="clone-job" class="btn btn-info" disabled>Clone Job</a>
             {% endif %}
@@ -138,7 +138,7 @@ $('#abort-job').on('click', function(event) {
             'Are you sure you want to abort this job?',
             function(result) {
                 if (result)
-                    $.ajax("{{url_for('abort_job', job_id=job.id())}}",
+                    $.ajax("{{url_for('digits.views.abort_job', job_id=job.id())}}",
                         {type: "POST"})
                     .done(function() {
                         $("#abort-job").hide();
@@ -153,10 +153,10 @@ $('#delete-job').on('click', function(event) {
             'Are you sure you want to delete this job?<br><br>All related files will be permanently removed.',
             function(result) {
                 if (result)
-                    $.ajax("{{url_for('delete_job', job_id=job.id())}}",
+                    $.ajax("{{url_for('digits.views.delete_job', job_id=job.id())}}",
                         {type: "DELETE"})
                     .done(function() {
-                        window.location = "{{url_for('home')}}";
+                        window.location = "{{url_for('digits.views.home')}}";
                         })
                     .fail(function(data) { errorAlert(data); });
             });
@@ -249,7 +249,7 @@ $('#delete-job').on('click', function(event) {
                     <script type="text/javascript">
                         function updateJobNotes() {
                         var newNotes = $("textarea[name=job-notes]").val();
-                        $.ajax("{{url_for('edit_job', job_id=job.id())}}",
+                        $.ajax("{{url_for('digits.views.edit_job', job_id=job.id())}}",
                                 {
                                     type: "PUT",
                                     data: {"job_notes": newNotes}

--- a/digits/templates/job_row.html
+++ b/digits/templates/job_row.html
@@ -3,9 +3,9 @@
 {% if job.job_type() != 'Job For Testing' %}
 {# Base the choice between models_show and datasets_show on the last work in the job_type. This is fragile. #}
 {%     set list = job.job_type().split(' ') %}
-{%     set show_func = 'models_show' if list[-1] == 'Model' else 'datasets_show' %}
+{%     set show_func = 'digits.model.views.show' if list[-1] == 'Model' else 'digits.dataset.views.show' %}
 {%     set show_url = url_for(show_func, job_id=job.id()) %}
-{%     set abort_url = url_for("abort_job", job_id=job.id()) %}
+{%     set abort_url = url_for('digits.views.abort_job', job_id=job.id()) %}
 {% else %}
 {%     set show_url = '' %}
 {%     set abort_url = '' %}

--- a/digits/templates/models/images/classification/classify_many.html
+++ b/digits/templates/models/images/classification/classify_many.html
@@ -2,7 +2,7 @@
 {% extends "layout.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('models_show', job_id=job.id())}}">{{job.name()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.name()}}</a></li>
 <li class="active"><a>Classify Many</a></li>
 {% endblock %}
 

--- a/digits/templates/models/images/classification/classify_one.html
+++ b/digits/templates/models/images/classification/classify_one.html
@@ -2,7 +2,7 @@
 {% extends "layout.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('models_show', job_id=job.id())}}">{{job.name()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.name()}}</a></li>
 <li class="active"><a>Classify One</a></li>
 {% endblock %}
 

--- a/digits/templates/models/images/classification/large_graph.html
+++ b/digits/templates/models/images/classification/large_graph.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{ url_for('show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
+<li class="active"><a href="{{ url_for('digits.views.show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
 {% endblock %}
 
 {% block content %}

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -11,7 +11,7 @@ New Image Classification Model
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{url_for('image_classification_model_new')}}">New Model</a></li>
+<li class="active"><a href="{{url_for('digits.model.images.classification.views.new')}}">New Model</a></li>
 {% endblock %}
 
 {% block content %}
@@ -19,7 +19,7 @@ New Image Classification Model
     <h1>New Image Classification Model</h1>
 </div>
 
-<form id="model-form" action="{{url_for('image_classification_model_create')}}" enctype="multipart/form-data" method="post">
+<form id="model-form" action="{{url_for('digits.model.images.classification.views.create')}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
     {{ print_errors(form) }}
@@ -313,7 +313,7 @@ showHideAdvancedLROptions();
                             }));
                         }
                         function getLRGraph() {
-                            $.ajax("{{url_for('models_visualize_lr')}}",
+                            $.ajax("{{url_for('digits.model.views.visualize_lr')}}",
                             {
                                 type: "POST",
                                 data: $(".learning-rate-option").serialize()
@@ -348,7 +348,7 @@ function customizeNetwork(network, snapshot_list, framework) {
         data = null;
         if (snapshot_list)
             data = {'snapshot_epoch': $('#'+snapshot_list).val()};
-        $.ajax("{{url_for('models_customize')}}?network=" + network+"&framework="+framework,
+        $.ajax("{{url_for('digits.model.views.customize')}}?network=" + network+"&framework="+framework,
                 {
                     type: "POST",
                     data: data
@@ -501,7 +501,7 @@ function setFramework(fwid)
                                     <td>
                                         {{network}}
                                         {{network.label}}
-                                        <a href="{{url_for("models_show", job_id=network.data)}}" target="_blank">View</a>
+                                        <a href="{{url_for('digits.model.views.show', job_id=network.data)}}" target="_blank">View</a>
                                         <span class="badge">{{previous_job.train_task().get_framework_id()}}</span>
                                     </td>
                                     <td>
@@ -597,7 +597,7 @@ function setFramework(fwid)
 
 function visualizeNetwork() {
     framework = $('#framework').val();
-    $.ajax("{{url_for('models_visualize_network')}}?framework="+framework,
+    $.ajax("{{url_for('digits.model.views.visualize_network')}}?framework="+framework,
         {
             type: "POST",
             data: $('#custom_network').serialize()

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -18,11 +18,11 @@
                 <dd>{{job.disk_size_fmt()}}</dd>
                 {% for key,value in task.get_model_files().items() %}
                 <dt>{{key}}</dt>
-                <dd><a href="{{url_for('serve_file', path=task.path(value, relative=True))}}">{{value}}</a></dd>
+                <dd><a href="{{url_for('digits.views.serve_file', path=task.path(value, relative=True))}}">{{value}}</a></dd>
                 {% endfor %}
                 {% if task.log_file %}
                 <dt>Raw {{task.get_framework_id()}} output</dt>
-                <dd><a href="{{url_for('serve_file', path=task.path(task.log_file, relative=True))}}">{{task.log_file}}</a></dd>
+                <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.log_file, relative=True))}}">{{task.log_file}}</a></dd>
                 {% endif %}
                 {% if task.pretrained_model %}
                 <dt>Pretrained Model</dt>
@@ -56,7 +56,7 @@
                                 ></span>
             <div class="pull-right combined-graph" style="display:none;">
                 <a class="btn btn-primary btn-sm" target="_blank"
-                    href="{{url_for('image_classification_model_large_graph', job_id=job.id())}}">
+                    href="{{url_for('digits.model.images.classification.views.large_graph', job_id=job.id())}}">
                     View Large
                 </a>
             </div>
@@ -129,7 +129,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                     </div>
                     <div class="col-sm-4">
                         <button
-                            formaction="{{url_for('models_download', job_id=job.id())}}"
+                            formaction="{{url_for('digits.model.views.download', job_id=job.id())}}"
                             formmethod="post"
                             formenctype="multipart/form-data"
                             class="btn btn-info">
@@ -166,7 +166,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                                 ></span>
                         </div>
                         <button name="classify-one-btn"
-                            formaction="{{url_for('image_classification_model_classify_one', job_id=job.id())}}"
+                            formaction="{{url_for('digits.model.images.classification.views.classify_one', job_id=job.id())}}"
                             formmethod="post"
                             formenctype="multipart/form-data"
                             formtarget="_blank"
@@ -182,7 +182,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             <small>Accepts a list of filenames or urls (you can use your val.txt file)</small>
                         </div>
                         <button name="classify-many-btn"
-                            formaction="{{url_for('image_classification_model_classify_many', job_id=job.id())}}"
+                            formaction="{{url_for('digits.model.images.classification.views.classify_many', job_id=job.id())}}"
                             formmethod="post"
                             formenctype="multipart/form-data"
                             formtarget="_blank"
@@ -204,7 +204,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             <input type="text" id="top_n" name="top_n" class="form-control" placeholder="9">
                         </div>
                         <button name="top-n-btn"
-                            formaction="{{url_for('image_classification_model_top_n', job_id=job.id())}}"
+                            formaction="{{url_for('digits.model.images.classification.views.top_n', job_id=job.id())}}"
                             formmethod="post"
                             formenctype="multipart/form-data"
                             formtarget="_blank"

--- a/digits/templates/models/images/classification/top_n.html
+++ b/digits/templates/models/images/classification/top_n.html
@@ -3,7 +3,7 @@
 {% extends "layout.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('models_show', job_id=job.id())}}">{{job.job_type()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.job_type()}}</a></li>
 <li class="active"><a>Top N</a></li>
 {% endblock %}
 

--- a/digits/templates/models/images/generic/infer_many.html
+++ b/digits/templates/models/images/generic/infer_many.html
@@ -2,7 +2,7 @@
 {% extends "layout.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('models_show', job_id=job.id())}}">{{job.name()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.name()}}</a></li>
 <li class="active"><a>Test Many</a></li>
 {% endblock %}
 

--- a/digits/templates/models/images/generic/infer_one.html
+++ b/digits/templates/models/images/generic/infer_one.html
@@ -2,7 +2,7 @@
 {% extends "layout.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('models_show', job_id=job.id())}}">{{job.name()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.name()}}</a></li>
 <li class="active"><a>Test One</a></li>
 {% endblock %}
 

--- a/digits/templates/models/images/generic/large_graph.html
+++ b/digits/templates/models/images/generic/large_graph.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{ url_for('show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
+<li class="active"><a href="{{ url_for('digits.views.show_job', job_id=job.id()) }}">{{job.job_type()}}</a></li>
 {% endblock %}
 
 {% block content %}

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -11,7 +11,7 @@ New Image Model
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{url_for('generic_image_model_new')}}">New Model</a></li>
+<li class="active"><a href="{{url_for('digits.model.images.generic.views.new')}}">New Model</a></li>
 {% endblock %}
 
 {% block content %}
@@ -19,7 +19,7 @@ New Image Model
     <h1>New Image Model</h1>
 </div>
 
-<form id="model-form" action="{{url_for('generic_image_model_create')}}" enctype="multipart/form-data" method="post">
+<form id="model-form" action="{{url_for('digits.model.images.generic.views.create')}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
     {{ print_errors(form) }}
@@ -312,7 +312,7 @@ showHideAdvancedLROptions();
                             }));
                         }
                         function getLRGraph() {
-                            $.ajax("{{url_for('models_visualize_lr')}}",
+                            $.ajax("{{url_for('digits.model.views.visualize_lr')}}",
                             {
                                 type: "POST",
                                 data: $(".learning-rate-option").serialize()
@@ -347,7 +347,7 @@ function customizeNetwork(network, snapshot_list, framework) {
         data = null;
         if (snapshot_list)
             data = {'snapshot_epoch': $('#'+snapshot_list).val()};
-        $.ajax("{{url_for('models_customize')}}?network=" + network + "&framework="+framework,
+        $.ajax("{{url_for('digits.model.views.customize')}}?network=" + network + "&framework="+framework,
                 {
                     type: "POST",
                     data: data
@@ -435,7 +435,7 @@ function setFramework(fwid)
                                     <td>
                                         {{network}}
                                         {{network.label}}
-                                        <a href="{{url_for("models_show", job_id=network.data)}}" target="_blank">View</a>
+                                        <a href="{{url_for('digits.model.views.show', job_id=network.data)}}" target="_blank">View</a>
                                         <span class="badge">{{previous_job.train_task().get_framework_id()}}</span>
                                     </td>
                                     <td>
@@ -527,7 +527,7 @@ $('#customFramework li').on('shown.bs.tab', function(e) {
 
 function visualizeNetwork() {
     framework = $('#framework').val();
-    $.ajax("{{url_for('models_visualize_network')}}?framework="+framework,
+    $.ajax("{{url_for('digits.model.views.visualize_network')}}?framework="+framework,
         {
             type: "POST",
             data: $("#custom_network").serialize()

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -18,11 +18,11 @@
                 <dd>{{job.disk_size_fmt()}}</dd>
                 {% for key,value in task.get_model_files().items() %}
                 <dt>{{key}}</dt>
-                <dd><a href="{{url_for('serve_file', path=task.path(value, relative=True))}}">{{value}}</a></dd>
+                <dd><a href="{{url_for('digits.views.serve_file', path=task.path(value, relative=True))}}">{{value}}</a></dd>
                 {% endfor %}
                 {% if task.log_file %}
                 <dt>Raw {{task.get_framework_id()}} output</dt>
-                <dd><a href="{{url_for('serve_file', path=task.path(task.log_file, relative=True))}}">{{task.log_file}}</a></dd>
+                <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.log_file, relative=True))}}">{{task.log_file}}</a></dd>
                 {% endif %}
                 {% if task.pretrained_model %}
                 <dt>Pretrained Model</dt>
@@ -50,7 +50,7 @@
                 style="height:500px;width:100%;background:white;display:none;"></div>
             <div class="pull-right combined-graph" style="display:none;">
                 <a class="btn btn-primary btn-sm" target="_blank"
-                    href="{{url_for('generic_image_model_large_graph', job_id=job.id())}}">
+                    href="{{url_for('digits.model.images.generic.views.large_graph', job_id=job.id())}}">
                     View Large
                 </a>
             </div>
@@ -123,7 +123,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                     </div>
                     <div class="col-sm-4">
                         <button
-                            formaction="{{url_for('models_download', job_id=job.id())}}"
+                            formaction="{{url_for('digits.model.views.download', job_id=job.id())}}"
                             formmethod="post"
                             formenctype="multipart/form-data"
                             class="btn btn-info">
@@ -159,7 +159,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                                 ></span>
                         </div>
                         <button name="infer-one-btn"
-                            formaction="{{url_for('generic_image_model_infer_one', job_id=job.id())}}"
+                            formaction="{{url_for('digits.model.images.generic.views.infer_one', job_id=job.id())}}"
                             formmethod="post"
                             formenctype="multipart/form-data"
                             formtarget="_blank"
@@ -175,7 +175,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             <small>Accepts a list of filenames or urls (you can use your val.txt file)</small>
                         </div>
                         <button name="infer-many-btn"
-                            formaction="{{url_for('generic_image_model_infer_many', job_id=job.id())}}"
+                            formaction="{{url_for('digits.model.images.generic.views.infer_many', job_id=job.id())}}"
                             formmethod="post"
                             formenctype="multipart/form-data"
                             formtarget="_blank"

--- a/digits/utils/auth.py
+++ b/digits/utils/auth.py
@@ -43,7 +43,7 @@ def requires_login(f=None, redirect=True):
             if request_wants_json() or not redirect:
                 raise werkzeug.exceptions.Unauthorized()
             else:
-                return flask.redirect(flask.url_for('login', next=flask.request.path))
+                return flask.redirect(flask.url_for('digits.views.login', next=flask.request.path))
         try:
             # Validate username
             validate_username(username)

--- a/digits/webapp.py
+++ b/digits/webapp.py
@@ -34,6 +34,23 @@ app.jinja_env.trim_blocks = True
 app.jinja_env.lstrip_blocks = True
 
 import digits.views
+app.register_blueprint(digits.views.blueprint)
+import digits.dataset.views
+app.register_blueprint(digits.dataset.views.blueprint, url_prefix='/datasets')
+import digits.dataset.images.views
+app.register_blueprint(digits.dataset.images.views.blueprint, url_prefix='/datasets/images')
+import digits.dataset.images.classification.views
+app.register_blueprint(digits.dataset.images.classification.views.blueprint, url_prefix='/datasets/images/classification')
+import digits.dataset.images.generic.views
+app.register_blueprint(digits.dataset.images.generic.views.blueprint, url_prefix='/datasets/images/generic')
+import digits.model.views
+app.register_blueprint(digits.model.views.blueprint, url_prefix='/models')
+import digits.model.images.views
+app.register_blueprint(digits.model.images.views.blueprint, url_prefix='/models/images')
+import digits.model.images.classification.views
+app.register_blueprint(digits.model.images.classification.views.blueprint, url_prefix='/models/images/classification')
+import digits.model.images.generic.views
+app.register_blueprint(digits.model.images.generic.views.blueprint, url_prefix='/models/images/generic')
 
 def username_decorator(f):
     from functools import wraps


### PR DESCRIPTION
> Blueprints can greatly simplify how large applications work and provide a central means for Flask extensions to register operations on applications.
http://flask.pocoo.org/docs/0.10/blueprints/

This just helps with code quality and readability. This doesn't make any changes that are externally visible in the application.
* Add routes deliberately in `webapp.py` rather than implicitly through each of the `views.py` files
* Makes the `url_for()` statements match the actual code layout more closely