### PR TITLE
Fix another import bug from #501

### DIFF
--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -9,8 +9,6 @@ import subprocess
 import sys
 import time
 
-import caffe
-import caffe_pb2
 from google.protobuf import text_format
 import numpy as np
 import scipy
@@ -20,6 +18,10 @@ from digits import utils, dataset
 from digits.config import config_value
 from digits.status import Status
 from digits.utils import subclass, override, constants
+
+# Must import after importing digit.config
+import caffe
+import caffe_pb2
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 3

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -9,7 +9,6 @@ import subprocess
 import tempfile
 import time
 
-import caffe_pb2
 import h5py
 import numpy as np
 import PIL.Image
@@ -20,6 +19,9 @@ from digits import utils, dataset
 from digits.config import config_value
 from digits.dataset import ImageClassificationDatasetJob
 from digits.utils import subclass, override, constants
+
+# Must import after importing digit.config
+import caffe_pb2
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 1
@@ -627,7 +629,7 @@ class TorchTrainTask(TrainTask):
                     continue
                 idx = int(layer_id)
                 # activations
-                if 'activations' in layer:                    
+                if 'activations' in layer:
                     data = np.array(layer['activations'][...])
                     # skip batch dimension
                     if len(data.shape)>1 and data.shape[0]==1:


### PR DESCRIPTION
For some reason I was unable to do run individual test suites without this change:

```
$ ./digits-test -s digits/model/images/classification/test_views.py
E
======================================================================
ERROR: Failure: ImportError (No module named caffe)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/greg/ws/venv/local/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/greg/ws/venv/local/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/greg/ws/venv/local/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/greg/ws/digits/digits/model/__init__.py", line 4, in <module>
    from .images import *
  File "/home/greg/ws/digits/digits/model/images/__init__.py", line 4, in <module>
    from .classification import *
  File "/home/greg/ws/digits/digits/model/images/classification/__init__.py", line 4, in <module>
    from .job import ImageClassificationModelJob
  File "/home/greg/ws/digits/digits/model/images/classification/job.py", line 6, in <module>
    from ..job import ImageModelJob
  File "/home/greg/ws/digits/digits/model/images/job.py", line 4, in <module>
    from ..job import ModelJob
  File "/home/greg/ws/digits/digits/model/job.py", line 4, in <module>
    from . import tasks
  File "/home/greg/ws/digits/digits/model/tasks/__init__.py", line 4, in <module>
    from .caffe_train import CaffeTrainTask
  File "/home/greg/ws/digits/digits/model/tasks/caffe_train.py", line 12, in <module>
    import caffe
ImportError: No module named caffe
```