### PR TITLE
Don't use "_" for package names in testsuite

### DIFF
--- a/digits/config/test_config_file.py
+++ b/digits/config/test_config_file.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import tempfile
 
-from . import config_file as _
+from . import config_file
 
 class TestConfigFile():
     def test_write_and_read(self):
@@ -19,14 +19,14 @@ class TestConfigFile():
         filename = None
         with tempfile.NamedTemporaryFile(suffix='cfg') as tmp:
             filename = tmp.name
-        cf1 = _.ConfigFile(filename)
+        cf1 = config_file.ConfigFile(filename)
         assert not cf1.exists(), 'tempfile already exists'
         assert cf1.can_write(), "can't write to tempfile"
 
         cf1.set(name, value)
         cf1.save()
 
-        cf2 = _.ConfigFile(filename)
+        cf2 = config_file.ConfigFile(filename)
         assert cf2.exists(), "tempfile doesn't exist"
         assert cf2.can_read(), "can't read from tempfile"
 

--- a/digits/config/test_prompt.py
+++ b/digits/config/test_prompt.py
@@ -8,31 +8,31 @@ import sys
 import mock
 from nose.tools import raises
 
-from . import prompt as _
+from . import prompt
 
 class TestValueToStr():
     def test_none(self):
         # pass none to value_to_str
-        assert _.value_to_str(None) == '', 'passing None should return an empty string'
+        assert prompt.value_to_str(None) == '', 'passing None should return an empty string'
 
     def test_nonstring(self):
         # pass a non-string value to value_to_str
-        assert _.value_to_str(1) == '1', 'passing 1 should return the string "1"'
+        assert prompt.value_to_str(1) == '1', 'passing 1 should return the string "1"'
 
 class TestSuggestion():
     @raises(ValueError)
     def test_new_bad_char_type(self):
         # pass a non-string type as char to suggestion
-        _.Suggestion(None, 1)
+        prompt.Suggestion(None, 1)
 
     @raises(ValueError)
     def test_new_bad_multichar(self):
         # pass multiple chars where one is expected
-        _.Suggestion(None, 'badvalue')
+        prompt.Suggestion(None, 'badvalue')
 
     def test_str_method(self):
         # test __str__ method of Suggestion
-        suggestion = _.Suggestion('alpha', 'a', 'test', True)
+        suggestion = prompt.Suggestion('alpha', 'a', 'test', True)
         strval = str(suggestion)
         expect = '<Suggestion char="a" desc="test" value="alpha" default>'
 
@@ -47,7 +47,7 @@ def mockInput(fn):
 
 class TestGetInput():
     def setUp(self):
-        self.suggestions = [_.Suggestion('alpha', 'a', 'test', False)]
+        self.suggestions = [prompt.Suggestion('alpha', 'a', 'test', False)]
 
     @raises(SystemExit)
     def test_get_input_sys_exit(self):
@@ -56,7 +56,7 @@ class TestGetInput():
             raise KeyboardInterrupt
 
         with mockInput(temp):
-            _.get_input('Test', lambda _: True, self.suggestions)
+            prompt.get_input('Test', lambda _: True, self.suggestions)
 
     def test_get_input_empty_then_full(self):
         # test both major paths of get_input
@@ -72,21 +72,21 @@ class TestGetInput():
                     return 'a'
 
         with mockInput(Temp()):
-            assert _.get_input('Test', lambda x: x, self.suggestions) == 'alpha', 'get_input should return "alpha" for input "a"'
+            assert prompt.get_input('Test', lambda x: x, self.suggestions) == 'alpha', 'get_input should return "alpha" for input "a"'
 
     def test_get_input_empty_default(self):
         # empty input should choose the default
         self.suggestions[0].default = True
 
         with mockInput(lambda _: ''):
-            assert _.get_input('Test', lambda x: x+'_validated', self.suggestions) == 'alpha_validated', 'get_input should return the default value "alpha"'
+            assert prompt.get_input('Test', lambda x: x+'_validated', self.suggestions) == 'alpha_validated', 'get_input should return the default value "alpha"'
 
     def test_get_input_empty_default_no_validator(self):
         # empty input should choose the default and not validate
         self.suggestions[0].default = True
 
         with mockInput(lambda _: ''):
-            assert _.get_input('Test', suggestions=self.suggestions) == 'alpha', 'get_input should return the default value "alpha"'
+            assert prompt.get_input('Test', suggestions=self.suggestions) == 'alpha', 'get_input should return the default value "alpha"'
 
     @mock.patch('os.path.expanduser')
     def test_get_input_path(self, mock_expanduser):
@@ -94,5 +94,5 @@ class TestGetInput():
         mock_expanduser.side_effect = lambda x: '/path'+x
 
         with mockInput(lambda _: '/test'):
-            assert _.get_input(validator=lambda x: x, is_path=True) == '/path/test', 'get_input should return the default value "alpha"'
+            assert prompt.get_input(validator=lambda x: x, is_path=True) == '/path/test', 'get_input should return the default value "alpha"'
 

--- a/digits/model/tasks/test_caffe_train.py
+++ b/digits/model/tasks/test_caffe_train.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from . import caffe_train as _
+from . import caffe_train
 
 def test_caffe_imports():
     import numpy

--- a/digits/test_device_query.py
+++ b/digits/test_device_query.py
@@ -6,7 +6,7 @@ import os
 import platform
 import unittest
 
-from . import device_query as _
+from . import device_query
 
 class TestGetDevices():
     """
@@ -15,14 +15,14 @@ class TestGetDevices():
     @classmethod
     def tearDownClass(cls):
         # Reload the normal list of devices
-        _.get_devices(True)
+        device_query.get_devices(True)
 
     @unittest.skipIf(platform.system() not in ['Linux', 'Darwin'],
             'Platform not supported')
     @mock.patch('digits.device_query.ctypes.cdll')
     def test_no_cudart(self, mock_cdll):
         mock_cdll.LoadLibrary.return_value = None
-        assert _.get_devices(True) == [], 'Devices found even when CUDA disabled!'
+        assert device_query.get_devices(True) == [], 'Devices found even when CUDA disabled!'
 
 
 class TestGetNvmlInfo():
@@ -31,13 +31,13 @@ class TestGetNvmlInfo():
     """
     @classmethod
     def setUpClass(cls):
-        if _.get_library('libnvidia-ml') is None:
+        if device_query.get_library('libnvidia-ml') is None:
             raise unittest.SkipTest('NVML not found')
 
-    @unittest.skipIf(len(_.get_devices(True)) == 0,
+    @unittest.skipIf(len(device_query.get_devices(True)) == 0,
             'No GPUs on system')
     def test_memory_info_exists(self):
-        for index, device in enumerate(_.get_devices(True)):
-            assert 'memory' in _.get_nvml_info(index), 'NVML should have memory information for "%s"' % device.name
+        for index, device in enumerate(device_query.get_devices(True)):
+            assert 'memory' in device_query.get_nvml_info(index), 'NVML should have memory information for "%s"' % device.name
 
 

--- a/digits/test_scheduler.py
+++ b/digits/test_scheduler.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import mock
 from nose.tools import assert_raises
 
-from . import scheduler as _
+from . import scheduler
 from .config import config_value
 from .job import Job
 from digits.utils import subclass, override
@@ -12,7 +12,7 @@ from digits.utils import subclass, override
 class TestScheduler():
 
     def get_scheduler(self):
-        return _.Scheduler(config_value('gpu_list'))
+        return scheduler.Scheduler(config_value('gpu_list'))
 
     def test_add_before_start(self):
         s = self.get_scheduler()
@@ -40,7 +40,7 @@ class TestSchedulerFlow():
 
     @classmethod
     def setUpClass(cls):
-        cls.s = _.Scheduler(config_value('gpu_list'))
+        cls.s = scheduler.Scheduler(config_value('gpu_list'))
         assert cls.s.start(), 'failed to start'
 
     @classmethod

--- a/digits/utils/test_image.py
+++ b/digits/utils/test_image.py
@@ -12,7 +12,7 @@ import numpy as np
 import PIL.Image
 
 from . import errors
-from . import image as _
+from . import image as image_utils
 
 class TestLoadImage():
 
@@ -27,7 +27,7 @@ class TestLoadImage():
     def check_none(self, path):
         assert_raises(
                 errors.LoadImageError,
-                _.load_image,
+                image_utils.load_image,
                 path,
                 )
 
@@ -60,7 +60,7 @@ class TestLoadImage():
         # temp files cause permission errors so just generate the name
         tmp = tempfile.mkstemp(suffix='.' + suffix)
         orig.save(tmp[1])
-        new = _.load_image(tmp[1])
+        new = image_utils.load_image(tmp[1])
         try:
             # sometimes on windows the file is not closed yet
             # which can cause an exception
@@ -90,7 +90,7 @@ class TestLoadImage():
         mock_Image.open = mock.Mock()
         mock_Image.open.return_value.mode = 'RGB'
 
-        assert _.load_image('http://some-url') is not None
+        assert image_utils.load_image('http://some-url') is not None
         mock_cStringIO.StringIO.assert_called_with('some content')
         mock_Image.open.assert_called_with('an object')
 
@@ -111,13 +111,13 @@ class TestLoadImage():
         fname = tempfile.mkstemp(suffix='.bin')
         f = os.fdopen(fname[0],'wb')
         fname = fname[1]
-        
+
         f.write(corrupted)
         f.close()
 
         assert_raises(
                 errors.LoadImageError,
-                _.load_image,
+                image_utils.load_image,
                 fname,
                 )
 
@@ -162,7 +162,7 @@ class TestResizeImage():
             i = self.pil_gray
         else:
             i = self.pil_color
-        r = _.resize_image(i, h, w, c, m)
+        r = image_utils.resize_image(i, h, w, c, m)
         assert r.shape == s, 'Resized PIL.Image (orig=%s) should have been %s, but was %s %s' % (i.size, s, r.shape, self.args_to_str(args))
         assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
 
@@ -173,7 +173,7 @@ class TestResizeImage():
             i = self.np_gray
         else:
             i = self.np_color
-        r = _.resize_image(i, h, w, c, m)
+        r = image_utils.resize_image(i, h, w, c, m)
         assert r.shape == s, 'Resized np.ndarray (orig=%s) should have been %s, but was %s %s' % (i.shape, s, r.shape, self.args_to_str(args))
         assert r.dtype == np.uint8, 'image.dtype should be uint8, not %s' % r.dtype
 

--- a/tools/test_analyze_db.py
+++ b/tools/test_analyze_db.py
@@ -8,7 +8,7 @@ import caffe.io
 import lmdb
 import numpy as np
 
-from . import analyze_db as _
+from . import analyze_db
 
 # Must import after importing digits.config
 import caffe_pb2
@@ -46,10 +46,10 @@ class BaseTestWithDB(object):
         return caffe.io.array_to_datum(image)
 
     def test_defaults(self):
-        assert _.analyze_db(self.db.path()) == self.PASS_DEFAULTS
+        assert analyze_db.analyze_db(self.db.path()) == self.PASS_DEFAULTS
 
     def test_force_shape(self):
-        assert _.analyze_db(self.db.path(), force_same_shape=True) == self.PASS_FORCE
+        assert analyze_db.analyze_db(self.db.path(), force_same_shape=True) == self.PASS_FORCE
 
 class TestSameShape(BaseTestWithDB):
     pass

--- a/tools/test_create_db.py
+++ b/tools/test_create_db.py
@@ -14,7 +14,7 @@ import nose.tools
 import numpy as np
 import PIL.Image
 
-from . import create_db as _
+from . import create_db
 
 class BaseTest():
     """
@@ -69,7 +69,7 @@ class TestFillLoadQueue(BaseTest):
 
     def check_valid_file(self, shuffle):
         queue = Queue.Queue()
-        result = _._fill_load_queue(self.good_file[1], queue, shuffle)
+        result = create_db._fill_load_queue(self.good_file[1], queue, shuffle)
         assert result == self.image_count, 'lines not added'
         assert queue.qsize() == self.image_count, 'queue not full'
 
@@ -80,8 +80,8 @@ class TestFillLoadQueue(BaseTest):
     def check_empty_file(self, shuffle):
         queue = Queue.Queue()
         nose.tools.assert_raises(
-                _.BadInputFileError,
-                _._fill_load_queue,
+                create_db.BadInputFileError,
+                create_db._fill_load_queue,
                 self.empty_file[1], queue, shuffle)
 
 class TestParseLine():
@@ -98,7 +98,7 @@ class TestParseLine():
 
     def check_good_line(self, line, label):
         c = Counter()
-        p, l = _._parse_line(line, c)
+        p, l = create_db._parse_line(line, c)
         assert l == label, 'parsed label wrong'
         assert c[l] == 1, 'distribution is wrong'
 
@@ -112,8 +112,8 @@ class TestParseLine():
 
     def check_bad_line(self, line):
         nose.tools.assert_raises(
-                _.ParseLineError,
-                _._parse_line,
+                create_db.ParseLineError,
+                create_db._parse_line,
                 line, Counter()
                 )
 
@@ -129,7 +129,7 @@ class TestCalculateBatchSize():
             yield self.check, count, batch_size
 
     def check(self, count, batch_size):
-        assert _._calculate_batch_size(count) == batch_size
+        assert create_db._calculate_batch_size(count) == batch_size
 
 
 class TestCalculateNumThreads():
@@ -146,18 +146,18 @@ class TestCalculateNumThreads():
             yield self.check, batch_size, shuffle, num
 
     def check(self, batch_size, shuffle, num):
-        assert _._calculate_num_threads(
+        assert create_db._calculate_num_threads(
                 batch_size, shuffle) == num
 
 
 class TestInitialImageSum():
     def test_color(self):
-        s = _._initial_image_sum(10, 10, 3)
+        s = create_db._initial_image_sum(10, 10, 3)
         assert s.shape == (10, 10, 3)
         assert s.dtype == 'float64'
 
     def test_grayscale(self):
-        s = _._initial_image_sum(10, 10, 1)
+        s = create_db._initial_image_sum(10, 10, 1)
         assert s.shape == (10, 10)
         assert s.dtype == 'float64'
 
@@ -169,14 +169,14 @@ class TestImageToDatum(BaseTest):
             yield self.check_grayscale, compression
 
     def check_color(self, compression):
-        d = _._array_to_datum(self.numpy_image_color, 1, compression)
+        d = create_db._array_to_datum(self.numpy_image_color, 1, compression)
         assert d.height == self.numpy_image_color.shape[0]
         assert d.width == self.numpy_image_color.shape[1]
         assert d.channels == 3
         assert d.encoded == bool(compression)
 
     def check_grayscale(self, compression):
-        d = _._array_to_datum(self.numpy_image_gray, 1, compression)
+        d = create_db._array_to_datum(self.numpy_image_gray, 1, compression)
         assert d.height == self.numpy_image_gray.shape[0]
         assert d.width == self.numpy_image_gray.shape[1]
         assert d.channels == 1
@@ -197,7 +197,7 @@ class TestSaveMeans():
         else:
             s = np.ones((8,10),dtype='float64')
 
-        _._save_means(s, 2, [filename])
+        create_db._save_means(s, 2, [filename])
         assert os.path.exists(filename)
 
 class BaseCreationTest(BaseTest):
@@ -208,18 +208,18 @@ class BaseCreationTest(BaseTest):
                 yield self.check_image_sizes, width, channels, False
 
     def check_image_sizes(self, width, channels, shuffle):
-        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+        create_db.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
                 width, 10, channels, self.BACKEND)
 
     def test_no_shuffle(self):
-        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+        create_db.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
                 10, 10, 1, self.BACKEND, shuffle=False)
 
     def test_means(self):
         mean_files = []
         for suffix in 'jpg','npy','png','binaryproto':
             mean_files.append(os.path.join(self.empty_dir, 'mean.%s' % suffix))
-        _.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
+        create_db.create_db(self.good_file[1], os.path.join(self.empty_dir, 'db'),
                 10, 10, 1, self.BACKEND, mean_files=mean_files)
 
 class TestLmdbCreation(BaseCreationTest):
@@ -230,7 +230,7 @@ class TestHdf5Creation(BaseCreationTest):
 
     def test_dset_limit(self):
         db_dir = os.path.join(self.empty_dir, 'db')
-        _.create_db(self.good_file[1], db_dir,
+        create_db.create_db(self.good_file[1], db_dir,
                 10, 10, 1, 'hdf5', hdf5_dset_limit=10*10)
         with open(os.path.join(db_dir, 'list.txt')) as infile:
             lines = infile.readlines()

--- a/tools/test_parse_folder.py
+++ b/tools/test_parse_folder.py
@@ -11,14 +11,14 @@ from nose.tools import raises, assert_raises
 import numpy as np
 import PIL.Image
 
-from . import parse_folder as _
+from . import parse_folder
 
 class TestUnescape():
     def test_hello(self):
-        assert _.unescape('hello') == 'hello'
+        assert parse_folder.unescape('hello') == 'hello'
 
     def test_space(self):
-        assert _.unescape('%20') == ' '
+        assert parse_folder.unescape('%20') == ' '
 
 class TestValidateFolder():
     @classmethod
@@ -34,16 +34,16 @@ class TestValidateFolder():
             pass
 
     def test_dir(self):
-        assert _.validate_folder(self.tmpdir) == True
+        assert parse_folder.validate_folder(self.tmpdir) == True
 
     def test_file(self):
-        assert _.validate_folder(self.tmpfile) == False
+        assert parse_folder.validate_folder(self.tmpfile) == False
 
     def test_nonexistent_dir(self):
-        assert _.validate_folder(os.path.abspath('not-a-directory')) == False
+        assert parse_folder.validate_folder(os.path.abspath('not-a-directory')) == False
 
     def test_nonexistent_url(self):
-        assert _.validate_folder('http://localhost/not-a-url') == False
+        assert parse_folder.validate_folder('http://localhost/not-a-url') == False
 
 class TestValidateOutputFile():
     @classmethod
@@ -59,26 +59,26 @@ class TestValidateOutputFile():
             pass
 
     def test_missing_file(self):
-        assert _.validate_output_file(None) == True, 'all new files should be valid'
+        assert parse_folder.validate_output_file(None) == True, 'all new files should be valid'
 
     def test_file(self):
-        assert _.validate_output_file(os.path.join(self.tmpdir, 'output.txt')) == True
+        assert parse_folder.validate_output_file(os.path.join(self.tmpdir, 'output.txt')) == True
 
     @mock.patch('os.access')
     def test_local_file(self, mock_access):
         mock_access.return_value = True
-        assert _.validate_output_file('not-a-file.txt') == True, 'relative paths should be accepted'
+        assert parse_folder.validate_output_file('not-a-file.txt') == True, 'relative paths should be accepted'
 
     @mock.patch('os.access')
     def test_not_writeable(self, mock_access):
         mock_access.return_value = False
-        assert _.validate_output_file(self.tmpfile) == False, 'should not succeed without write permission'
+        assert parse_folder.validate_output_file(self.tmpfile) == False, 'should not succeed without write permission'
 
     def test_existing_file(self):
-        assert _.validate_output_file(self.tmpfile) == False
+        assert parse_folder.validate_output_file(self.tmpfile) == False
 
     def test_nonexistent_dir(self):
-        assert _.validate_output_file(
+        assert parse_folder.validate_output_file(
                 os.path.join(
                     os.path.abspath('not-a-dir'),
                     'output.txt'
@@ -96,38 +96,38 @@ class TestValidateInputFile():
         os.remove(cls.tmpfile)
 
     def test_missing_file(self):
-        assert _.validate_input_file('not-a-file.txt') == False, 'should not pass on missigle file'
+        assert parse_folder.validate_input_file('not-a-file.txt') == False, 'should not pass on missigle file'
 
     @mock.patch('os.access')
     def test_not_readable(self, mock_access):
         mock_access.return_value = False
-        assert _.validate_input_file(self.tmpfile) == False, 'should not succeed without read permission'
+        assert parse_folder.validate_input_file(self.tmpfile) == False, 'should not succeed without read permission'
 
 class TestValidateRange():
     def test_no_range(self):
-        assert _.validate_range(0) == True
+        assert parse_folder.validate_range(0) == True
 
     def test_min_less(self):
-        assert _.validate_range(-1, min_value=0) == False
+        assert parse_folder.validate_range(-1, min_value=0) == False
     def test_min_equal(self):
-        assert _.validate_range(0, min_value=0) == True
+        assert parse_folder.validate_range(0, min_value=0) == True
     def test_min_more(self):
-        assert _.validate_range(1, min_value=0) == True
+        assert parse_folder.validate_range(1, min_value=0) == True
 
     def test_max_less(self):
-        assert _.validate_range(9, max_value=10) == True
+        assert parse_folder.validate_range(9, max_value=10) == True
     def test_max_equal(self):
-        assert _.validate_range(10, max_value=10) == True
+        assert parse_folder.validate_range(10, max_value=10) == True
     def test_max_more(self):
-        assert _.validate_range(11, max_value=10) == False
+        assert parse_folder.validate_range(11, max_value=10) == False
 
     def test_allow_none_true(self):
-        assert _.validate_range(None, allow_none=True) == True
+        assert parse_folder.validate_range(None, allow_none=True) == True
     def test_allow_none_false(self):
-        assert _.validate_range(None, allow_none=False) == False
+        assert parse_folder.validate_range(None, allow_none=False) == False
 
     def test_string(self):
-        assert _.validate_range('foo') == False
+        assert parse_folder.validate_range('foo') == False
 
 
 @mock.patch('tools.parse_folder.validate_output_file')
@@ -135,7 +135,7 @@ class TestValidateRange():
 class TestCalculatePercentages():
     @raises(AssertionError)
     def test_making_0(self, mock_input, mock_output):
-        _.calculate_percentages(None, None, None, None, None, None, None)
+        parse_folder.calculate_percentages(None, None, None, None, None, None, None)
 
     def test_making_1(self, mock_input, mock_output):
         mock_input.return_value = True
@@ -151,7 +151,7 @@ class TestCalculatePercentages():
             args = {k: None for k in ['labels_file', 'train_file', 'percent_train', 'val_file', 'percent_val', 'test_file', 'percent_test']}
             args.update({supplied: ''})
 
-            output = _.calculate_percentages(**args)
+            output = parse_folder.calculate_percentages(**args)
             assert output == expected, 'expected output of {}, got {}'.format(output, expected) 
 
     def test_making_2(self, mock_input, mock_output):
@@ -168,7 +168,7 @@ class TestCalculatePercentages():
 
             # Tricky line. itertools returns combinations in sorted order, always.
             # The order of the returned non-zero values should always be correct.
-            output = [x for x in _.calculate_percentages(**args) if x != 0]
+            output = [x for x in parse_folder.calculate_percentages(**args) if x != 0]
             assert output == list(expected), 'expected output of {}, got {}'.format(output, expected) 
 
 
@@ -177,7 +177,7 @@ class TestCalculatePercentages():
         mock_output.return_value = True
 
         expected = (25, 30, 45)
-        assert _.calculate_percentages(
+        assert parse_folder.calculate_percentages(
             labels_file='not-a-file.txt',
             train_file='not-a-file.txt', percent_train=25,
             val_file='not-a-file.txt', percent_val=30,
@@ -190,7 +190,7 @@ class TestCalculatePercentages():
         mock_output.return_value = True
 
         expected = 45
-        assert _.calculate_percentages(
+        assert parse_folder.calculate_percentages(
             labels_file='not-a-file.txt',
             train_file='not-a-file.txt', percent_train=25,
             val_file='not-a-file.txt', percent_val=30,
@@ -204,7 +204,7 @@ class TestCalculatePercentages():
         mock_output.return_value = True
 
         # should raise AssertionError because percentages not between 0-100 are invalid
-        _.calculate_percentages(
+        parse_folder.calculate_percentages(
             labels_file='not-a-file.txt',
             train_file='not-a-file.txt', percent_train=-1,
             val_file=None, percent_val=None,
@@ -219,7 +219,7 @@ class TestParseWebListing():
             yield self.check_url_raises, url
 
     def check_url_raises(self, url):
-        assert_raises(Exception, _.parse_web_listing, url)
+        assert_raises(Exception, parse_folder.parse_web_listing, url)
 
     def test_mock_url(self):
         for content, dirs, files in [
@@ -264,7 +264,7 @@ class TestParseWebListing():
                 yield self.check_listing, (dirs, files)
 
     def check_listing(self, rc):
-        assert _.parse_web_listing('any_url') == rc
+        assert parse_folder.parse_web_listing('any_url') == rc
 
 class TestSplitIndices():
     def test_indices(self):
@@ -276,7 +276,7 @@ class TestSplitIndices():
     def check_split(self, size, pct_b, pct_c):
         ideala = size * float(100 - pct_b - pct_c)/100.0
         idealb = size * float(100 - pct_c)/100.0
-        idxa, idxb = _.three_way_split_indices(size, pct_b, pct_c)
+        idxa, idxb = parse_folder.three_way_split_indices(size, pct_b, pct_c)
 
         assert abs(ideala-idxa) <= 2, 'split should be close to {}, is {}'.format(ideala, idxa)
         assert abs(idealb-idxb) <= 2, 'split should be close to {}, is {}'.format(idealb, idxb)
@@ -295,7 +295,7 @@ class TestParseFolder():
         labels_file = os.path.join(tmpdir, 'labels.txt')
         train_file = os.path.join(tmpdir, 'train.txt')
 
-        _.parse_folder(tmpdir, labels_file, train_file=train_file,
+        parse_folder.parse_folder(tmpdir, labels_file, train_file=train_file,
                 percent_train=100, percent_val=0, percent_test=0)
 
         with open(labels_file) as infile:

--- a/tools/test_resize_image.py
+++ b/tools/test_resize_image.py
@@ -5,47 +5,47 @@ import os
 import stat
 import tempfile
 
-from . import resize_image as _
+from . import resize_image
 
 class TestOutputValidation():
     def test_no_filename(self):
-        assert _.validate_output_file(None), 'All new files should be valid'
+        assert resize_image.validate_output_file(None), 'All new files should be valid'
 
     @mock.patch('os.access')
     def test_not_writable(self, mock_access):
         mock_access.return_value = False
         with tempfile.NamedTemporaryFile('r') as f:
-            assert not _.validate_output_file(f.name), 'validation should not pass on unwritable file'
+            assert not resize_image.validate_output_file(f.name), 'validation should not pass on unwritable file'
 
     def test_normal(self):
         with tempfile.NamedTemporaryFile('r') as f:
-            assert _.validate_output_file(f.name), 'validation should pass on temporary file'
+            assert resize_image.validate_output_file(f.name), 'validation should pass on temporary file'
 
 
 class TestInputValidation():
     def test_does_not_exist(self):
-        assert not _.validate_input_file(''), 'validation should not pass on missing file'
+        assert not resize_image.validate_input_file(''), 'validation should not pass on missing file'
 
     @mock.patch('os.access')
     def test_unreadable_file(self, mock_access):
         mock_access.return_value = False
         with tempfile.NamedTemporaryFile('r') as f:
-            assert not _.validate_input_file(f.name), 'validation should not pass on unreadable file'
+            assert not resize_image.validate_input_file(f.name), 'validation should not pass on unreadable file'
 
 
 class TestRangeValidation():
     def test_number_none_and_not_allowed(self):
-        assert not _.validate_range(None, allow_none=False), 'number=None should not be allowed with allow_none=False'
+        assert not resize_image.validate_range(None, allow_none=False), 'number=None should not be allowed with allow_none=False'
 
     def test_number_not_float_compatible(self):
         value = 'a'
-        assert not _.validate_range(value), 'number=%s should not be accepted' % value
+        assert not resize_image.validate_range(value), 'number=%s should not be accepted' % value
 
     def test_number_below_min(self):
-        assert not _.validate_range(0, min_value=1), 'validation should not pass with number < min_value'
+        assert not resize_image.validate_range(0, min_value=1), 'validation should not pass with number < min_value'
 
     def test_number_above_max(self):
-        assert not _.validate_range(2, max_value=1), 'validation should not pass with number > max_value'
+        assert not resize_image.validate_range(2, max_value=1), 'validation should not pass with number > max_value'
 
     def test_range(self):
-        assert _.validate_range(5, min_value=0, max_value=255), 'validation should pass with 5 in range (0, 255)'
+        assert resize_image.validate_range(5, min_value=0, max_value=255), 'validation should pass with 5 in range (0, 255)'


### PR DESCRIPTION
It's supposed to refer to a throwaway variable, not the most relevant package in the test suite.

This is a non-functional change.