### PR TITLE
Force requirement wtforms>=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests>=2.2.1
 gevent>=1.0
 Flask>=0.10.1
 Flask-WTF>=0.11
+wtforms>=2.0.0
 Flask-SocketIO==0.6.0
 gunicorn==17.5
 setuptools>=3.3


### PR DESCRIPTION
Reported by @flx42

If you have `wtforms==1.0.1` installed from the [ubuntu deb package](http://packages.ubuntu.com/trusty/python/python-wtforms) `python-wtforms`, and then run `pip install -r requirements.txt`, you would expect pip to install `wtforms>=1.0.5` since `requirements.txt` includes the line `Flask-WTF>=0.11` and `Flask-WTF==0.11` requires `wtforms>=1.0.5` ([see here](https://github.com/lepture/flask-wtf/blob/v0.11/setup.py#L51)).

But it doesn't. So we have to specify the requirement again.