### PR TITLE
Fix file serving for files with absolute paths

### DIFF
--- a/digits/job.py
+++ b/digits/job.py
@@ -123,8 +123,8 @@ class Job(StatusCls):
             path = filename
         else:
             path = os.path.join(self._dir, filename)
-        if relative:
-            path = os.path.relpath(path, config_value('jobs_dir'))
+            if relative:
+                path = os.path.relpath(path, config_value('jobs_dir'))
         return str(path).replace("\\","/")
 
     def path_is_local(self, path):

--- a/digits/task.py
+++ b/digits/task.py
@@ -133,8 +133,8 @@ class Task(StatusCls):
             path = filename
         else:
             path = os.path.join(self.job_dir, filename)
-        if relative:
-            path = os.path.relpath(path, config_value('jobs_dir'))
+            if relative:
+                path = os.path.relpath(path, config_value('jobs_dir'))
         return str(path).replace("\\","/")
 
     def ready_to_queue(self):

--- a/digits/templates/datasets/images/classification/show.html
+++ b/digits/templates/datasets/images/classification/show.html
@@ -1,6 +1,7 @@
 {# Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
 {% extends "job.html" %}
+{% from "helper.html" import serve_file %}
 
 {% macro print_job_information() %}
 <div class="panel-heading">
@@ -79,10 +80,10 @@
 <div class="panel-body">
     <dl>
         <dt>Input File{{' (before shuffling)' if task.shuffle }}</dt>
-        <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.input_file, relative=True))}}">{{task.input_file}}</a></dd>
+        <dd>{{serve_file(task, task.input_file)}}</dd>
         {% if task.create_db_log_file %}
         <dt>DB Creation log file</dt>
-        <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.create_db_log_file, relative=True))}}">{{task.create_db_log_file}}</a></dd>
+        <dd>{{serve_file(task, task.create_db_log_file)}}</dd>
         {% endif %}
         {% if task.entries_count %}
         <dt>DB Entries</dt>

--- a/digits/templates/datasets/images/generic/show.html
+++ b/digits/templates/datasets/images/generic/show.html
@@ -1,6 +1,7 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
 {% extends "job.html" %}
+{% from "helper.html" import serve_file %}
 
 {% macro print_analyze_db_task(task) %}
 <div class="panel-heading">
@@ -30,7 +31,7 @@
         </dd>
         {% if task.analyze_db_log_file %}
         <dt>DB analysis log file</dt>
-        <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.analyze_db_log_file, relative=True))}}">{{task.analyze_db_log_file}}</a></dd>
+        <dd>{{serve_file(task, task.analyze_db_log_file)}}</dd>
         {% endif %}
     </dl>
 </div>

--- a/digits/templates/helper.html
+++ b/digits/templates/helper.html
@@ -51,3 +51,12 @@
         {{ ' has-warning' if form.warnings else '' }}
     {% endfor %}
 {% endmacro %}
+
+{% macro serve_file(obj, path) %}
+    {% if path[0] == '/' %}
+        {# Absolute path - don't serve file for security reasons #}
+        {{path}}
+    {% else %}
+        <a href="{{url_for('digits.views.serve_file', path=obj.path(path, relative=True))}}">{{path}}</a>
+    {% endif %}
+{% endmacro %}

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -1,6 +1,7 @@
 {# Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
 {% extends "job.html" %}
+{% from "helper.html" import serve_file %}
 
 {% block job_content %}
 
@@ -18,11 +19,11 @@
                 <dd>{{job.disk_size_fmt()}}</dd>
                 {% for key,value in task.get_model_files().items() %}
                 <dt>{{key}}</dt>
-                <dd><a href="{{url_for('digits.views.serve_file', path=task.path(value, relative=True))}}">{{value}}</a></dd>
+                <dd>{{serve_file(task, value)}}</dd>
                 {% endfor %}
                 {% if task.log_file %}
                 <dt>Raw {{task.get_framework_id()}} output</dt>
-                <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.log_file, relative=True))}}">{{task.log_file}}</a></dd>
+                <dd>{{serve_file(task, task.log_file)}}</dd>
                 {% endif %}
                 {% if task.pretrained_model %}
                 <dt>Pretrained Model</dt>

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -1,6 +1,7 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
 {% extends "job.html" %}
+{% from "helper.html" import serve_file %}
 
 {% block job_content %}
 
@@ -18,11 +19,11 @@
                 <dd>{{job.disk_size_fmt()}}</dd>
                 {% for key,value in task.get_model_files().items() %}
                 <dt>{{key}}</dt>
-                <dd><a href="{{url_for('digits.views.serve_file', path=task.path(value, relative=True))}}">{{value}}</a></dd>
+                <dd>{{serve_file(task, value)}}</dd>
                 {% endfor %}
                 {% if task.log_file %}
                 <dt>Raw {{task.get_framework_id()}} output</dt>
-                <dd><a href="{{url_for('digits.views.serve_file', path=task.path(task.log_file, relative=True))}}">{{task.log_file}}</a></dd>
+                <dd>{{serve_file(task, task.log_file)}}</dd>
                 {% endif %}
                 {% if task.pretrained_model %}
                 <dt>Pretrained Model</dt>


### PR DESCRIPTION
Bug reported at https://groups.google.com/d/msg/digits-users/MW_kHbOEqNo/y7wXpvlSFAAJ

To reproduce:
* Create a dataset from textfiles on the server (i.e. enter the path on the server manually)
* Click on the textfile from the DatasetJob page
* Get a 404 error because the path is wrong