### PR TITLE
Re-use all weights when re-training on same dataset

### DIFF
--- a/digits/frameworks/caffe_framework.py
+++ b/digits/frameworks/caffe_framework.py
@@ -86,17 +86,20 @@ class CaffeFramework(Framework):
         return network
 
     @override
-    def get_network_from_previous(self, previous_network):
+    def get_network_from_previous(self, previous_network, use_same_dataset):
         """
         return new instance of network from previous network
         """
         network = caffe_pb2.NetParameter()
         network.CopyFrom(previous_network)
-        # Rename the final layer
-        # XXX making some assumptions about network architecture here
-        ip_layers = [l for l in network.layer if l.type == 'InnerProduct']
-        if len(ip_layers) > 0:
-            ip_layers[-1].name = '%s_retrain' % ip_layers[-1].name
+
+        if not use_same_dataset:
+            # Rename the final layer
+            # XXX making some assumptions about network architecture here
+            ip_layers = [l for l in network.layer if l.type == 'InnerProduct']
+            if len(ip_layers) > 0:
+                ip_layers[-1].name = '%s_retrain' % ip_layers[-1].name
+
         return network
 
     @override

--- a/digits/frameworks/framework.py
+++ b/digits/frameworks/framework.py
@@ -48,7 +48,7 @@ class Framework(object):
         """
         raise NotImplementedError('Please implement me')
 
-    def get_network_from_previous(self, previous_network):
+    def get_network_from_previous(self, previous_network, use_same_dataset):
         """
         return new instance of network from previous network
         """

--- a/digits/frameworks/torch_framework.py
+++ b/digits/frameworks/torch_framework.py
@@ -76,11 +76,18 @@ class TorchFramework(Framework):
         return network_desc
 
     @override
-    def get_network_from_previous(self, previous_network):
+    def get_network_from_previous(self, previous_network, use_same_dataset):
         """
         return new instance of network from previous network
         """
-        # return the same string
+        # note: use_same_dataset is ignored here because for Torch, DIGITS
+        # does not change the number of outputs of the last linear layer
+        # to match the number of classes in the case of a classification
+        # network. In order to write a flexible network description that
+        # accounts for the number of classes, the `nClasses` external
+        # parameter must be used, see documentation.
+
+        # return the same network description
         return previous_network
 
     @override

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -116,7 +116,8 @@ def create():
                 raise werkzeug.exceptions.BadRequest(
                         'Job not found: %s' % form.previous_networks.data)
 
-            network = fw.get_network_from_previous(old_job.train_task().network)
+            use_same_dataset = (old_job.dataset_id == job.dataset_id)
+            network = fw.get_network_from_previous(old_job.train_task().network, use_same_dataset)
 
             for choice in form.previous_networks.choices:
                 if choice[0] == form.previous_networks.data:

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -101,7 +101,8 @@ def create():
                 raise werkzeug.exceptions.BadRequest(
                         'Job not found: %s' % form.previous_networks.data)
 
-            network = fw.get_network_from_previous(old_job.train_task().network)
+            use_same_dataset = (old_job.dataset_id == job.dataset_id)
+            network = fw.get_network_from_previous(old_job.train_task().network, use_same_dataset)
 
             for choice in form.previous_networks.choices:
                 if choice[0] == form.previous_networks.data:


### PR DESCRIPTION
Current behaviour:
When a classification model is being re-trained the last `InnerProduct` layer is renamed to allow training on another dataset (with a possibly different number of classes).
This implies that the weights of that last layer are discarded.

Problem:
If the model is being re-trained on the same dataset then initially the model will perform badly as it needs to re-learn the weights of its last `InnerProduct` layer.

Solution:
Refrain from renaming the last `InnerProduct` layer if the model is being re-trained on the same dataset

Note:
This applies to Caffe only.

closes #533