### PR TITLE
Changes to layer exclusion prefixes and Softmax-related code [DON'T MERGE]

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -52,14 +52,14 @@ layer {
     top: "output"
 }
 layer {
-    name: "loss"
+    name: "train_loss"
     type: "SoftmaxWithLoss"
     bottom: "output"
     bottom: "label"
     top: "loss"
 }
 layer {
-    name: "accuracy"
+    name: "train_accuracy"
     type: "Accuracy"
     bottom: "output"
     bottom: "label"
@@ -67,6 +67,12 @@ layer {
     include {
         phase: TEST
     }
+}
+layer {
+    name: "deploy_prob"
+    type: "Softmax"
+    bottom: "output"
+    top: "prob"
 }
 """
 
@@ -426,7 +432,7 @@ class BaseTestCreation(BaseViewsTestWithDataset):
                     top: "output"
                 }
                 layer {
-                    name: "loss"
+                    name: "train_loss"
                     type: "SoftmaxWithLoss"
                     bottom: "output"
                     bottom: "label"
@@ -834,14 +840,14 @@ layer {
     top: "output"
 }
 layer {
-    name: "loss"
+    name: "train_loss"
     type: "SoftmaxWithLoss"
     bottom: "output"
     bottom: "label"
     top: "loss"
 }
 layer {
-    name: "accuracy"
+    name: "train_accuracy"
     type: "Accuracy"
     bottom: "output"
     bottom: "label"
@@ -849,6 +855,12 @@ layer {
     include {
         phase: TEST
     }
+}
+layer {
+    name: "deploy_prob"
+    type: "Softmax"
+    bottom: "output"
+    top: "prob"
 }
 """
     TORCH_NETWORK = \
@@ -1001,14 +1013,14 @@ layer {
     top: "output"
 }
 layer {
-    name: "loss"
+    name: "train_loss"
     type: "SoftmaxWithLoss"
     bottom: "output"
     bottom: "label"
     top: "loss"
 }
 layer {
-    name: "accuracy"
+    name: "train_accuracy"
     type: "Accuracy"
     bottom: "output"
     bottom: "label"
@@ -1027,7 +1039,12 @@ layer {
         layer: "PythonLayer"
     }
 }
-
+layer {
+    name: "deploy_prob"
+    type: "Softmax"
+    bottom: "output"
+    top: "prob"
+}
 """
     def write_python_layer_script(self, filename):
         with open(filename, 'w') as f:

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -34,6 +34,9 @@ CAFFE_TRAIN_VAL_FILE = 'train_val.prototxt'
 CAFFE_SNAPSHOT_PREFIX = 'snapshot'
 CAFFE_DEPLOY_FILE = 'deploy.prototxt'
 
+TRAIN_VAL_LAYER_EXCLUSION_PREFIX = "deploy_"
+DEPLOY_LAYER_EXCLUSION_PREFIX = "train_"
+
 @subclass
 class Error(Exception):
     pass
@@ -244,7 +247,7 @@ class CaffeTrainTask(TrainTask):
         bottoms = {}
         train_data_layer = None
         val_data_layer = None
-        hidden_layers = caffe_pb2.NetParameter()
+        hidden_layers = []
         loss_layers = []
         accuracy_layers = []
         for layer in self.network.layer:
@@ -268,7 +271,7 @@ class CaffeTrainTask(TrainTask):
                 if addThis:
                     accuracy_layers.append(layer)
             else:
-                hidden_layers.layer.add().CopyFrom(layer)
+                hidden_layers.append(layer)
                 if len(layer.bottom) == 1 and len(layer.top) == 1 and layer.bottom[0] == layer.top[0]:
                     pass
                 else:
@@ -289,7 +292,7 @@ class CaffeTrainTask(TrainTask):
         assert len(network_outputs), 'network must have an output'
 
         # Update num_output for any output InnerProduct layers automatically
-        for layer in hidden_layers.layer:
+        for layer in hidden_layers:
             if layer.type == 'InnerProduct':
                 for top in layer.top:
                     if top in network_outputs:
@@ -413,7 +416,12 @@ class CaffeTrainTask(TrainTask):
                     val_data_layer.hdf5_data_param.batch_size = constants.DEFAULT_BATCH_SIZE
 
         # hidden layers
-        train_val_network.MergeFrom(hidden_layers)
+        for layer in hidden_layers:
+            # don't add layers with names starting with the exclusion prefix
+            if not layer.name.startswith(TRAIN_VAL_LAYER_EXCLUSION_PREFIX):
+                train_val_network.layer.add().CopyFrom(layer)
+                if layer.name.startswith(DEPLOY_LAYER_EXCLUSION_PREFIX):
+                    train_val_network.layer[-1].name = layer.name[len(DEPLOY_LAYER_EXCLUSION_PREFIX):]
 
         # output layers
         train_val_network.layer.extend(loss_layers)
@@ -445,7 +453,12 @@ class CaffeTrainTask(TrainTask):
             shape.dim.append(self.dataset.image_dims[1])
 
         # hidden layers
-        deploy_network.MergeFrom(hidden_layers)
+        for layer in hidden_layers:
+            # don't add layers with names starting with the exclusion prefix
+            if not layer.name.startswith(DEPLOY_LAYER_EXCLUSION_PREFIX):
+                deploy_network.layer.add().CopyFrom(layer)
+                if layer.name.startswith(TRAIN_VAL_LAYER_EXCLUSION_PREFIX):
+                    deploy_network.layer[-1].name = layer.name[len(TRAIN_VAL_LAYER_EXCLUSION_PREFIX):]
 
         # output layers
         if loss_layers[-1].type == 'SoftmaxWithLoss':
@@ -590,12 +603,12 @@ class CaffeTrainTask(TrainTask):
 
         for layer in self.network.layer:
             assert layer.type not in ['MemoryData', 'HDF5Data', 'ImageData'], 'unsupported data layer type'
-            if layer.name.startswith('train_'):
+            if layer.name.startswith(DEPLOY_LAYER_EXCLUSION_PREFIX):
                 train_val_layers.layer.add().CopyFrom(layer)
-                train_val_layers.layer[-1].name = train_val_layers.layer[-1].name[6:]
-            elif layer.name.startswith('deploy_'):
+                train_val_layers.layer[-1].name = train_val_layers.layer[-1].name[len(DEPLOY_LAYER_EXCLUSION_PREFIX):]
+            elif layer.name.startswith(TRAIN_VAL_LAYER_EXCLUSION_PREFIX):
                 deploy_layers.layer.add().CopyFrom(layer)
-                deploy_layers.layer[-1].name = deploy_layers.layer[-1].name[7:]
+                deploy_layers.layer[-1].name = deploy_layers.layer[-1].name[len(TRAIN_VAL_LAYER_EXCLUSION_PREFIX):]
             elif layer.type == 'Data':
                 for rule in layer.include:
                     if rule.phase == caffe_pb2.TRAIN:

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -444,6 +444,12 @@ class CaffeTrainTask(TrainTask):
         # network sanity checks
         self.logger.debug("Network sanity check - deploy")
         CaffeTrainTask.net_sanity_check(deploy_network, caffe_pb2.TEST)
+        found_softmax = False
+        for layer in deploy_network.layer:
+            if layer.type == 'Softmax':
+                found_softmax = True
+                break
+        assert found_softmax, 'Your deploy network is missing a Softmax layer! Read the documentation for custom networks and/or look at the standard networks for examples.'
 
         ### Write solver file
 

--- a/digits/standard-networks/caffe/alexnet.prototxt
+++ b/digits/standard-networks/caffe/alexnet.prototxt
@@ -358,7 +358,7 @@ layer {
   }
 }
 layer {
-  name: "accuracy"
+  name: "train_accuracy"
   type: "Accuracy"
   bottom: "fc8"
   bottom: "label"
@@ -368,9 +368,15 @@ layer {
   }
 }
 layer {
-  name: "loss"
+  name: "train_loss"
   type: "SoftmaxWithLoss"
   bottom: "fc8"
   bottom: "label"
   top: "loss"
+}
+layer {
+  name: "deploy_prob"
+  type: "Softmax"
+  bottom: "fc8"
+  top: "prob"
 }

--- a/digits/standard-networks/caffe/alexnet.prototxt
+++ b/digits/standard-networks/caffe/alexnet.prototxt
@@ -347,6 +347,10 @@ layer {
     decay_mult: 0
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 1000
     weight_filler {
       type: "gaussian"
       std: 0.01

--- a/digits/standard-networks/caffe/googlenet.prototxt
+++ b/digits/standard-networks/caffe/googlenet.prototxt
@@ -831,7 +831,7 @@ layer {
   top: "inception_4a/output"
 }
 layer {
-  name: "loss1/ave_pool"
+  name: "train_loss1/ave_pool"
   type: "Pooling"
   bottom: "inception_4a/output"
   top: "loss1/ave_pool"
@@ -842,7 +842,7 @@ layer {
   }
 }
 layer {
-  name: "loss1/conv"
+  name: "train_loss1/conv"
   type: "Convolution"
   bottom: "loss1/ave_pool"
   top: "loss1/conv"
@@ -868,13 +868,13 @@ layer {
   }
 }
 layer {
-  name: "loss1/relu_conv"
+  name: "train_loss1/relu_conv"
   type: "ReLU"
   bottom: "loss1/conv"
   top: "loss1/conv"
 }
 layer {
-  name: "loss1/fc"
+  name: "train_loss1/fc"
   type: "InnerProduct"
   bottom: "loss1/conv"
   top: "loss1/fc"
@@ -899,13 +899,13 @@ layer {
   }
 }
 layer {
-  name: "loss1/relu_fc"
+  name: "train_loss1/relu_fc"
   type: "ReLU"
   bottom: "loss1/fc"
   top: "loss1/fc"
 }
 layer {
-  name: "loss1/drop_fc"
+  name: "train_loss1/drop_fc"
   type: "Dropout"
   bottom: "loss1/fc"
   top: "loss1/fc"
@@ -914,7 +914,7 @@ layer {
   }
 }
 layer {
-  name: "loss1/classifier"
+  name: "train_loss1/classifier"
   type: "InnerProduct"
   bottom: "loss1/fc"
   top: "loss1/classifier"
@@ -938,7 +938,7 @@ layer {
   }
 }
 layer {
-  name: "loss1/loss"
+  name: "train_loss1/loss"
   type: "SoftmaxWithLoss"
   bottom: "loss1/classifier"
   bottom: "label"
@@ -946,7 +946,7 @@ layer {
   loss_weight: 0.3
 }
 layer {
-  name: "loss1/top-1"
+  name: "train_loss1/top-1"
   type: "Accuracy"
   bottom: "loss1/classifier"
   bottom: "label"
@@ -956,7 +956,7 @@ layer {
   }
 }
 layer {
-  name: "loss1/top-5"
+  name: "train_loss1/top-5"
   type: "Accuracy"
   bottom: "loss1/classifier"
   bottom: "label"
@@ -1614,7 +1614,7 @@ layer {
   top: "inception_4d/output"
 }
 layer {
-  name: "loss2/ave_pool"
+  name: "train_loss2/ave_pool"
   type: "Pooling"
   bottom: "inception_4d/output"
   top: "loss2/ave_pool"
@@ -1625,7 +1625,7 @@ layer {
   }
 }
 layer {
-  name: "loss2/conv"
+  name: "train_loss2/conv"
   type: "Convolution"
   bottom: "loss2/ave_pool"
   top: "loss2/conv"
@@ -1651,13 +1651,13 @@ layer {
   }
 }
 layer {
-  name: "loss2/relu_conv"
+  name: "train_loss2/relu_conv"
   type: "ReLU"
   bottom: "loss2/conv"
   top: "loss2/conv"
 }
 layer {
-  name: "loss2/fc"
+  name: "train_loss2/fc"
   type: "InnerProduct"
   bottom: "loss2/conv"
   top: "loss2/fc"
@@ -1682,13 +1682,13 @@ layer {
   }
 }
 layer {
-  name: "loss2/relu_fc"
+  name: "train_loss2/relu_fc"
   type: "ReLU"
   bottom: "loss2/fc"
   top: "loss2/fc"
 }
 layer {
-  name: "loss2/drop_fc"
+  name: "train_loss2/drop_fc"
   type: "Dropout"
   bottom: "loss2/fc"
   top: "loss2/fc"
@@ -1697,7 +1697,7 @@ layer {
   }
 }
 layer {
-  name: "loss2/classifier"
+  name: "train_loss2/classifier"
   type: "InnerProduct"
   bottom: "loss2/fc"
   top: "loss2/classifier"
@@ -1721,7 +1721,7 @@ layer {
   }
 }
 layer {
-  name: "loss2/loss"
+  name: "train_loss2/loss"
   type: "SoftmaxWithLoss"
   bottom: "loss2/classifier"
   bottom: "label"
@@ -1729,7 +1729,7 @@ layer {
   loss_weight: 0.3
 }
 layer {
-  name: "loss2/top-1"
+  name: "train_loss2/top-1"
   type: "Accuracy"
   bottom: "loss2/classifier"
   bottom: "label"
@@ -1739,7 +1739,7 @@ layer {
   }
 }
 layer {
-  name: "loss2/top-5"
+  name: "train_loss2/top-5"
   type: "Accuracy"
   bottom: "loss2/classifier"
   bottom: "label"
@@ -2451,7 +2451,7 @@ layer {
   }
 }
 layer {
-  name: "loss3/loss"
+  name: "train_loss3/loss"
   type: "SoftmaxWithLoss"
   bottom: "loss3/classifier"
   bottom: "label"
@@ -2459,7 +2459,7 @@ layer {
   loss_weight: 1
 }
 layer {
-  name: "loss3/top-1"
+  name: "train_loss3/top-1"
   type: "Accuracy"
   bottom: "loss3/classifier"
   bottom: "label"
@@ -2469,7 +2469,7 @@ layer {
   }
 }
 layer {
-  name: "loss3/top-5"
+  name: "train_loss3/top-5"
   type: "Accuracy"
   bottom: "loss3/classifier"
   bottom: "label"
@@ -2480,4 +2480,10 @@ layer {
   accuracy_param {
     top_k: 5
   }
+}
+layer {
+  name: "deploy_prob"
+  type: "Softmax"
+  bottom: "loss3/classifier"
+  top: "prob"
 }

--- a/digits/standard-networks/caffe/googlenet.prototxt
+++ b/digits/standard-networks/caffe/googlenet.prototxt
@@ -927,6 +927,10 @@ layer {
     decay_mult: 0
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 1000
     weight_filler {
       type: "xavier"
       std: 0.0009765625
@@ -1710,6 +1714,10 @@ layer {
     decay_mult: 0
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 1000
     weight_filler {
       type: "xavier"
       std: 0.0009765625
@@ -2441,6 +2449,10 @@ layer {
     decay_mult: 0
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 1000
     weight_filler {
       type: "xavier"
     }

--- a/digits/standard-networks/caffe/lenet.prototxt
+++ b/digits/standard-networks/caffe/lenet.prototxt
@@ -149,7 +149,7 @@ layer {
   }
 }
 layer {
-  name: "accuracy"
+  name: "train_accuracy"
   type: "Accuracy"
   bottom: "ip2"
   bottom: "label"
@@ -159,9 +159,15 @@ layer {
   }
 }
 layer {
-  name: "loss"
+  name: "train_loss"
   type: "SoftmaxWithLoss"
   bottom: "ip2"
   bottom: "label"
   top: "loss"
+}
+layer {
+  name: "deploy_prob"
+  type: "Softmax"
+  bottom: "ip2"
+  top: "prob"
 }

--- a/digits/standard-networks/caffe/lenet.prototxt
+++ b/digits/standard-networks/caffe/lenet.prototxt
@@ -140,6 +140,10 @@ layer {
     lr_mult: 2
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 10
     weight_filler {
       type: "xavier"
     }

--- a/digits/templates/models/images/classification/custom_network_explanation.html
+++ b/digits/templates/models/images/classification/custom_network_explanation.html
@@ -1,13 +1,39 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
-
 <h1>Specifying a custom Caffe network</h1>
 
 <p>
-    You should enter a train_val network here. Some cleanup is done for you automatically:
+    This .prototxt file should describe three different networks - <code>Train</code>, <code>Val</code> and <code>Deploy</code>.
 </p>
-
 <ul>
+    <li>
+        You can mark a layer as belonging to a specific phase by using <b>layer.include.phase</b>.
+        The TRAIN phase is used for the <code>Train</code> network, while the TEST phase is used for both the <code>Val</code> and <code>Deploy</code> networks.
+        <pre>
+include { phase: TRAIN } # only Train
+include { phase: TEST }  # Val and Deploy</pre>
+    </li>
+</ul>
+
+<p>
+    This alone isn't sufficient to specify all three networks, so DIGITS has a mechanism to differentiate layers which belong to <code>Train</code> and <code>Val</code> networks, and those which belong to the <code>Deploy</code> network.
+</p>
+<ul>
+    <li>
+        As an addition to DIGITS, you can also differentiate between <code>train/val</code> and <code>deploy</code> by adding a prefix to <b>layer.name</b>.
+        <pre>
+            layer {
+                # Included in the "train" and "val" phases
+                name: "train_loss"
+                type: "SoftmaxWithLoss"
+            }
+            layer {
+                # Included in the "deploy" phase
+                name: "deploy_softmax"
+                type: "Softmax"
+            }
+        </pre>
+    </li>
     <li>
         The <i>num_output</i> for each <b>InnerProduct</b> layer which is a network output gets set to the number of labels in the chosen dataset.
     </li>


### PR DESCRIPTION
*Close #605, close #335*

**NOTE: this will break networks which used to work in DIGITS**

Changes:

1. Add layer exclusion to classification nets (originally in #605)
1. Stop automatically creating `Softmax` layers in the deploy prototxt when `SoftmaxWithLoss` layers were present in the original prototxt (since you can do it manually with prefixes now)
1. Only set `inner_product_param.num_output` when it was unset in the original prototxt
1. Update standard networks to use the new features
  1. Prune useless GoogLeNet layers from deploy prototxt (#335)

TODO:

- [ ] Upgrade old internal network definitions
- [ ] Documentation