### PR TITLE
Use image limit value for "Classify/Test Many"

### DIFF
--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -353,6 +353,11 @@ def classify_many():
     else:
         image_folder = None
 
+    if 'num_test_images' in flask.request.form and flask.request.form['num_test_images'].strip():
+        num_test_images = int(flask.request.form['num_test_images'])
+    else:
+        num_test_images = None
+
     epoch = None
     if 'snapshot_epoch' in flask.request.form:
         epoch = float(flask.request.form['snapshot_epoch'])
@@ -379,6 +384,9 @@ def classify_many():
             path = os.path.join(image_folder, path)
         paths.append(path)
         ground_truths.append(ground_truth)
+
+        if num_test_images is not None and len(paths) >= num_test_images:
+            break
 
     # create inference job
     inference_job = ImageInferenceJob(
@@ -457,10 +465,11 @@ def top_n():
         top_n = int(flask.request.form['top_n'])
     else:
         top_n = 9
+
     if 'num_test_images' in flask.request.form and flask.request.form['num_test_images'].strip():
-        num_images = int(flask.request.form['num_test_images'])
+        num_test_images = int(flask.request.form['num_test_images'])
     else:
-        num_images = None
+        num_test_images = None
 
     paths = []
     for line in image_list.readlines():
@@ -476,6 +485,10 @@ def top_n():
         else:
             path = line
         paths.append(path)
+
+        if num_test_images is not None and len(paths) >= num_test_images:
+            break
+
     random.shuffle(paths)
 
     # create inference job

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -320,6 +320,11 @@ def infer_many():
     else:
         image_folder = None
 
+    if 'num_test_images' in flask.request.form and flask.request.form['num_test_images'].strip():
+        num_test_images = int(flask.request.form['num_test_images'])
+    else:
+        num_test_images = None
+
     epoch = None
     if 'snapshot_epoch' in flask.request.form:
         epoch = float(flask.request.form['snapshot_epoch'])
@@ -342,6 +347,9 @@ def infer_many():
         if not utils.is_url(path) and image_folder and not os.path.isabs(path):
             path = os.path.join(image_folder, path)
         paths.append(path)
+
+        if num_test_images is not None and len(paths) >= num_test_images:
+            break
 
     # create inference job
     inference_job = ImageInferenceJob(

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -187,6 +187,11 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             <input type="text" id="image_folder" name="image_folder" class="form-control autocomplete_path">
                             <small>Relative paths in the text file will be prepended with this value before reading</small>
                         </div>
+                        <div class="form-group">
+                            <label for="num_test_images" class="control-label">Number of images use from the file</label>
+                            <input type="text" id="num_test_images" name="num_test_images" class="form-control" placeholder="All">
+                            <small>Leave blank to use all</small>
+                        </div>
                         <button name="classify-many-btn"
                             formaction="{{url_for('digits.model.images.classification.views.classify_many', job_id=job.id())}}"
                             formmethod="post"
@@ -200,11 +205,6 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             data-container="body"
                             title="Classify a list of images and show the top 5 category predictions for each."
                             ></span>
-                        <div class="form-group">
-                            <label for="num_test_images" class="control-label">Number of images use from the file</label>
-                            <input type="text" id="num_test_images" name="num_test_images" class="form-control" value="100" placeholder="All">
-                            <small>Leave blank to use all</small>
-                        </div>
                         <div class="form-group">
                             <label for="top_n" class="control-label">Number of images to show per category</label>
                             <input type="text" id="top_n" name="top_n" class="form-control" placeholder="9">

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -180,6 +180,11 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             <input type="text" id="image_folder" name="image_folder" class="form-control autocomplete_path">
                             <small>Relative paths in the text file will be prepended with this value before reading</small>
                         </div>
+                        <div class="form-group">
+                            <label for="num_test_images" class="control-label">Number of images use from the file</label>
+                            <input type="text" id="num_test_images" name="num_test_images" class="form-control" placeholder="All">
+                            <small>Leave blank to use all</small>
+                        </div>
                         <button name="infer-many-btn"
                             formaction="{{url_for('digits.model.images.generic.views.infer_many', job_id=job.id())}}"
                             formmethod="post"


### PR DESCRIPTION
As requested, now the "Classify Many" and "Test Many" tools can use the image limit value.
* Use `num_test_images` for "Classify Many"
* Add `num_test_images` to generic path for "Test Many"
* Default to "All" instead of 100
* Remove a print debugging statement

---

![highlight-image-limit](https://cloud.githubusercontent.com/assets/687269/13232322/928124c6-d963-11e5-9555-48941e29aa27.jpg)