### PR TITLE
Use layer stages for all-in-one nets

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -57,6 +57,7 @@ layer {
     bottom: "output"
     bottom: "label"
     top: "loss"
+    exclude { stage: "deploy" }
 }
 layer {
     name: "accuracy"
@@ -64,9 +65,14 @@ layer {
     bottom: "output"
     bottom: "label"
     top: "accuracy"
-    include {
-        phase: TEST
-    }
+    include { stage: "val" }
+}
+layer {
+    name: "softmax"
+    type: "Softmax"
+    bottom: "output"
+    top: "softmax"
+    include { stage: "deploy" }
 }
 """
 
@@ -431,6 +437,14 @@ class BaseTestCreation(BaseViewsTestWithDataset):
                     bottom: "output"
                     bottom: "label"
                     top: "loss"
+                    exclude { stage: "deploy" }
+                }
+                layer {
+                    name: "softmax"
+                    type: "Softmax"
+                    bottom: "output"
+                    top: "softmax"
+                    include { stage: "deploy" }
                 }
                 """
         elif self.FRAMEWORK == 'torch':
@@ -839,6 +853,7 @@ layer {
     bottom: "output"
     bottom: "label"
     top: "loss"
+    exclude { stage: "deploy" }
 }
 layer {
     name: "accuracy"
@@ -846,9 +861,14 @@ layer {
     bottom: "output"
     bottom: "label"
     top: "accuracy"
-    include {
-        phase: TEST
-    }
+    include { stage: "val" }
+}
+layer {
+    name: "softmax"
+    type: "Softmax"
+    bottom: "output"
+    top: "softmax"
+    include { stage: "deploy" }
 }
 """
     TORCH_NETWORK = \
@@ -1006,6 +1026,7 @@ layer {
     bottom: "output"
     bottom: "label"
     top: "loss"
+    exclude { stage: "deploy" }
 }
 layer {
     name: "accuracy"
@@ -1013,9 +1034,7 @@ layer {
     bottom: "output"
     bottom: "label"
     top: "accuracy"
-    include {
-        phase: TEST
-    }
+    include { stage: "val" }
 }
 layer {
     name: "py_test"
@@ -1027,7 +1046,13 @@ layer {
         layer: "PythonLayer"
     }
 }
-
+layer {
+    name: "softmax"
+    type: "Softmax"
+    bottom: "output"
+    top: "softmax"
+    include { stage: "deploy" }
+}
 """
     def write_python_layer_script(self, filename):
         with open(filename, 'w') as f:

--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -66,11 +66,12 @@ layer {
   }
 }
 layer {
-  name: "train_loss"
+  name: "loss"
   type: "EuclideanLoss"
   bottom: "output"
   bottom: "label"
   top: "loss"
+  exclude { stage: "deploy" }
 }
 """
 
@@ -711,11 +712,12 @@ layer {
   }
 }
 layer {
-  name: "train_loss"
+  name: "loss"
   type: "EuclideanLoss"
   bottom: "output"
   bottom: "label"
   top: "loss"
+  exclude { stage: "deploy" }
 }
 """
 

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -1425,7 +1425,7 @@ def cleanedUpClassificationNetwork(original_network, num_categories):
     network = caffe_pb2.NetParameter()
     network.CopyFrom(original_network)
 
-    for layer in network.layer:
+    for i, layer in enumerate(network.layer):
         if 'Data' in layer.type:
             assert layer.type in ['Data', 'HDF5Data'], \
                 'Unsupported data layer type %s' % layer.type
@@ -1433,11 +1433,8 @@ def cleanedUpClassificationNetwork(original_network, num_categories):
         if layer.type == 'Accuracy':
             # Check to see if top_k > num_categories
             if ( layer.accuracy_param.HasField('top_k') and
-                    layer.accuracy_param.top_k >= num_categories ):
-                self.logger.warning(
-                    'Removing layer %s because top_k=%s while there are are only %s labels in this dataset' % (
-                        layer.name, layer.accuracy_param.top_k, num_categories
-                ))
+                    layer.accuracy_param.top_k > num_categories ):
+                del network.layer[i]
 
         elif layer.type == 'InnerProduct':
             # Check to see if num_output is unset

--- a/digits/standard-networks/caffe/alexnet.prototxt
+++ b/digits/standard-networks/caffe/alexnet.prototxt
@@ -1,3 +1,4 @@
+# AlexNet
 name: "AlexNet"
 layer {
   name: "data"
@@ -347,6 +348,10 @@ layer {
     decay_mult: 0
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 1000
     weight_filler {
       type: "gaussian"
       std: 0.01
@@ -363,9 +368,7 @@ layer {
   bottom: "fc8"
   bottom: "label"
   top: "accuracy"
-  include {
-    phase: TEST
-  }
+  include { stage: "val" }
 }
 layer {
   name: "loss"
@@ -373,4 +376,12 @@ layer {
   bottom: "fc8"
   bottom: "label"
   top: "loss"
+  exclude { stage: "deploy" }
+}
+layer {
+  name: "softmax"
+  type: "Softmax"
+  bottom: "fc8"
+  top: "softmax"
+  include { stage: "deploy" }
 }

--- a/digits/standard-networks/caffe/googlenet.prototxt
+++ b/digits/standard-networks/caffe/googlenet.prototxt
@@ -1,3 +1,4 @@
+# GoogLeNet
 name: "GoogleNet"
 layer {
   name: "data"
@@ -840,6 +841,7 @@ layer {
     kernel_size: 5
     stride: 3
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss1/conv"
@@ -866,12 +868,14 @@ layer {
       value: 0.2
     }
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss1/relu_conv"
   type: "ReLU"
   bottom: "loss1/conv"
   top: "loss1/conv"
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss1/fc"
@@ -897,12 +901,14 @@ layer {
       value: 0.2
     }
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss1/relu_fc"
   type: "ReLU"
   bottom: "loss1/fc"
   top: "loss1/fc"
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss1/drop_fc"
@@ -912,6 +918,7 @@ layer {
   dropout_param {
     dropout_ratio: 0.7
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss1/classifier"
@@ -927,6 +934,10 @@ layer {
     decay_mult: 0
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 1000
     weight_filler {
       type: "xavier"
       std: 0.0009765625
@@ -936,6 +947,7 @@ layer {
       value: 0
     }
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss1/loss"
@@ -944,6 +956,7 @@ layer {
   bottom: "label"
   top: "loss1/loss"
   loss_weight: 0.3
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss1/top-1"
@@ -951,9 +964,7 @@ layer {
   bottom: "loss1/classifier"
   bottom: "label"
   top: "loss1/accuracy"
-  include {
-    phase: TEST
-  }
+  include { stage: "val" }
 }
 layer {
   name: "loss1/top-5"
@@ -961,9 +972,7 @@ layer {
   bottom: "loss1/classifier"
   bottom: "label"
   top: "loss1/accuracy-top5"
-  include {
-    phase: TEST
-  }
+  include { stage: "val" }
   accuracy_param {
     top_k: 5
   }
@@ -1623,6 +1632,7 @@ layer {
     kernel_size: 5
     stride: 3
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss2/conv"
@@ -1649,12 +1659,14 @@ layer {
       value: 0.2
     }
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss2/relu_conv"
   type: "ReLU"
   bottom: "loss2/conv"
   top: "loss2/conv"
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss2/fc"
@@ -1680,12 +1692,14 @@ layer {
       value: 0.2
     }
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss2/relu_fc"
   type: "ReLU"
   bottom: "loss2/fc"
   top: "loss2/fc"
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss2/drop_fc"
@@ -1695,6 +1709,7 @@ layer {
   dropout_param {
     dropout_ratio: 0.7
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss2/classifier"
@@ -1710,6 +1725,10 @@ layer {
     decay_mult: 0
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 1000
     weight_filler {
       type: "xavier"
       std: 0.0009765625
@@ -1719,6 +1738,7 @@ layer {
       value: 0
     }
   }
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss2/loss"
@@ -1727,6 +1747,7 @@ layer {
   bottom: "label"
   top: "loss2/loss"
   loss_weight: 0.3
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss2/top-1"
@@ -1734,9 +1755,7 @@ layer {
   bottom: "loss2/classifier"
   bottom: "label"
   top: "loss2/accuracy"
-  include {
-    phase: TEST
-  }
+  include { stage: "val" }
 }
 layer {
   name: "loss2/top-5"
@@ -1744,9 +1763,7 @@ layer {
   bottom: "loss2/classifier"
   bottom: "label"
   top: "loss2/accuracy-top5"
-  include {
-    phase: TEST
-  }
+  include { stage: "val" }
   accuracy_param {
     top_k: 5
   }
@@ -2441,6 +2458,10 @@ layer {
     decay_mult: 0
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 1000
     weight_filler {
       type: "xavier"
     }
@@ -2457,6 +2478,7 @@ layer {
   bottom: "label"
   top: "loss"
   loss_weight: 1
+  exclude { stage: "deploy" }
 }
 layer {
   name: "loss3/top-1"
@@ -2464,9 +2486,7 @@ layer {
   bottom: "loss3/classifier"
   bottom: "label"
   top: "accuracy"
-  include {
-    phase: TEST
-  }
+  include { stage: "val" }
 }
 layer {
   name: "loss3/top-5"
@@ -2474,10 +2494,15 @@ layer {
   bottom: "loss3/classifier"
   bottom: "label"
   top: "accuracy-top5"
-  include {
-    phase: TEST
-  }
+  include { stage: "val" }
   accuracy_param {
     top_k: 5
   }
+}
+layer {
+  name: "softmax"
+  type: "Softmax"
+  bottom: "loss3/classifier"
+  top: "softmax"
+  include { stage: "deploy" }
 }

--- a/digits/standard-networks/caffe/lenet.prototxt
+++ b/digits/standard-networks/caffe/lenet.prototxt
@@ -1,3 +1,4 @@
+# LeNet
 name: "LeNet"
 layer {
   name: "mnist"
@@ -140,6 +141,10 @@ layer {
     lr_mult: 2
   }
   inner_product_param {
+    # Since num_output is unset, DIGITS will automatically set it to the
+    #   number of classes in your dataset.
+    # Uncomment this line to set it explicitly:
+    #num_output: 10
     weight_filler {
       type: "xavier"
     }
@@ -154,9 +159,7 @@ layer {
   bottom: "ip2"
   bottom: "label"
   top: "accuracy"
-  include {
-    phase: TEST
-  }
+  include { stage: "val" }
 }
 layer {
   name: "loss"
@@ -164,4 +167,12 @@ layer {
   bottom: "ip2"
   bottom: "label"
   top: "loss"
+  exclude { stage: "deploy" }
+}
+layer {
+  name: "softmax"
+  type: "Softmax"
+  bottom: "ip2"
+  top: "softmax"
+  include { stage: "deploy" }
 }

--- a/digits/templates/models/images/classification/custom_network_explanation.html
+++ b/digits/templates/models/images/classification/custom_network_explanation.html
@@ -1,36 +1,107 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
-
 <h1>Specifying a custom Caffe network</h1>
 
 <p>
-    You should enter a train_val network here. Some cleanup is done for you automatically:
+    Use this field to enter a Caffe network in .prototxt format.
 </p>
 
+<p>
+    Classification are special in a few ways:
+</p>
 <ul>
     <li>
-        The <i>num_output</i> for each <b>InnerProduct</b> layer which is a network output gets set to the number of labels in the chosen dataset.
+        The Deploy network <b>must contain a Softmax layer</b>.
+        This should produce the only network output.
     </li>
     <li>
-        Any <b>Accuracy</b> layers with <i>top_k</i> &gt;= num_labels is removed automatically.
+        If any InnerProduct layers have left <i>num_output</i> unset, DIGITS will <b>fill it in for you automatically</b> with the number of classes in your dataset.
+    </li>
+    <li>
+        If any Accuracy layer has a <i>top_k</i> value that is smaller than the number of classes in your dataset, then that layer is <b>removed</b>.
     </li>
 </ul>
 
 <p>
-    The deploy network will be created for you automatically. Once caffe implements their "all-in-one" nets feature, you will be able to specify which layers to include in the deploy file. Until then, these things are done automatically:
+    The network should include the necessary layers for all computation states - Train, Val and Deploy.
+    When searching for layers, the network will be set to one of these three states:
 </p>
-
 <ul>
-    <li>
-        The last <b>SoftmaxWithLoss</b> layer is replaced with a <b>Softmax</b> layer.
-    </li>
-    <li>
-        All other loss layers and accuracy layers are removed.
-    </li>
+    <li>phase: TRAIN stage: "train"</li>
+    <li>phase: TEST stage: "val"</li>
+    <li>phase: TEST stage: "deploy"</li>
 </ul>
+<p>
+    Your layer's include and exclude rules should be set properly to be picked up by the desired computation state[s].
+    You can look at the standard networks for examples.
+    In addition, since there are many ways to specify the rules, here's a table that you may find useful:
+</p>
+<table class="table">
+    <tr>
+        <th>Rule</th>
+        <th>Train</th>
+        <th>Val</th>
+        <th>Deploy</th>
+    </tr>
+    <tr>
+        <td><i>none</i></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+    </tr>
+    <tr>
+        <td>include { phase: TRAIN }</td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>include { stage: "train" }</td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>include { phase: TEST }</td>
+        <td></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+    </tr>
+    <tr>
+        <td>include { stage: "val" }</td>
+        <td></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td><td></td>
+    </tr>
+    <tr>
+        <td>include { stage: "deploy" }</td>
+        <td></td>
+        <td></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+    </tr>
+    <tr>
+        <td>exclude { stage: "deploy" }</td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>
+            include { stage: "train" }
+            include { stage: "val" }
+        </td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td></td>
+    </tr>
+</table>
+<p>
+    You may notice that DIGITS still generates separate files for <i>train_val</i> and <i>deploy</i> networks, and that they each only use <i>phase</i> and not <i>stage</i>.
+    This is because Caffe doesn't fully support all-in-one networks yet.
+</p>
 
 <h1>Specifying a custom Torch network</h1>
 
 <p>
-    You should enter a Torch network description here. Refer to the documentation for more information.
+    Use this field to enter a Torch network using Lua code.
+    Refer to the documentation for more information.
 </p>

--- a/digits/templates/models/images/generic/custom_network_explanation.html
+++ b/digits/templates/models/images/generic/custom_network_explanation.html
@@ -1,29 +1,91 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 
-
 <h1>Specifying a custom Caffe network</h1>
 
 <p>
-    You should enter a train_val network here. Some cleanup is done for you automatically:
+    Use this field to enter a Caffe network in .prototxt format.
 </p>
-
-<ul>
-    <li>Data layers for the LMDBs in your dataset are created for you automatically</li>
-    <li>If you provide a Data layer here and leave the <code>data_param.source</code> blank, it will be filled in for you with the appropriate path</li>
-</ul>
 
 <p>
-    The deploy network will be created for you automatically. Once caffe implements their "all-in-one" nets feature, you will be able to specify which layers to include in the deploy file. Until then, these things are done automatically:
+    The network should include the necessary layers for all computation states - Train, Val and Deploy.
+    When searching for layers, the network will be set to one of these three states:
 </p>
-
 <ul>
-    <li>All loss layers and accuracy layers are removed from the deploy file</li>
-    <li>Layers with names starting with <code>train_</code> are <strong>not included</strong> in the deploy file</li>
-    <li>Layers with names starting with <code>deploy_</code> are <strong>only included</strong> in the deploy file</li>
+    <li>phase: TRAIN stage: "train"</li>
+    <li>phase: TEST stage: "val"</li>
+    <li>phase: TEST stage: "deploy"</li>
 </ul>
+<p>
+    Your layer's include and exclude rules should be set properly to be picked up by the desired computation state[s].
+    You can look at the standard networks for examples.
+    In addition, since there are many ways to specify the rules, here's a table that you may find useful:
+</p>
+<table class="table">
+    <tr>
+        <th>Rule</th>
+        <th>Train</th>
+        <th>Val</th>
+        <th>Deploy</th>
+    </tr>
+    <tr>
+        <td><i>none</i></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+    </tr>
+    <tr>
+        <td>include { phase: TRAIN }</td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>include { stage: "train" }</td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>include { phase: TEST }</td>
+        <td></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+    </tr>
+    <tr>
+        <td>include { stage: "val" }</td>
+        <td></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td><td></td>
+    </tr>
+    <tr>
+        <td>include { stage: "deploy" }</td>
+        <td></td>
+        <td></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+    </tr>
+    <tr>
+        <td>exclude { stage: "deploy" }</td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>
+            include { stage: "train" }
+            include { stage: "val" }
+        </td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td><span class="glyphicon glyphicon-ok"></span></td>
+        <td></td>
+    </tr>
+</table>
+<p>
+    You may notice that DIGITS still generates separate files for <i>train_val</i> and <i>deploy</i> networks, and that they each only use <i>phase</i> and not <i>stage</i>.
+    This is because Caffe doesn't fully support all-in-one networks yet.
+</p>
 
 <h1>Specifying a custom Torch network</h1>
 
 <p>
-    You should enter a Torch network description. Refer to the documentation for more information.
+    Use this field to enter a Torch network using Lua code.
+    Refer to the documentation for more information.
 </p>


### PR DESCRIPTION
*Close #605, close #623, close #335*

* Use layer.include.stage to specify train/val/deploy all in a single .prototxt description
* Stop automatically creating Softmax layers in deploy networks for classification jobs
* Only set inner_product_param.num_output for classification jobs if it was unset
* Update the standard networks

TODO:

- [x] Documentation