### PR TITLE
Support for non-persistent jobs

### DIFF
--- a/digits/inference/job.py
+++ b/digits/inference/job.py
@@ -20,7 +20,7 @@ class InferenceJob(Job):
         epoch   -- epoch of model snapshot to use
         layers  -- layers to import ('all' or 'none')
         """
-        super(InferenceJob, self).__init__(**kwargs)
+        super(InferenceJob, self).__init__(persistent = False, **kwargs)
 
         # get handle to framework object
         fw_id = model.train_task().framework_id
@@ -55,11 +55,3 @@ class InferenceJob(Job):
         """Return inference data"""
         task = self.inference_task()
         return task.inference_inputs, task.inference_outputs, task.inference_layers
-
-    @override
-    def is_read_only(self):
-        """
-        Returns True if this job cannot be edited
-        """
-        return True
-

--- a/digits/job.py
+++ b/digits/job.py
@@ -44,7 +44,7 @@ class Job(StatusCls):
                     task.detect_snapshots()
             return job
 
-    def __init__(self, name, username):
+    def __init__(self, name, username, persistent = True):
         """
         Arguments:
         name -- name of this job
@@ -62,6 +62,7 @@ class Job(StatusCls):
         self.exception = None
         self._notes = None
         self.event = threading.Event()
+        self.persistent = persistent
 
         os.mkdir(self._dir)
 
@@ -86,6 +87,7 @@ class Job(StatusCls):
         if 'username' not in state:
             state['username'] = None
         self.__dict__ = state
+        self.persistent = True
 
     def json_dict(self, detailed=False):
         """
@@ -266,8 +268,14 @@ class Job(StatusCls):
         if hasattr(self, 'event'):
             self.event.wait()
 
+    def is_persistent(self):
+        """
+        Returns whether job is persistent
+        """
+        return self.persistent
+
     def is_read_only(self):
         """
         Returns False if this job can be edited
         """
-        return False
+        return not self.is_persistent()


### PR DESCRIPTION
~~Volatile jobs are not persisted to disk. Besides, they are automatically deleted by the scheduler 1 hour after completion.~~

These jobs are not saved to disk. Besides, they are automatically deleted by the scheduler 1 hour after completion.

This should become useful if jobs are increasingly used for background processing, inference, etc.