### PR TITLE
Fix inference image paths in presence of invalid paths

### DIFF
--- a/digits/inference/tasks/inference.py
+++ b/digits/inference/tasks/inference.py
@@ -105,7 +105,6 @@ class InferenceTask(Task):
         super(InferenceTask, self).after_run()
 
         # retrieve inference data
-        inputs = None
         visualizations = []
         outputs = {}
         if self.inference_data_filename is not None:
@@ -115,8 +114,9 @@ class InferenceTask(Task):
             # - layer activations and weights, if requested, in a group "/layers/"
             db = h5py.File(self.inference_data_filename, 'r')
 
-            # collect inputs
-            inputs = db['inputs'][...]
+            # collect paths and data
+            input_ids = db['input_ids'][...]
+            input_data = db['input_data'][...]
 
             # collect outputs
             for output_key, output_data in db['outputs'].items():
@@ -152,12 +152,11 @@ class InferenceTask(Task):
                 # sort by layer ID (as HDF5 ASCII sorts)
                 visualizations = sorted(visualizations,key=lambda x:x['id'])
             db.close()
+            # save inference data for further use
+            self.inference_inputs = {'ids': input_ids, 'data': input_data}
+            self.inference_outputs = outputs
+            self.inference_layers = visualizations
         self.inference_log.close()
-
-        # save inference to data for further use
-        self.inference_inputs = inputs
-        self.inference_outputs = outputs
-        self.inference_layers = visualizations
 
     @override
     def offer_resources(self, resources):

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -286,8 +286,8 @@ def infer_one():
         pass
 
     image = None
-    if inputs is not None and len(inputs) == 1:
-        image = utils.image.embed_image_html(inputs[0])
+    if inputs is not None and len(inputs['data']) == 1:
+        image = utils.image.embed_image_html(inputs['data'][0])
 
     if request_wants_json():
         return flask.jsonify({'outputs': dict((name, blob.tolist()) for name,blob in outputs.iteritems())})
@@ -373,9 +373,12 @@ def infer_many():
     # delete job folder and remove from scheduler list
     scheduler.delete_job(inference_job)
 
-    if len(outputs) < 1:
+    if outputs is not None and len(outputs) < 1:
         # an error occurred
         outputs = None
+
+    if inputs is not None:
+        paths = [paths[idx] for idx in inputs['ids']]
 
     if request_wants_json():
         result = {}


### PR DESCRIPTION
Bug introduced by #573: if a path from the list is invalid this leads to a misalignment between image paths and predictions, like:
![test-many-one-invalid-path](https://cloud.githubusercontent.com/assets/3889770/13353623/f48a2e58-dc95-11e5-8149-cb624db6d3c9.png)

To fix this the image paths of images that were successfully loaded must be returned by the inference tool.
