### PR TITLE
Only look in one location for config files

### DIFF
--- a/digits/config/config_file.py
+++ b/digits/config/config_file.py
@@ -114,24 +114,7 @@ class ConfigFile(object):
             cfg.write(outfile)
 
 
-class SystemConfigFile(ConfigFile):
-    def __init__(self):
-        if platform.system() in ['Linux','Darwin']:
-            filename = '/etc/digits.cfg'
-        else:
-            filename = None
-        super(SystemConfigFile, self).__init__(filename)
-
-class UserConfigFile(ConfigFile):
-    def __init__(self):
-        if 'HOME' in os.environ:
-            filename = os.path.join(os.environ['HOME'], '.digits.cfg')
-        else:
-            filename = None
-        super(UserConfigFile, self).__init__(filename)
-
 class InstanceConfigFile(ConfigFile):
     def __init__(self):
         filename = os.path.join(os.path.dirname(digits.__file__), 'digits.cfg')
         super(InstanceConfigFile, self).__init__(filename)
-

--- a/digits/config/edit.py
+++ b/digits/config/edit.py
@@ -18,10 +18,7 @@ def print_config(verbose=False):
     if verbose:
         min_visibility = config_option.Visibility.HIDDEN
 
-    levels = [
-            ('INSTANCE', config_file.InstanceConfigFile()),
-            ('USER', config_file.UserConfigFile()),
-            ('SYSTEM', config_file.SystemConfigFile())]
+    levels = [('INSTANCE', config_file.InstanceConfigFile())]
     # filter out the files which don't exist
     levels = [l for l in levels if l[1].can_read()]
 
@@ -80,16 +77,6 @@ def edit_config_file(verbose=False):
         suggestions.append(prompt.Suggestion(
             instanceConfig.filename(), 'I',
             desc = 'Instance', default=True))
-    userConfig = config_file.UserConfigFile()
-    if userConfig.can_write():
-        suggestions.append(prompt.Suggestion(
-            userConfig.filename(), 'U',
-            desc = 'User', default=True))
-    systemConfig = config_file.SystemConfigFile()
-    if systemConfig.can_write():
-        suggestions.append(prompt.Suggestion(
-            systemConfig.filename(), 'S',
-            desc = 'System', default=True))
 
     def filenameValidator(filename):
         """
@@ -125,12 +112,6 @@ def edit_config_file(verbose=False):
     if filename == instanceConfig.filename():
         is_standard_location = True
         instanceConfig = None
-    if filename == userConfig.filename():
-        is_standard_location = True
-        userConfig = None
-    if filename == systemConfig.filename():
-        is_standard_location = True
-        systemConfig = None
 
     configFile = config_file.ConfigFile(filename)
 
@@ -152,16 +133,6 @@ def edit_config_file(verbose=False):
             if instance_value is not None:
                 suggestions.append(prompt.Suggestion(instance_value, 'I',
                     desc = 'Instance', default = is_standard_location))
-        if userConfig is not None:
-            user_value = userConfig.get(option.config_file_key())
-            if user_value is not None:
-                suggestions.append(prompt.Suggestion(user_value, 'U',
-                    desc = 'User', default = is_standard_location))
-        if systemConfig is not None:
-            system_value = systemConfig.get(option.config_file_key())
-            if system_value is not None:
-                suggestions.append(prompt.Suggestion(system_value, 'S',
-                    desc = 'System', default = is_standard_location))
         suggestions += option.suggestions()
         if option.optional():
             suggestions.append(prompt.Suggestion('', 'N',

--- a/digits/config/load.py
+++ b/digits/config/load.py
@@ -9,10 +9,7 @@ from . import current_config
 from . import prompt
 
 def load_option(option, mode, newConfig,
-        instanceConfig  =None,
-        userConfig      = None,
-        systemConfig    = None,
-        ):
+                instanceConfig=None):
     """
     Called from load_config() [below]
 
@@ -21,8 +18,6 @@ def load_option(option, mode, newConfig,
     mode -- see docstring for load_config()
     newConfig -- an instance of ConfigFile
     instanceConfig -- the current InstanceConfigFile
-    userConfig -- the current UserConfigFile
-    systemConfig -- the current SystemConfigFile
     """
     if 'DIGITS_MODE_TEST' in os.environ and option.has_test_value():
         option.set(option.test_value())
@@ -33,14 +28,6 @@ def load_option(option, mode, newConfig,
     if instance_value is not None:
         suggestions.append(prompt.Suggestion(instance_value, '',
             desc = 'Previous', default = True))
-    user_value = userConfig.get(option.config_file_key())
-    if user_value is not None:
-        suggestions.append(prompt.Suggestion(user_value, 'U',
-            desc = 'User', default = True))
-    system_value = systemConfig.get(option.config_file_key())
-    if system_value is not None:
-        suggestions.append(prompt.Suggestion(system_value, 'S',
-            desc = 'System', default = True))
     suggestions += option.suggestions()
     if option.optional():
         suggestions.append(prompt.Suggestion('', 'N',
@@ -107,8 +94,6 @@ def load_config(mode='force'):
     current_config.reset()
 
     instanceConfig = config_file.InstanceConfigFile()
-    userConfig = config_file.UserConfigFile()
-    systemConfig = config_file.SystemConfigFile()
     newConfig = config_file.InstanceConfigFile()
 
     non_framework_options = [o for o in current_config.option_list
@@ -118,8 +103,7 @@ def load_config(mode='force'):
 
     # Load non-framework config options
     for option in non_framework_options:
-        load_option(option, mode, newConfig,
-                instanceConfig, userConfig, systemConfig)
+        load_option(option, mode, newConfig, instanceConfig)
 
     has_one_framework = False
     verbose_for_frameworks = False
@@ -130,8 +114,7 @@ def load_config(mode='force'):
         else:
             framework_mode = mode
         for option in framework_options:
-            load_option(option, framework_mode, newConfig,
-                    instanceConfig, userConfig, systemConfig)
+            load_option(option, framework_mode, newConfig, instanceConfig)
             if option.has_value():
                 has_one_framework = True
 


### PR DESCRIPTION
Keep using `digits/digits.cfg` but don't look at `$HOME/.digits.cfg` or `/etc/digits.cfg`.

**Why**
It's not that useful after all and creates too many opportunities for confusing configuration errors.

**How**
This is the quickest way to make the change. It ends up leaving a bunch of cruft in the `digits/config/*` code to handle multiple config files. That could be addressed later.