### PR TITLE
Use Travis scripts outside of Travis more easily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
     - export PATH=/home/travis/miniconda/bin:$PATH
 install:
     # Caffe
-    - pushd .
     - ./scripts/travis/install-caffe.sh $(pwd)/deps/caffe
 
     # Torch

--- a/scripts/travis/install-caffe.sh
+++ b/scripts/travis/install-caffe.sh
@@ -12,6 +12,8 @@ fi
 INSTALL_DIR=$1
 mkdir -p $INSTALL_DIR
 
+NUM_THREADS=${NUM_THREADS-4}
+
 CAFFE_BRANCH="caffe-0.13"
 CAFFE_URL="https://github.com/NVIDIA/caffe.git"
 
@@ -22,8 +24,8 @@ cd $INSTALL_DIR
 # Install dependencies
 sudo -E ./scripts/travis/travis_install.sh
 # change permissions for installed python packages
-sudo chown travis:travis -R /home/travis/miniconda
-sudo chown travis:travis -R /home/travis/.cache
+sudo chown $USER -R ~/miniconda
+sudo chown $USER -R ~/.cache
 
 # Build source
 cp Makefile.config.example Makefile.config


### PR DESCRIPTION
Still takes some work on the Caffe side of things, but this makes it a bit easier to simulate the Travis environment on a non-Travis build system.