### PR TITLE
Fix error-handling on loading jobs with no job_id

### DIFF
--- a/digits/scheduler.py
+++ b/digits/scheduler.py
@@ -148,7 +148,7 @@ class Scheduler:
                     job.load_dataset()
                     self.jobs[job.id()] = job
                 except Exception as e:
-                    failed_jobs.append((job.id(), e))
+                    failed_jobs.append((dir_name, e))
 
         logger.info('Loaded %d jobs.' % len(self.jobs))
 


### PR DESCRIPTION
I introduced an obscure bug in https://github.com/NVIDIA/DIGITS/pull/465. If you somehow created a pickle file without a job_id, then the `load_past_jobs()` function failed to catch the error (or rather, only caught it the first time), and the server failed to start. This should fix that.

/cc @jmancewicz