### PR TITLE
Reduce scheduler polling period in test mode

### DIFF
--- a/digits/scheduler.py
+++ b/digits/scheduler.py
@@ -405,8 +405,10 @@ class Scheduler:
                         if job.status.is_running():
                             job.save()
                     last_saved = time.time()
-
-                time.sleep(utils.wait_time())
+                if 'DIGITS_MODE_TEST' not in os.environ:
+                    time.sleep(utils.wait_time())
+                else:
+                    time.sleep(0.05)
         except KeyboardInterrupt:
             pass
 


### PR DESCRIPTION
On my workstation this reduces the time to execute the following command to 29s down from 36s.
```
./digits-test digits/model/images/classification/test_views.py:TestCaffeCreated
```
Waiting to see the effect on Travis...