### PR TITLE
Fix nginx redirection to ports other than 80

### DIFF
--- a/nginx.site
+++ b/nginx.site
@@ -8,7 +8,7 @@ server {
         proxy_pass http://127.0.0.1:34448;
         proxy_redirect off;
 
-        proxy_set_header Host $host;
+        proxy_set_header Host $host:$server_port;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 


### PR DESCRIPTION
*Fix #528*

After using `dpkg-reconfigure` to change the reverse proxy front-end port from 80 to something else (e.g. 5000), redirects were still going back to port 80.

~~Solution based on answers to [this SO post](http://serverfault.com/questions/576365/use-nginx-reverse-proxy-for-redirection).~~

/cc @dadap @3XX0 - anyone know of a more elegant fix?