### PR TITLE
Fix timing in example/classification scripts

### DIFF
--- a/examples/classification/example.py
+++ b/examples/classification/example.py
@@ -141,12 +141,14 @@ def forward_pass(images, net, transformer, batch_size=None):
         for index, image in enumerate(chunk):
             image_data = transformer.preprocess('data', image)
             net.blobs['data'].data[index] = image_data
+        start = time.time()
         output = net.forward()[net.outputs[-1]]
+        end = time.time()
         if scores is None:
             scores = np.copy(output)
         else:
             scores = np.vstack((scores, output))
-        print 'Processed %s/%s images ...' % (len(scores), len(caffe_images))
+        print 'Processed %s/%s images in %f seconds ...' % (len(scores), len(caffe_images), (end - start))
 
     return scores
 
@@ -199,9 +201,7 @@ def classify(caffemodel, deploy_file, image_files,
     labels = read_labels(labels_file)
 
     # Classify the image
-    classify_start_time = time.time()
     scores = forward_pass(images, net, transformer, batch_size=batch_size)
-    print 'Classification took %s seconds.' % (time.time() - classify_start_time,)
 
     ### Process the results
 
@@ -255,5 +255,5 @@ if __name__ == '__main__':
     classify(args['caffemodel'], args['deploy_file'], args['image_file'],
             args['mean'], args['labels'], not args['nogpu'])
 
-    print 'Script took %s seconds.' % (time.time() - script_start_time,)
+    print 'Script took %f seconds.' % (time.time() - script_start_time,)
 

--- a/examples/classification/use_archive.py
+++ b/examples/classification/use_archive.py
@@ -101,5 +101,5 @@ if __name__ == '__main__':
                           use_gpu=(not args['nogpu']),
                           )
 
-    print 'Script took %s seconds.' % (time.time() - script_start_time,)
+    print 'Script took %f seconds.' % (time.time() - script_start_time,)
 


### PR DESCRIPTION
Previously, the scripts printed out a misleading message:
```
Processed 1/1 images ...
Classification took 0.0561039447784 seconds.
```
In fact, that value included more computation than just the `net.forward()` call.

Now, you get much more accurate timing information. You can see the difference between the first batch and any subsequent batch, for example:
```
Processed 1/1 images in 0.031234 seconds ...
Processed 1/1 images in 0.006955 seconds ...
Processed 1/1 images in 0.006529 seconds ...
```
Thanks for @flx42 for pointing this out!