### PR TITLE
Support for inference on LMDB

### DIFF
--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -572,6 +572,19 @@ class BaseTestCreated(BaseViewsTestWithModel):
         headers = s.select('table.table th')
         assert headers is not None, 'unrecognized page format'
 
+    def test_infer_db(self):
+        val_db_path = os.path.join(self.imageset_folder, 'val_images')
+
+        rv = self.app.post(
+                '/models/images/generic/infer_db?job_id=%s' % self.model_id,
+                data = {'db_path': val_db_path}
+                )
+        s = BeautifulSoup(rv.data, 'html.parser')
+        body = s.select('body')
+        assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
+        headers = s.select('table.table th')
+        assert headers is not None, 'unrecognized page format'
+
     def test_infer_many_from_folder(self):
         textfile_images = '%s\n' % os.path.basename(self.test_image)
 
@@ -599,6 +612,17 @@ class BaseTestCreated(BaseViewsTestWithModel):
                 data = {'image_list': file_upload}
                 )
         assert rv.status_code == 200, 'POST failed with %s' % rv.status_code
+        data = json.loads(rv.data)
+        assert 'outputs' in data, 'invalid response'
+
+    def test_infer_db_json(self):
+        val_db_path = os.path.join(self.imageset_folder, 'val_images')
+
+        rv = self.app.post(
+                '/models/images/generic/infer_db.json?job_id=%s' % self.model_id,
+                data = {'db_path': val_db_path}
+                )
+        assert rv.status_code == 200, 'POST failed with %s\n\n%s' % (rv.status_code, body)
         data = json.loads(rv.data)
         assert 'outputs' in data, 'invalid response'
 

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -301,6 +301,70 @@ def infer_one():
                 total_parameters= sum(v['param_count'] for v in visualizations if v['vis_type'] == 'Weights'),
                 )
 
+@blueprint.route('/infer_db.json', methods=['POST'])
+@blueprint.route('/infer_db', methods=['POST', 'GET'])
+def infer_db():
+    """
+    Infer a database
+    """
+    model_job = job_from_request()
+
+    if not 'db_path' in flask.request.form or flask.request.form['db_path'] is None:
+        raise werkzeug.exceptions.BadRequest('db_path is a required field')
+
+    db_path = flask.request.form['db_path']
+
+    if not os.path.exists(db_path):
+            raise werkzeug.exceptions.BadRequest('DB "%s" does not exit' % db_path)
+
+    epoch = None
+    if 'snapshot_epoch' in flask.request.form:
+        epoch = float(flask.request.form['snapshot_epoch'])
+
+    # create inference job
+    inference_job = ImageInferenceJob(
+                username    = utils.auth.get_username(),
+                name        = "Infer Many Images",
+                model       = model_job,
+                images      = db_path,
+                epoch       = epoch,
+                layers      = 'none',
+                )
+
+    # schedule tasks
+    scheduler.add_job(inference_job)
+
+    # wait for job to complete
+    inference_job.wait_completion()
+
+    # retrieve inference data
+    inputs, outputs, _ = inference_job.get_data()
+
+    # delete job folder and remove from scheduler list
+    scheduler.delete_job(inference_job)
+
+    if outputs is not None and len(outputs) < 1:
+        # an error occurred
+        outputs = None
+
+    if inputs is not None:
+        keys = [str(idx) for idx in inputs['ids']]
+    else:
+        keys = None
+
+    if request_wants_json():
+        result = {}
+        for i, key in enumerate(keys):
+            result[key] = dict((name, blob[i].tolist()) for name,blob in outputs.iteritems())
+        return flask.jsonify({'outputs': result})
+    else:
+        return flask.render_template('models/images/generic/infer_db.html',
+                model_job       = model_job,
+                job             = inference_job,
+                keys            = keys,
+                network_outputs = outputs,
+                )
+
 @blueprint.route('/infer_many.json', methods=['POST'])
 @blueprint.route('/infer_many', methods=['POST', 'GET'])
 def infer_many():

--- a/digits/templates/models/images/generic/infer_db.html
+++ b/digits/templates/models/images/generic/infer_db.html
@@ -1,0 +1,53 @@
+{# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
+{% extends "job.html" %}
+
+{% block nav %}
+<li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
+<li class="active"><a>Test Many</a></li>
+{% endblock %}
+
+{% block job_content %}
+
+<div class="page-header">
+    <h1>
+        {{model_job.name()}}
+        <small>
+            {{job.job_type()}}
+        </small>
+    </h1>
+</div>
+
+{% if not network_outputs %}
+<div class="alert alert-danger">
+    <p>Inference failed, see job log</p>
+</div>
+{% endif %}
+
+{% endblock %}
+
+{% block job_content_details %}
+
+{% if network_outputs %}
+<table class="table">
+    <tr>
+        <th>Index</th>
+        <th>Key</th>
+        {% for key in network_outputs.keys() %}
+        <th>{{key}}</th>
+        {% endfor %}
+    </tr>
+    {% for key in keys %}
+    <tr>
+        <td>{{loop.index}}</td>
+        <td>{{key}}</td>
+        {% set index=loop.index0 %}
+        {% for key, val in network_outputs.iteritems() %}
+        <td>{{network_outputs[key][index]}}</td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
+
+{% endblock %}
+

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -167,6 +167,20 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             class="btn btn-primary">
                             Test One
                         </button>
+                        <h3>Test a Database</h3>
+                        <div class="form-group">
+                            <label for="db_path" class="control-label">LMDB path</label>
+                            <input type="text" id="db_path" name="db_path" class="form-control autocomplete_path">
+                            <small>Specify path to LMDB database on server</small>
+                        </div>
+                        <button name="infer-db-btn"
+                            formaction="{{url_for('digits.model.images.generic.views.infer_db', job_id=job.id())}}"
+                            formmethod="post"
+                            formenctype="multipart/form-data"
+                            formtarget="_blank"
+                            class="btn btn-primary">
+                            Test One
+                        </button>
                     </div>
                     <div class="col-sm-6">
                         <h3>Test a list of images</h3>


### PR DESCRIPTION
A (small) step towards support for non-image data: this makes it possible to perform inference on any 3D blob. Blobs may not be "proper" images (e.g. because they don't have a standard number of channels).

close #619
close #630 

A new field and a new button were added to allow inference on LMDB database:

![generic-inference-form](https://cloud.githubusercontent.com/assets/3889770/13817166/7eecb624-eb91-11e5-8bf3-fdded6a3c91c.png)

Results are shown as follows (using DB key instead of image path):

![infer_db](https://cloud.githubusercontent.com/assets/3889770/13817195/9a0470aa-eb91-11e5-858a-e3801cf4309e.png)

# Progress #

- [x] Add "Test DB" form to generic model show page
- [x] Create new route
- [x] Update inference job to take in a path to a database
- [x] Update inference tool to parse an LMDB database
- [x] Add tests