### PR TITLE
Revert "Use last version of lightningmdb wrapper for Torch"

### DIFF
--- a/docs/BuildTorchLMDB.md
+++ b/docs/BuildTorchLMDB.md
@@ -37,8 +37,8 @@ During installation, lightningmdb requires the LMDB header and libraries, so lua
 Install lightningmdb (you may need to edit the paths at the end for your specific LMDB installation):
 ```sh
 # Ubuntu 14.04
-% luarocks install https://raw.githubusercontent.com/shmul/lightningmdb/master/lightningmdb-scm-1.rockspec LMDB_INCDIR=/usr/include LMDB_LIBDIR=/usr/lib/x86_64-linux-gnu
+% luarocks install lightningmdb LMDB_INCDIR=/usr/include LMDB_LIBDIR=/usr/lib/x86_64-linux-gnu
 
 # From source
-% luarocks install https://raw.githubusercontent.com/shmul/lightningmdb/master/lightningmdb-scm-1.rockspec LMDB_INCDIR=~/lmdb/libraries/liblmdb LMDB_LIBDIR=~/lmdb/libraries/liblmdb
+% luarocks install lightningmdb LMDB_INCDIR=~/lmdb/libraries/liblmdb LMDB_LIBDIR=~/lmdb/libraries/liblmdb
 ```

--- a/scripts/travis/install-torch.sh
+++ b/scripts/travis/install-torch.sh
@@ -22,5 +22,5 @@ cd $INSTALL_DIR; ./install.sh -b
 ${INSTALL_DIR}/install/bin/luarocks install image
 ${INSTALL_DIR}/install/bin/luarocks install "https://raw.github.com/deepmind/torch-hdf5/master/hdf5-0-0.rockspec"
 ${INSTALL_DIR}/install/bin/luarocks install "https://raw.github.com/Sravan2j/lua-pb/master/lua-pb-scm-0.rockspec"
-${INSTALL_DIR}/install/bin/luarocks install "https://raw.githubusercontent.com/shmul/lightningmdb/master/lightningmdb-scm-1.rockspec" LMDB_INCDIR=/usr/local/include LMDB_LIBDIR=/usr/local/lib
+${INSTALL_DIR}/install/bin/luarocks install lightningmdb LMDB_INCDIR=/usr/local/include LMDB_LIBDIR=/usr/local/lib
 


### PR DESCRIPTION
This reverts commit 3afb6ab5017a234a02e47629a27a8bacddded3f7 (from https://github.com/NVIDIA/DIGITS/pull/545).

See discussion at https://github.com/NVIDIA/DIGITS/issues/544. 