### PR TITLE
Fix another import bug from #501

### DIFF
--- a/tools/test_analyze_db.py
+++ b/tools/test_analyze_db.py
@@ -5,12 +5,13 @@ import shutil
 import tempfile
 
 import caffe.io
-import caffe_pb2
 import lmdb
 import numpy as np
 
 from . import analyze_db as _
 
+# Must import after importing digits.config
+import caffe_pb2
 
 class BaseTestWithDB(object):
     SAME_SHAPE = True


### PR DESCRIPTION
Like with #508, need to import `digits.config` before importing `caffe_pb2` in order to run this test file by itself.

    ./digits-test tools/