### PR TITLE
 	Show accuracy and confusion matrix in classify_many

### DIFF
--- a/digits/inference/tasks/inference.py
+++ b/digits/inference/tasks/inference.py
@@ -105,7 +105,6 @@ class InferenceTask(Task):
         super(InferenceTask, self).after_run()
 
         # retrieve inference data
-        inputs = None
         visualizations = []
         outputs = {}
         if self.inference_data_filename is not None:
@@ -115,8 +114,9 @@ class InferenceTask(Task):
             # - layer activations and weights, if requested, in a group "/layers/"
             db = h5py.File(self.inference_data_filename, 'r')
 
-            # collect inputs
-            inputs = db['inputs'][...]
+            # collect paths and data
+            input_ids = db['input_ids'][...]
+            input_data = db['input_data'][...]
 
             # collect outputs
             for output_key, output_data in db['outputs'].items():
@@ -152,12 +152,11 @@ class InferenceTask(Task):
                 # sort by layer ID (as HDF5 ASCII sorts)
                 visualizations = sorted(visualizations,key=lambda x:x['id'])
             db.close()
+            # save inference data for further use
+            self.inference_inputs = {'ids': input_ids, 'data': input_data}
+            self.inference_outputs = outputs
+            self.inference_layers = visualizations
         self.inference_log.close()
-
-        # save inference to data for further use
-        self.inference_inputs = inputs
-        self.inference_outputs = outputs
-        self.inference_layers = visualizations
 
     @override
     def offer_resources(self, resources):

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -286,8 +286,8 @@ def infer_one():
         pass
 
     image = None
-    if inputs is not None and len(inputs) == 1:
-        image = utils.image.embed_image_html(inputs[0])
+    if inputs is not None and len(inputs['data']) == 1:
+        image = utils.image.embed_image_html(inputs['data'][0])
 
     if request_wants_json():
         return flask.jsonify({'outputs': dict((name, blob.tolist()) for name,blob in outputs.iteritems())})
@@ -373,9 +373,12 @@ def infer_many():
     # delete job folder and remove from scheduler list
     scheduler.delete_job(inference_job)
 
-    if len(outputs) < 1:
+    if outputs is not None and len(outputs) < 1:
         # an error occurred
         outputs = None
+
+    if inputs is not None:
+        paths = [paths[idx] for idx in inputs['ids']]
 
     if request_wants_json():
         result = {}

--- a/digits/templates/models/images/classification/classify_many.html
+++ b/digits/templates/models/images/classification/classify_many.html
@@ -23,17 +23,63 @@
 </div>
 {% endif %}
 
+{% if show_ground_truth %}
+<div class="panel-heading">
+    <h4>Summary</h4>
+</div>
+<div class="panel-body">
+    <dl>
+        <dt>Top-1 accuracy</dt>
+        <dd>{{top1_accuracy}}%</dd>
+    </dl>
+    <dl>
+        <dt>Top-5 accuracy</dt>
+        <dd>{{top5_accuracy}}%</dd>
+    </dl>
+</div>
+{% endif %}
+
 {% endblock %}
 
 {% block job_content_details %}
 
+{% if classifications %}
+    {% if show_ground_truth %}
+    <div class="panel-heading">
+        <h4>Confusion matrix</h4>
+    </div>
+    <table class="table">
+        <tr>
+            <th></th>
+            {% for label in labels %}
+                <th>{{label}}</th>
+            {% endfor %}
+            <th>Per-class accuracy</th>
+        </tr>
+        {% for row in confusion_matrix %}
+            {% set label_idx = loop.index0 %}
+            {% if per_class_accuracy[label_idx] is not none %}
+            <tr>
+                <th>{{labels[label_idx]}}</th>
+                {% for column in row %}
+                    {% set column_idx = loop.index[0] %}
+                    <td>{{column}}</td>
+                {% endfor %}
+                <td>{{per_class_accuracy[label_idx]}}%</td>
+            </tr>
+            {% endif %}
+        {% endfor %}
+    </table>
+    {% endif %}
+<div class="panel-heading">
+    <h4>All classifications</h4>
+</div>
 <table class="table">
     <tr>
         <th>Path</th>
         {% if show_ground_truth %}<th>Ground truth</th>{% endif %}
         <th colspan=10>Top predictions</th>
     </tr>
-    {% if classifications %}
     {% for path in paths %}
     {% set result = classifications[loop.index0] %}
     {% set ground_truth = ground_truths[loop.index0] %}
@@ -50,8 +96,8 @@
         {% endfor %}
     </tr>
     {% endfor %}
-    {% endif %}
 </table>
+{% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
Show some stats when ground truth is provided in text file:
- top-1 accuracy,
- top-5 accuracy,
- per-class accuracy,
- confusion matrix.


This may produce output like:
![alexnet-classify-many-stats](https://cloud.githubusercontent.com/assets/3889770/13394176/fa0198aa-dee6-11e5-94a7-254cb8ae120e.png)
