### PR TITLE
Fix broken link to UbuntuInstall.md

### DIFF
--- a/docs/WebInstall.md
+++ b/docs/WebInstall.md
@@ -3,7 +3,7 @@
 Prior to DIGITS v3.0, a tarball installer was provided.
 **This has been removed in favor of deb packages**:
 
-[UbuntuInstall.md](docs/UbuntuInstall.md)
+[UbuntuInstall.md](UbuntuInstall.md)
 
 The old instructions are still available here:
 


### PR DESCRIPTION
Current link is to `docs/docs/UbuntuInstall.md`.  The `docs`  is duplicated.
