### PR TITLE
Inference jobs

### DIFF
--- a/digits/frameworks/errors.py
+++ b/digits/frameworks/errors.py
@@ -29,14 +29,4 @@ class NetworkVisualizationError(Error):
     def __str__(self):
         return repr(self.message)
 
-@subclass
-class InferenceError(Error):
-    """
-    Errors that occur during inference
-    """
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return repr(self.message)
 

--- a/digits/frameworks/framework.py
+++ b/digits/frameworks/framework.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
+from digits.inference.tasks import InferenceTask
 
 class Framework(object):
 
@@ -38,6 +39,12 @@ class Framework(object):
         validate a network (must be implemented in child class)
         """
         raise NotImplementedError('Please implement me')
+
+    def create_inference_task(self, **kwargs):
+        """
+        create inference task
+        """
+        return InferenceTask(**kwargs)
 
     def create_train_task(self, **kwargs):
         """

--- a/digits/inference/__init__.py
+++ b/digits/inference/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .images import *
+from .job import InferenceJob
+

--- a/digits/inference/errors.py
+++ b/digits/inference/errors.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from digits.utils import subclass, override
+
+@subclass
+class Error(Exception):
+    pass
+
+@subclass
+class InferenceError(Error):
+    """
+    Errors that occur during inference
+    """
+    def __init__(self, message):
+        self.message = message
+
+    @override
+    def __str__(self):
+        return repr(self.message)
+

--- a/digits/inference/images/__init__.py
+++ b/digits/inference/images/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .job import ImageInferenceJob

--- a/digits/inference/images/job.py
+++ b/digits/inference/images/job.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from ..job import InferenceJob
+from digits.job import Job
+from digits.utils import subclass, override
+
+@subclass
+class ImageInferenceJob(InferenceJob):
+    """
+    A Job that exercises the forward pass of an image neural network
+    """
+
+    @override
+    def job_type(self):
+        return 'Image Inference'

--- a/digits/inference/job.py
+++ b/digits/inference/job.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from . import tasks
+import digits.frameworks
+from digits.job import Job
+from digits.utils import subclass, override
+
+@subclass
+class InferenceJob(Job):
+    """
+    A Job that exercises the forward pass of a neural network
+    """
+
+    def __init__(self, model, images, epoch, layers, **kwargs):
+        """
+        Arguments:
+        model   -- job object associated with model to perform inference on
+        images  -- list of image paths to perform inference on
+        epoch   -- epoch of model snapshot to use
+        layers  -- layers to import ('all' or 'none')
+        """
+        super(InferenceJob, self).__init__(**kwargs)
+
+        # get handle to framework object
+        fw_id = model.train_task().framework_id
+        fw = digits.frameworks.get_framework_by_id(fw_id)
+
+        # create inference task
+        self.tasks.append(fw.create_inference_task(
+            job_dir   = self.dir(),
+            model     = model,
+            images    = images,
+            epoch     = epoch,
+            layers    = layers))
+
+    @override
+    def __getstate__(self):
+        fields_to_save = ['_id', '_name']
+        full_state = super(InferenceJob, self).__getstate__()
+        state_to_save = {}
+        for field in fields_to_save:
+            state_to_save[field] = full_state[field]
+        return state_to_save
+
+    def inference_task(self):
+        """Return the first and only InferenceTask for this job"""
+        return [t for t in self.tasks if isinstance(t, tasks.InferenceTask)][0]
+
+    @override
+    def __setstate__(self, state):
+        super(InferenceJob, self).__setstate__(state)
+
+    def get_data(self):
+        """Return inference data"""
+        task = self.inference_task()
+        return task.inference_inputs, task.inference_outputs, task.inference_layers
+
+    @override
+    def is_read_only(self):
+        """
+        Returns True if this job cannot be edited
+        """
+        return True
+

--- a/digits/inference/tasks/__init__.py
+++ b/digits/inference/tasks/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .inference import InferenceTask
+

--- a/digits/inference/tasks/inference.py
+++ b/digits/inference/tasks/inference.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import base64
+import h5py
+import os.path
+import tempfile
+import re
+import sys
+
+import digits
+from digits import device_query
+from digits.task import Task
+from digits.utils import subclass, override
+from digits.utils.image import embed_image_html
+from digits.status import Status
+from ..errors import InferenceError
+
+@subclass
+class InferenceTask(Task):
+    """
+    A task for inference jobs
+    """
+
+    def __init__(self, model, images, epoch, layers, **kwargs):
+        """
+        Arguments:
+        model  -- trained model to perform inference on
+        images -- list of images to perform inference on
+        epoch  -- model snapshot to use
+        layers -- which layers to visualize (by default only the activations of the last layer)
+        """
+        # memorize parameters
+        self.model = model
+        self.images = images
+        self.epoch = epoch
+        self.layers = layers
+
+        self.image_list_path = None
+        self.inference_log_file = "inference.log"
+
+        # resources
+        self.gpu = None
+
+        # generated data
+        self.inference_data_filename = None
+        self.inference_inputs = None
+        self.inference_outputs = None
+        self.inference_layers = []
+
+        super(InferenceTask, self).__init__(**kwargs)
+
+    @override
+    def name(self):
+        return 'Infer Model'
+
+    @override
+    def __getstate__(self):
+        state = super(InferenceTask, self).__getstate__()
+        if 'inference_log' in state:
+            # don't save file handle
+            del state['inference_log']
+        return state
+
+    @override
+    def __setstate__(self, state):
+        super(InferenceTask, self).__setstate__(state)
+
+    @override
+    def before_run(self):
+        super(InferenceTask, self).before_run()
+        # create log file
+        self.inference_log = open(self.path(self.inference_log_file), 'a')
+        # create a file to pass the list of images to perform inference on
+        imglist_handle, self.image_list_path = tempfile.mkstemp(dir=self.job_dir, suffix='.txt')
+        for image_path in self.images:
+            os.write(imglist_handle, "%s\n" % image_path)
+        os.close(imglist_handle)
+
+    @override
+    def process_output(self, line):
+        self.inference_log.write('%s\n' % line)
+        self.inference_log.flush()
+
+        timestamp, level, message = self.preprocess_output_digits(line)
+        if not message:
+            return False
+
+        # progress
+        match = re.match(r'Processed (\d+)\/(\d+)', message)
+        if match:
+            self.progress = float(match.group(1))/int(match.group(2))
+            return True
+
+        # path to inference data
+        match = re.match(r'Saved data to (.*)', message)
+        if match:
+            self.inference_data_filename = match.group(1).strip()
+            return True
+
+        return False
+
+    @override
+    def after_run(self):
+        super(InferenceTask, self).after_run()
+
+        # retrieve inference data
+        inputs = None
+        visualizations = []
+        outputs = {}
+        if self.inference_data_filename is not None:
+            # the HDF5 database contains:
+            # - input images, in a dataset "/inputs"
+            # - all network outputs, in a group "/outputs/"
+            # - layer activations and weights, if requested, in a group "/layers/"
+            db = h5py.File(self.inference_data_filename, 'r')
+
+            # collect inputs
+            inputs = db['inputs'][...]
+
+            # collect outputs
+            for output_key, output_data in db['outputs'].items():
+                output_name = base64.urlsafe_b64decode(str(output_key))
+                outputs[output_name] = output_data[...]
+
+            # collect layer data, if applicable
+            if 'layers' in db.keys():
+                for layer_id, layer in db['layers'].items():
+                    visualization = {
+                        'id': int(layer_id),
+                        'name': layer.attrs['name'],
+                        'vis_type': layer.attrs['vis_type'],
+                        'data_stats': {
+                            'shape': layer.attrs['shape'],
+                            'mean': layer.attrs['mean'],
+                            'stddev': layer.attrs['stddev'],
+                            'histogram': [
+                                layer.attrs['histogram_y'].tolist(),
+                                layer.attrs['histogram_x'].tolist(),
+                                layer.attrs['histogram_ticks'].tolist(),
+                                ]
+                        }
+                    }
+                    if 'param_count' in layer.attrs:
+                        visualization['param_count'] = layer.attrs['param_count']
+                    if 'layer_type' in layer.attrs:
+                        visualization['layer_type'] = layer.attrs['layer_type']
+                    vis = layer[...]
+                    if vis.shape[0] > 0:
+                        visualization['image_html'] = embed_image_html(vis)
+                    visualizations.append(visualization)
+                # sort by layer ID (as HDF5 ASCII sorts)
+                visualizations = sorted(visualizations,key=lambda x:x['id'])
+            db.close()
+        self.inference_log.close()
+
+        # save inference to data for further use
+        self.inference_inputs = inputs
+        self.inference_outputs = outputs
+        self.inference_layers = visualizations
+
+    @override
+    def offer_resources(self, resources):
+        reserved_resources = {}
+        # we need one CPU resource from inference_task_pool
+        cpu_key = 'inference_task_pool'
+        if cpu_key not in resources:
+            return None
+        for resource in resources[cpu_key]:
+            if resource.remaining() >= 1:
+                reserved_resources[cpu_key] = [(resource.identifier, 1)]
+                # we reserve the first available GPU, if there are any
+                gpu_key = 'gpus'
+                if resources[gpu_key]:
+                    for resource in resources[gpu_key]:
+                        if resource.remaining() >= 1:
+                            self.gpu = int(resource.identifier)
+                            reserved_resources[gpu_key] = [(resource.identifier, 1)]
+                            break
+                return reserved_resources
+        return None
+
+    @override
+    def task_arguments(self, resources, env):
+
+        args = [sys.executable,
+            os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(digits.__file__))), 'tools', 'inference.py'),
+            self.image_list_path,
+            self.job_dir,
+            self.model.id(),
+            '--jobs_dir=%s' % digits.config.config_value('jobs_dir'),
+            ]
+
+        if self.epoch != None:
+            args.append('--epoch=%s' % repr(self.epoch))
+
+        if self.layers == 'all':
+            args.append('--layers=all')
+        else:
+            args.append('--layers=none')
+
+        if self.gpu is not None:
+            args.append('--gpu=%d' % self.gpu)
+
+        return args
+
+

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -14,6 +14,7 @@ from digits import frameworks
 from digits import utils
 from digits.config import config_value
 from digits.dataset import GenericImageDatasetJob
+from digits.inference import ImageInferenceJob
 from digits.status import Status
 from digits.utils import filesystem as fs
 from digits.utils.forms import fill_form_if_cloned, save_form_to_job
@@ -235,28 +236,18 @@ def infer_one():
     """
     Infer one image
     """
-    job = job_from_request()
+    model_job = job_from_request()
 
     image = None
     if 'image_url' in flask.request.form and flask.request.form['image_url']:
-        image = utils.image.load_image(flask.request.form['image_url'])
+        image_path = flask.request.form['image_url']
     elif 'image_file' in flask.request.files and flask.request.files['image_file']:
         outfile = tempfile.mkstemp(suffix='.bin')
         flask.request.files['image_file'].save(outfile[1])
-        image = utils.image.load_image(outfile[1])
+        image_path = outfile[1]
         os.close(outfile[0])
-        os.remove(outfile[1])
     else:
         raise werkzeug.exceptions.BadRequest('must provide image_url or image_file')
-
-    # resize image
-    db_task = job.train_task().dataset.analyze_db_tasks()[0]
-    height = db_task.image_height
-    width = db_task.image_width
-    image = utils.image.resize_image(image, height, width,
-            channels = db_task.image_channels,
-            resize_mode = 'squash',
-            )
 
     epoch = None
     if 'snapshot_epoch' in flask.request.form:
@@ -266,14 +257,45 @@ def infer_one():
     if 'show_visualizations' in flask.request.form and flask.request.form['show_visualizations']:
         layers = 'all'
 
-    outputs, visualizations = job.train_task().infer_one(image, snapshot_epoch=epoch, layers=layers)
+    # create inference job
+    inference_job = ImageInferenceJob(
+                username    = utils.auth.get_username(),
+                name        = "Infer One Image",
+                model       = model_job,
+                images      = [image_path],
+                epoch       = epoch,
+                layers      = layers
+                )
+
+    # schedule tasks
+    scheduler.add_job(inference_job)
+
+    # wait for job to complete
+    inference_job.wait_completion()
+
+    # retrieve inference data
+    inputs, outputs, visualizations = inference_job.get_data()
+
+    # delete job folder and remove from scheduler list
+    scheduler.delete_job(inference_job)
+
+    # remove file (fails if a URL was provided)
+    try:
+        os.remove(image_path)
+    except:
+        pass
+
+    image = None
+    if inputs is not None and len(inputs) == 1:
+        image = utils.image.embed_image_html(inputs[0])
 
     if request_wants_json():
         return flask.jsonify({'outputs': dict((name, blob.tolist()) for name,blob in outputs.iteritems())})
     else:
         return flask.render_template('models/images/generic/infer_one.html',
-                job             = job,
-                image_src       = utils.image.embed_image_html(image),
+                model_job       = model_job,
+                job             = inference_job,
+                image_src       = image,
                 network_outputs = outputs,
                 visualizations  = visualizations,
                 total_parameters= sum(v['param_count'] for v in visualizations if v['vis_type'] == 'Weights'),
@@ -285,7 +307,7 @@ def infer_many():
     """
     Infer many images
     """
-    job = job_from_request()
+    model_job = job_from_request()
 
     image_list = flask.request.files.get('image_list')
     if not image_list:
@@ -303,12 +325,6 @@ def infer_many():
         epoch = float(flask.request.form['snapshot_epoch'])
 
     paths = []
-    images = []
-
-    db_task = job.train_task().dataset.analyze_db_tasks()[0]
-    height = db_task.image_height
-    width = db_task.image_width
-    channels = db_task.image_channels
 
     for line in image_list.readlines():
         line = line.strip()
@@ -323,27 +339,35 @@ def infer_many():
         else:
             path = line
 
-        try:
-            if not utils.is_url(path) and image_folder and not os.path.isabs(path):
-                path = os.path.join(image_folder, path)
-            print path
-            image = utils.image.load_image(path)
-            image = utils.image.resize_image(image, height, width,
-                    channels = channels,
-                    resize_mode = 'squash',
-                    )
-            paths.append(path)
-            images.append(image)
-        except utils.errors.LoadImageError as e:
-            print e
+        if not utils.is_url(path) and image_folder and not os.path.isabs(path):
+            path = os.path.join(image_folder, path)
+        paths.append(path)
 
-    if not len(images):
-        raise werkzeug.exceptions.BadRequest(
-                'Unable to load any images from the file')
+    # create inference job
+    inference_job = ImageInferenceJob(
+                username    = utils.auth.get_username(),
+                name        = "Infer Many Images",
+                model       = model_job,
+                images      = paths,
+                epoch       = epoch,
+                layers      = 'none'
+                )
 
-    outputs = job.train_task().infer_many(images, snapshot_epoch=epoch)
-    if outputs is None:
-        raise RuntimeError('An error occured while processing the images')
+    # schedule tasks
+    scheduler.add_job(inference_job)
+
+    # wait for job to complete
+    inference_job.wait_completion()
+
+    # retrieve inference data
+    inputs, outputs, _ = inference_job.get_data()
+
+    # delete job folder and remove from scheduler list
+    scheduler.delete_job(inference_job)
+
+    if len(outputs) < 1:
+        # an error occurred
+        outputs = None
 
     if request_wants_json():
         result = {}
@@ -352,7 +376,8 @@ def infer_many():
         return flask.jsonify({'outputs': result})
     else:
         return flask.render_template('models/images/generic/infer_many.html',
-                job             = job,
+                model_job       = model_job,
+                job             = inference_job,
                 paths           = paths,
                 network_outputs = outputs,
                 )

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -523,8 +523,10 @@ class TrainTask(Task):
             return None
 
     # return id of framework used for training
-    @override
     def get_framework_id(self):
+        """
+        Returns a string
+        """
         return self.framework_id
 
     def get_model_files(self):

--- a/digits/scheduler.py
+++ b/digits/scheduler.py
@@ -101,6 +101,7 @@ class Scheduler:
                 'parse_folder_task_pool': [Resource()],
                 'create_db_task_pool': [Resource(max_value=2)],
                 'analyze_db_task_pool': [Resource(max_value=4)],
+                'inference_task_pool': [Resource(max_value=4)],
                 'gpus': [Resource(identifier=index)
                     for index in gpu_list.split(',')] if gpu_list else [],
                 }

--- a/digits/task.py
+++ b/digits/task.py
@@ -76,12 +76,6 @@ class Task(StatusCls):
         """
         raise NotImplementedError
 
-    def get_framework_id(self):
-        """
-        Returns a string
-        """
-        raise NotImplementedError('Please implement me')
-
     def html_id(self):
         """
         Returns a string

--- a/digits/templates/job.html
+++ b/digits/templates/job.html
@@ -265,7 +265,7 @@ $('#delete-job').on('click', function(event) {
                         return false;
                     }
                     </script>
-                    <textarea name="job-notes" class="form-control" placeholder="Enter notes" rows="5">{% if job.notes() %}{{ job.notes() }}{% endif %}</textarea> 
+                    <textarea name="job-notes" class="form-control" placeholder="Enter notes" rows="5">{% if job.notes() %}{{ job.notes() }}{% endif %}</textarea>
                     <a href=# class="btn btn-primary" onClick="return updateJobNotes();">Update</a>
                     <a href=# class="btn btn-info" onClick="$('#edit-job-notes').hide(); $('#show-job-notes').show(); return false;">Cancel</a>
                 </div>
@@ -274,6 +274,10 @@ $('#delete-job').on('click', function(event) {
         </div>
     </div>
 
+</div>
+<div class="row">
+    {% block job_content_details %}
+    {% endblock %}
 </div>
 
 {% endblock %}

--- a/digits/templates/models/images/classification/classify_many.html
+++ b/digits/templates/models/images/classification/classify_many.html
@@ -1,22 +1,31 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
-{% extends "layout.html" %}
+{% extends "job.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.name()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
 <li class="active"><a>Classify Many</a></li>
 {% endblock %}
 
-{% block content %}
+{% block job_content %}
 
 <div class="page-header">
     <h1>
-        {{job.name()}}
+        {{model_job.name()}}
         <small>
-            {{job.job_type()}}
+            {{model_job.job_type()}}
         </small>
     </h1>
 </div>
 
+{% if not classifications %}
+<div class="alert alert-danger">
+        <p>Classification failed, see job log</p>
+</div>
+{% endif %}
+
+{% endblock %}
+
+{% block job_content_details %}
 
 <table class="table">
     <tr>
@@ -24,6 +33,7 @@
         {% if show_ground_truth %}<th>Ground truth</th>{% endif %}
         <th colspan=10>Top predictions</th>
     </tr>
+    {% if classifications %}
     {% for path in paths %}
     {% set result = classifications[loop.index0] %}
     {% set ground_truth = ground_truths[loop.index0] %}
@@ -40,6 +50,7 @@
         {% endfor %}
     </tr>
     {% endfor %}
+    {% endif %}
 </table>
 
 {% endblock %}

--- a/digits/templates/models/images/classification/classify_one.html
+++ b/digits/templates/models/images/classification/classify_one.html
@@ -1,25 +1,26 @@
 {# Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved. #}
-{% extends "layout.html" %}
+{% extends "job.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.name()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
 <li class="active"><a>Classify One</a></li>
 {% endblock %}
 
-{% block content %}
+{% block job_content %}
 
 <script src="{{ url_for('static', filename='js/jquery.elevateZoom.min.js') }}"></script>
 
 <div class="page-header">
     <h1>
-        {{job.name()}}
+        {{model_job.name()}}
         <small>
-            {{job.job_type()}}
+            {{model_job.job_type()}}
         </small>
     </h1>
 </div>
 
 <div class="row">
+    {% if image_src %}
     <div class="col-sm-6">
         <img src="{{image_src}}" style="max-width:100%;" />
     </div>
@@ -35,7 +36,17 @@
             {% endfor %}
         </ul>
     </div>
+    {% else %}
+    <div class="alert alert-danger">
+        <p>Classification failed, see job log</p>
+    </div>
+    {% endif %}
 </div>
+
+{% endblock %}
+
+{% block job_content_details %}
+
 <script type="text/javascript">
     function drawHistogram(id, data) {
         c3.generate({

--- a/digits/templates/models/images/classification/top_n.html
+++ b/digits/templates/models/images/classification/top_n.html
@@ -1,18 +1,29 @@
 {# Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
-{% extends "layout.html" %}
+{% extends "job.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.job_type()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.job_type()}}</a></li>
 <li class="active"><a>Top N</a></li>
 {% endblock %}
 
-{% block content %}
+{% block job_content %}
 
 <div class="page-header">
     <h1>Top N Predictions per Category</h1>
 </div>
 
+{% if not results %}
+<div class="alert alert-danger">
+        <p>Classification failed, see job log</p>
+</div>
+{% endif %}
+
+{% endblock %}
+
+{% block job_content_details %}
+
+{% if results %}
 <table class="table">
     <tr>
         <th>Category</th>
@@ -27,5 +38,6 @@
     </tr>
     {% endfor %}
 </table>
+{% endif %}
 
 {% endblock %}

--- a/digits/templates/models/images/generic/infer_many.html
+++ b/digits/templates/models/images/generic/infer_many.html
@@ -1,23 +1,33 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
-{% extends "layout.html" %}
+{% extends "job.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.name()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
 <li class="active"><a>Test Many</a></li>
 {% endblock %}
 
-{% block content %}
+{% block job_content %}
 
 <div class="page-header">
     <h1>
-        {{job.name()}}
+        {{model_job.name()}}
         <small>
             {{job.job_type()}}
         </small>
     </h1>
 </div>
 
+{% if not network_outputs %}
+<div class="alert alert-danger">
+    <p>Inference failed, see job log</p>
+</div>
+{% endif %}
 
+{% endblock %}
+
+{% block job_content_details %}
+
+{% if network_outputs %}
 <table class="table">
     <tr>
         <th>Image</th>
@@ -35,6 +45,7 @@
     </tr>
     {% endfor %}
 </table>
+{% endif %}
 
 {% endblock %}
 

--- a/digits/templates/models/images/generic/infer_one.html
+++ b/digits/templates/models/images/generic/infer_one.html
@@ -1,26 +1,27 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
-{% extends "layout.html" %}
+{% extends "job.html" %}
 
 {% block nav %}
-<li><a href="{{url_for('digits.model.views.show', job_id=job.id())}}">{{job.name()}}</a></li>
+<li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
 <li class="active"><a>Test One</a></li>
 {% endblock %}
 
-{% block content %}
+{% block job_content %}
 
 <script src="{{ url_for('static', filename='js/jquery.elevateZoom.min.js') }}"></script>
 
 <div class="page-header">
     <h1>
-        {{job.name()}}
+        {{model_job.name()}}
         <small>
-            {{job.job_type()}}
+            {{model_job.job_type()}}
         </small>
     </h1>
 </div>
 
 
 <div class="row">
+    {% if image_src %}
     <div class="col-sm-6">
         <img src="{{image_src}}" style="max-width:100%;" />
     </div>
@@ -31,7 +32,17 @@
         {{blob}}
         {% endfor %}
     </div>
+    {% else %}
+    <div class="alert alert-danger">
+        <p>Inference failed, see job log</p>
+    </div>
+    {% endif %}
 </div>
+
+{% endblock %}
+
+{% block job_content_details %}
+
 <script type="text/javascript">
     function drawHistogram(id, data) {
         c3.generate({

--- a/digits/utils/auth.py
+++ b/digits/utils/auth.py
@@ -63,6 +63,9 @@ def has_permission(job, action, username=None):
     Keyword arguments:
     username -- the user in question (defaults to current user)
     """
+    if job.is_read_only():
+        return False
+
     if username is None:
         username = get_username()
 

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python2
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+
+import argparse
+import base64
+import h5py
+import logging
+import numpy as np
+import PIL.Image
+import os
+import sys
+
+# Add path for DIGITS package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import digits.config
+digits.config.load_config()
+from digits import frameworks
+from digits import utils, log
+from digits.dataset import GenericImageDatasetJob
+from digits.dataset import ImageClassificationDatasetJob
+from digits.inference.errors import InferenceError
+from digits.job import Job
+
+# must call digits.config.load_config() before caffe to set the path
+import caffe.io
+import caffe_pb2
+
+logger = logging.getLogger('digits.tools.inference')
+
+"""
+Perform inference on a list of images using the specified model
+"""
+def infer(input_list, output_dir, jobs_dir, model_id, epoch, batch_size, layers, gpu):
+
+    # job directory defaults to that defined in DIGITS config
+    if jobs_dir == 'none':
+        jobs_dir = digits.config.config_value('jobs_dir')
+
+    # load model job
+    model_dir = os.path.join(jobs_dir, model_id)
+    assert os.path.isdir(model_dir), "Model dir %s does not exist" % model_dir
+    model = Job.load(model_dir)
+
+    # load dataset job
+    dataset_dir = os.path.join(jobs_dir, model.dataset_id)
+    assert os.path.isdir(dataset_dir), "Dataset dir %s does not exist" % dataset_dir
+    dataset = Job.load(dataset_dir)
+    for task in model.tasks:
+        task.dataset = dataset
+
+    # retrieve snapshot file
+    task = model.train_task()
+    snapshot_filename = None
+    epoch = float(epoch)
+    if epoch == -1 and len(task.snapshots):
+        # use last epoch
+        epoch = task.snapshots[-1][1]
+        snapshot_filename = task.snapshots[-1][0]
+    else:
+        for f, e in task.snapshots:
+            if e == epoch:
+                snapshot_filename = f
+                break
+    if not snapshot_filename:
+        raise InferenceError("Unable to find snapshot for epoch=%s" % repr(self.epoch))
+
+    # retrieve image dimensions and resize mode
+    if isinstance(dataset, ImageClassificationDatasetJob):
+        height = dataset.image_dims[0]
+        width = dataset.image_dims[1]
+        channels = dataset.image_dims[2]
+        resize_mode = dataset.resize_mode
+    elif isinstance(dataset, GenericImageDatasetJob):
+        db_task = dataset.analyze_db_tasks()[0]
+        height = db_task.image_height
+        width = db_task.image_width
+        channels = db_task.image_channels
+        resize_mode = 'squash'
+    else:
+        raise InferenceError("Unknown dataset type")
+
+    # load and resize images
+    images = []
+    paths = None
+    with open(input_list) as infile:
+        paths = infile.readlines()
+    for path in paths:
+        path = path.strip()
+        try:
+            image = utils.image.load_image(path.strip())
+            image = utils.image.resize_image(image,
+                        height, width,
+                        channels    = channels,
+                        resize_mode = resize_mode,
+                        )
+            images.append(image)
+        except utils.errors.LoadImageError as e:
+            print e
+
+    # perform inference
+    visualizations = None
+    predictions = []
+
+    if len(images) == 0:
+        raise InferenceError("Unable to load any image from file '%s'" % repr(input_list))
+    elif len(images) == 1:
+        # single image inference
+        outputs, visualizations = model.train_task().infer_one(images[0], snapshot_epoch=epoch, layers=layers, gpu=gpu)
+    else:
+        assert layers == 'none'
+        outputs = model.train_task().infer_many(images, snapshot_epoch=epoch, gpu=gpu)
+
+    # write to hdf5 file
+    db_path = os.path.join(output_dir, 'inference.hdf5')
+    db = h5py.File(db_path, 'w')
+
+    # write input images to database
+    db.create_dataset("inputs", data = images)
+
+    # write outputs to database
+    db_outputs = db.create_group("outputs")
+    for output_name,output_data in outputs.items():
+        output_key = base64.urlsafe_b64encode(str(output_name))
+        db_outputs.create_dataset(output_key, data=output_data)
+
+    # write visualization data
+    if visualizations is not None and len(visualizations)>0:
+        db_layers = db.create_group("layers")
+        for idx, layer in enumerate(visualizations):
+            vis = layer['vis'] if layer['vis'] is not None else np.empty(0)
+            dset = db_layers.create_dataset(str(idx), data=vis)
+            dset.attrs['name'] = layer['name']
+            dset.attrs['vis_type'] = layer['vis_type']
+            if 'param_count' in layer:
+                dset.attrs['param_count'] = layer['param_count']
+            if 'layer_type' in layer:
+                dset.attrs['layer_type'] = layer['layer_type']
+            dset.attrs['shape'] = layer['data_stats']['shape']
+            dset.attrs['mean'] = layer['data_stats']['mean']
+            dset.attrs['stddev'] = layer['data_stats']['stddev']
+            dset.attrs['histogram_y'] = layer['data_stats']['histogram'][0]
+            dset.attrs['histogram_x'] = layer['data_stats']['histogram'][1]
+            dset.attrs['histogram_ticks'] = layer['data_stats']['histogram'][2]
+    db.close()
+    logger.info('Saved data to %s', db_path)
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Inference tool - DIGITS')
+
+    ### Positional arguments
+
+    parser.add_argument('input_list',
+            help='An input file containing paths to input data')
+    parser.add_argument('output_dir',
+            help='Directory to write outputs to')
+    parser.add_argument('model',
+            help='Model ID')
+
+    ### Optional arguments
+    parser.add_argument('-e', '--epoch',
+            default='-1',
+            help="Epoch (-1 for last)"
+            )
+
+    parser.add_argument('-j', '--jobs_dir',
+            default='none',
+            help='Jobs directory (default: from DIGITS config)',
+            )
+
+    parser.add_argument('-l', '--layers',
+            default='none',
+            help='Which layers to write to output ("none" [default] or "all")',
+            )
+
+    parser.add_argument('-b', '--batch_size',
+            type=int,
+            default=1,
+            help='Batch size',
+            )
+
+    parser.add_argument('-g', '--gpu',
+            type=int,
+            default=None,
+            help='GPU to use (as in nvidia-smi output, default: None)',
+            )
+
+    args = vars(parser.parse_args())
+
+    try:
+        infer(
+            args['input_list'],
+            args['output_dir'],
+            args['jobs_dir'],
+            args['model'],
+            args['epoch'],
+            args['batch_size'],
+            args['layers'],
+            args['gpu'],
+                )
+    except Exception as e:
+        logger.error('%s: %s' % (type(e).__name__, e.message))
+        raise
+


### PR DESCRIPTION
Move inference to separate job

### Motivation

* Allow inference to run on different machine within cluster
* Allow long inference jobs to report progress through socketio
* Allow inference to reserve resources (GPUs)
* Image resizing done outside of server context
* Provide command-line inferface for inference using *exactly* the same path as DIGITS

### Features 

No new feature, will implement socketio updates in separate pull request

### Summary of changes

* New job and task created for inference
* To limit changes in source code, re-use existing inference API from model job/task
* No code duplication between Caffe/Torch, Classification/Generic
* New inference.py tool performs image resizing and inference
* Results are communicated back to DIGITS through a HDF5 file on filesystem

### Progress

- [x] Caffe single-image classification
- [x] Torch single-image classification
- [x] Caffe single-image inference
- [x] Torch single-image inference
- [x] Caffe multiple-image classification
- [x] Torch multiple-image classification
- [x] Caffe multiple-image inference
- [x] Torch multiple-image inference
- [x] Caffe layer visualizations
- [x] Torch layer visualizations
- [x] Delete job when done
- [x] Code Clean-up
- [x] Pass nostests
- [ ] Fix code coverage in presence of sub-processes
- [ ] Fix nosetest slowliness



