### PR TITLE
Add pop-out explanation for Python layers

### DIFF
--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -69,23 +69,23 @@ class ModelForm(Form):
             )
 
 
-    python_layer_from_client = wtforms.BooleanField(u'Use client side file',
+    python_layer_from_client = utils.forms.BooleanField(u'Use client-side file',
                                                 default=False)
 
     python_layer_client_file = utils.forms.FileField(
-        u'Python Layer File (client side)',
+        u'Client-side file',
         validators=[
             validate_py_ext
         ],
-        tooltip = "Choose the python file on the client containing layer functions."
+        tooltip = "Choose a Python file on the client containing layer definitions."
     )
     python_layer_server_file = utils.forms.StringField(
-        u'Python Layer File (server side)',
+        u'Server-side file',
         validators=[
             validate_file_exists,
             validate_py_ext
         ],
-        tooltip = "Choose the python file on the server containing layer functions."
+        tooltip = "Choose a Python file on the server containing layer definitions."
     )
 
     train_epochs = utils.forms.IntegerField('Training epochs',

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -485,7 +485,7 @@ class TrainTask(Task):
                     col_id = '%s-train' % name
                     data['xs'][col_id] = 'train_epochs'
                     data['names'][col_id] = '%s (train)' % name
-                    if 'accuracy' in output.kind.lower():
+                    if 'accuracy' in output.kind.lower() or 'accuracy' in name.lower():
                         data['columns'].append([col_id] + [
                             (100*x if x is not None else 'none')
                             for x in output.data[::stride]])
@@ -510,7 +510,7 @@ class TrainTask(Task):
                     col_id = '%s-val' % name
                     data['xs'][col_id] = 'val_epochs'
                     data['names'][col_id] = '%s (val)' % name
-                    if 'accuracy' in output.kind.lower():
+                    if 'accuracy' in output.kind.lower() or 'accuracy' in name.lower():
                         data['columns'].append([col_id] + [
                             (100*x if x is not None else 'none')
                             for x in output.data[::stride]])

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -36,10 +36,9 @@ New Image Classification Model
 
             <div class="col">
                 <div class="well">
-                    <label for="{{form.python_layer_from_client.name}}">
-                        {{form.python_layer_from_client}}
-                        {{form.python_layer_from_client.label}}
-                    </label>
+                    <h4 style="display:inline-block;">Python Layers</h4>
+                    {{form.python_layer_from_client.explanation(file='/models/python_layer_explanation.html')}}
+                    <br>
                     <div class="form-group{{' has-error' if form.python_layer_client_file.errors}} python-layer-client-side-file">
                         {{form.python_layer_client_file.label}}
                         {{form.python_layer_client_file.tooltip}}
@@ -50,6 +49,10 @@ New Image Classification Model
                         {{form.python_layer_server_file.tooltip}}
                         {{form.python_layer_server_file(class='form-control autocomplete_path')}}
                     </div>
+                    <label for="{{form.python_layer_from_client.name}}">
+                        {{form.python_layer_from_client}}
+                        {{form.python_layer_from_client.label}}
+                    </label>
                 </div>
             </div>
         </div>

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -35,10 +35,9 @@ New Image Model
             </div>
             <div class="col">
                 <div class="well">
-                    <label for="{{form.python_layer_from_client.name}}">
-                        {{form.python_layer_from_client}}
-                        {{form.python_layer_from_client.label}}
-                    </label>
+                    <h4 style="display:inline-block;">Python Layers</h4>
+                    {{form.python_layer_from_client.explanation(file='/models/python_layer_explanation.html')}}
+                    <br>
                     <div class="form-group{{' has-error' if form.python_layer_client_file.errors}} python-layer-client-side-file">
                         {{form.python_layer_client_file.label}}
                         {{form.python_layer_client_file.tooltip}}
@@ -49,6 +48,10 @@ New Image Model
                         {{form.python_layer_server_file.tooltip}}
                         {{form.python_layer_server_file(class='form-control autocomplete_path')}}
                     </div>
+                    <label for="{{form.python_layer_from_client.name}}">
+                        {{form.python_layer_from_client}}
+                        {{form.python_layer_from_client.label}}
+                    </label>
                 </div>
             </div>
         </div>

--- a/digits/templates/models/python_layer_explanation.html
+++ b/digits/templates/models/python_layer_explanation.html
@@ -1,0 +1,75 @@
+{# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+<h1>Using Python layers</h1>
+
+<p>
+    Caffe lets you define custom layers with Python.
+    Python layers are obviously much slower than their C++ counterparts, but are easy to write and test quickly since using them doesn't require recompilation.
+    DIGITS moves some files around for you so that you can specify different Python layers for each network.
+</p>
+<p>
+    The BVLC and DIGITS documentation online has detailed information and tutorials about how to use these layers.
+    Some of that information has been re-created here for your convenience.
+</p>
+
+<p>
+    First, you'll need to create a Python file which defines one or more layers.
+    As an example, here is a layer which re-creates the functionality of the standard Accuracy layer using JSON-encoded parameters:
+</p>
+<pre>
+import caffe
+import json
+
+class AccuracyLayer(caffe.Layer):
+    def setup(self, bottom, top):
+        if hasattr(self, 'param_str') and self.param_str:
+            params = json.loads(self.param_str)
+        else:
+            params = {}
+        self.top_k = params.get('top_k', 1)
+
+    def reshape(self, bottom, top):
+        top[0].reshape(1)
+
+    def forward(self, bottom, top):
+        # Renaming for clarity
+        predictions = bottom[0].data
+        ground_truth = bottom[1].data
+
+        num_correct = 0.0
+
+        # NumPy magic - get top K predictions for each datum
+        top_predictions = (-predictions).argsort()[:, :self.top_k]
+        for batch_index, predictions in enumerate(top_predictions):
+            if ground_truth[batch_index] in predictions:
+                num_correct += 1
+
+        # Accuracy is averaged over the batch
+        top[0].data[0] = num_correct / len(ground_truth)
+
+    def backward(self, top, propagate_down, bottom):
+        pass
+</pre>
+
+<p class="alert alert-warning">
+    <b>NOTE:</b> The uploaded file will be renamed to <b>digits_python_layers.py</b>, discarding the original filename.
+</p>
+
+<p>
+    To add the layer to your network, include this prototxt snippet in your custom network definition:
+</p>
+<pre>
+layer {
+    name: "accuracy"
+    type: "Python"
+    bottom: "pred"      # These blob names may differ in your network
+    bottom: "label"
+    top: "accuracy"
+    python_param {
+        module: "digits_python_layers"  # File name
+        layer: "AccuracyLayer"          # Class name
+        param_str: "{\"top_k\": 1}"
+    }
+    include { stage: "val" }
+}
+</pre>


### PR DESCRIPTION
*Close #636*

Cleanup Python layer upload UI and add some pop-out text similar to https://github.com/NVIDIA/DIGITS/pull/628#issuecomment-195137527.

Also add network outputs with names containing "accuracy" to the accuracy axis in graphs. It's a little hacky, but I don't think we need to find a general purpose solution to that problem just yet.