### PR TITLE
Show image index for infer_many

### DIFF
--- a/digits/templates/models/images/classification/classify_many.html
+++ b/digits/templates/models/images/classification/classify_many.html
@@ -29,6 +29,7 @@
 
 <table class="table">
     <tr>
+        <td></td>
         <th>Path</th>
         {% if show_ground_truth %}<th>Ground truth</th>{% endif %}
         <th colspan=10>Top predictions</th>
@@ -38,6 +39,7 @@
     {% set result = classifications[loop.index0] %}
     {% set ground_truth = ground_truths[loop.index0] %}
     <tr>
+        <td>{{loop.index}}</td>
         <td>{{path}}</td>
         {% if show_ground_truth %}<td>{% if ground_truth is not none%}{{ground_truth}}{% endif %}</td>{% endif %}
         {% for r in result %}

--- a/digits/templates/models/images/generic/infer_many.html
+++ b/digits/templates/models/images/generic/infer_many.html
@@ -30,6 +30,7 @@
 {% if network_outputs %}
 <table class="table">
     <tr>
+        <td></td>
         <th>Image</th>
         {% for key in network_outputs.keys() %}
         <th>{{key}}</th>
@@ -37,6 +38,7 @@
     </tr>
     {% for path in paths %}
     <tr>
+        <td>{{loop.index}}</td>
         <td>{{path}}</td>
         {% set index=loop.index0 %}
         {% for key, val in network_outputs.iteritems() %}


### PR DESCRIPTION
This mostly helpful when debugging shallow copy errors because it's easy to see when the first 16 images are wrong and everything else is right, for example. Hopefully with #603 those issues will go away and never come back, but this seems like it could still be useful.

Here's a screenshot of this feature used in conjunction with #608 (adds numbering to the bottom table):

![infer-many-loop-index](https://cloud.githubusercontent.com/assets/687269/13405804/1954bda2-ded5-11e5-8d03-33d21d135b1f.jpg)