### PR TITLE
pass batch_size to classify() via command line

### DIFF
--- a/examples/classification/example.py
+++ b/examples/classification/example.py
@@ -253,7 +253,7 @@ if __name__ == '__main__':
     args = vars(parser.parse_args())
 
     classify(args['caffemodel'], args['deploy_file'], args['image_file'],
-            args['mean'], args['labels'], not args['nogpu'])
+            args['mean'], args['labels'], args['batch_size'], not args['nogpu'])
 
     print 'Script took %f seconds.' % (time.time() - script_start_time,)
 


### PR DESCRIPTION
batch-size argument from command line wasn't being passed to classify(). This resulted in batch-size to always be 1 thereby reducing performance while classifying multiple images (wildcard input)


