### PR TITLE
Fix an ill-formed html file consistently with other html files.

### DIFF
--- a/digits/templates/models/images/classification/custom_network_explanation.html
+++ b/digits/templates/models/images/classification/custom_network_explanation.html
@@ -2,18 +2,24 @@
 
 
 <h1>Specifying a custom Caffe network</h1>
+
 <p>
     You should enter a train_val network here. Some cleanup is done for you automatically:
-    <ul>
-        <li>
-            The <i>num_output</i> for each <b>InnerProduct</b> layer which is a network output gets set to the number of labels in the chosen dataset.
-        </li>
-        <li>
-            Any <b>Accuracy</b> layers with <i>top_k</i> &gt;= num_labels is removed automatically.
-        </li>
-    </ul>
 </p>
-The deploy network will be created for you automatically. Once caffe implements their "all-in-one" nets feature, you will be able to specify which layers to include in the deploy file. Until then, these things are done automatically:
+
+<ul>
+    <li>
+        The <i>num_output</i> for each <b>InnerProduct</b> layer which is a network output gets set to the number of labels in the chosen dataset.
+    </li>
+    <li>
+        Any <b>Accuracy</b> layers with <i>top_k</i> &gt;= num_labels is removed automatically.
+    </li>
+</ul>
+
+<p>
+    The deploy network will be created for you automatically. Once caffe implements their "all-in-one" nets feature, you will be able to specify which layers to include in the deploy file. Until then, these things are done automatically:
+</p>
+
 <ul>
     <li>
         The last <b>SoftmaxWithLoss</b> layer is replaced with a <b>Softmax</b> layer.
@@ -22,9 +28,9 @@ The deploy network will be created for you automatically. Once caffe implements 
         All other loss layers and accuracy layers are removed.
     </li>
 </ul>
-</p>
 
 <h1>Specifying a custom Torch network</h1>
+
 <p>
     You should enter a Torch network description here. Refer to the documentation for more information.
-<p>
+</p>


### PR DESCRIPTION
`<ul>` tag should be outside of `<p>` tag. This PR fixes
`classification/custom_network_explanation.html`. The result is
consistent with `generic/customer_network_explanation.html` and others.