### PR TITLE
Deep copy in infer_many

### DIFF
--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+import copy
 import math
 import operator
 import os
@@ -1258,7 +1259,7 @@ class CaffeTrainTask(TrainTask):
                         'data', image)
             o = net.forward()
             if outputs is None:
-                outputs = o
+                outputs = copy.deepcopy(o)
             else:
                 for name,blob in o.iteritems():
                     outputs[name] = np.vstack((outputs[name], blob))


### PR DESCRIPTION
*Fix #599*

Fix a few problems:

1. Shallow copying - `infer_many` results are wrong for some images

  * Classification - https://github.com/NVIDIA/DIGITS/pull/361 snuck back in with https://github.com/NVIDIA/DIGITS/pull/573
  * Generic - has been wrong all along ([see here](https://github.com/NVIDIA/DIGITS/blob/f42f473710/digits/model/tasks/caffe_train.py#L1241))

2. ~~Output ordering - the wrong network output is displayed (e.g. for GoogLeNet)~~

  * ~~With https://github.com/NVIDIA/DIGITS/pull/573, network output order is lost and the wrong values are displayed~~

@gheinrich can you verify?