### PR TITLE
Remove `update_ago_timer` variable and `update_ago` function.

### DIFF
--- a/digits/templates/job_management.html
+++ b/digits/templates/job_management.html
@@ -35,18 +35,6 @@
      }
  }
 
- // update ago every 5 seconds
- var update_ago_timer = $.timer(update_ago, 1000);
- function update_ago() {
-     return;
-     $("small#ago" ).each(function(){
-         var start = $(this).attr('start')
-         var now = $.now() / 1000;
-         var time = print_time_diff(now - start);
-         $(this).html( "(" + time + " ago)" );
-     });
- }
-
  $(document).ready(function() {
      // Make the jobs DataTable
      // make 'table' a global variable


### PR DESCRIPTION
`Start Time` shows the start time of the job and doesn't seem to use these any more.
The timer calls this function every second (in comments it should be 5),
but the function `update_ago` just returns without doing anything.