### PR TITLE
Fix capitalization of python-flask package in docs

### DIFF
--- a/docs/BuildDigits.md
+++ b/docs/BuildDigits.md
@@ -34,7 +34,7 @@ Several PyPI packages need to be installed.
 
 To speed up installation, you could install most of these via apt-get packages first.
 ```sh
-% sudo apt-get install python-pil python-numpy python-scipy python-protobuf python-gevent python-Flask python-flaskext.wtf gunicorn python-h5py
+% sudo apt-get install python-pil python-numpy python-scipy python-protobuf python-gevent python-flask python-flaskext.wtf gunicorn python-h5py
 ```
 
 ## Caffe


### PR DESCRIPTION
The package is actually lowercase: http://packages.ubuntu.com/trusty/python-flask

Ubuntu 14.04 doesn't mind the sloppy capitalization, but 16.04 does.