### PR TITLE
Allow autocomplete for testing image paths

### DIFF
--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -288,15 +288,17 @@ def classify_one():
     """
     model_job = job_from_request()
 
-    if 'image_url' in flask.request.form and flask.request.form['image_url']:
-        image_path = flask.request.form['image_url']
+    remove_image_path = False
+    if 'image_path' in flask.request.form and flask.request.form['image_path']:
+        image_path = flask.request.form['image_path']
     elif 'image_file' in flask.request.files and flask.request.files['image_file']:
         outfile = tempfile.mkstemp(suffix='.png')
         flask.request.files['image_file'].save(outfile[1])
         image_path = outfile[1]
         os.close(outfile[0])
+        remove_image_path = True
     else:
-        raise werkzeug.exceptions.BadRequest('must provide image_url or image_file')
+        raise werkzeug.exceptions.BadRequest('must provide image_path or image_file')
 
     epoch = None
     if 'snapshot_epoch' in flask.request.form:
@@ -328,11 +330,8 @@ def classify_one():
     # delete job
     scheduler.delete_job(inference_job)
 
-    # remove file (fails silently if a URL was provided)
-    try:
+    if remove_image_path:
         os.remove(image_path)
-    except:
-        pass
 
     image = None
     predictions = []

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -238,16 +238,16 @@ def infer_one():
     """
     model_job = job_from_request()
 
-    image = None
-    if 'image_url' in flask.request.form and flask.request.form['image_url']:
-        image_path = flask.request.form['image_url']
+    remove_image_path = False
+    if 'image_path' in flask.request.form and flask.request.form['image_path']:
+        image_path = flask.request.form['image_path']
     elif 'image_file' in flask.request.files and flask.request.files['image_file']:
         outfile = tempfile.mkstemp(suffix='.bin')
         flask.request.files['image_file'].save(outfile[1])
         image_path = outfile[1]
         os.close(outfile[0])
     else:
-        raise werkzeug.exceptions.BadRequest('must provide image_url or image_file')
+        raise werkzeug.exceptions.BadRequest('must provide image_path or image_file')
 
     epoch = None
     if 'snapshot_epoch' in flask.request.form:
@@ -279,11 +279,8 @@ def infer_one():
     # delete job folder and remove from scheduler list
     scheduler.delete_job(inference_job)
 
-    # remove file (fails if a URL was provided)
-    try:
+    if remove_image_path:
         os.remove(image_path)
-    except:
-        pass
 
     image = None
     if inputs is not None and len(inputs['data']) == 1:

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -143,8 +143,13 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                     <div class="col-sm-6">
                         <h3>Test a single image</h3>
                         <div class="form-group">
-                            <label for="image_url" class="control-label">Image URL</label>
-                            <input type="text" id="image_url" name="image_url" class="form-control">
+                            <label for="image_path" class="control-label">Image Path</label>
+                            <span name="image_path_explanation"
+                                class="explanation-tooltip glyphicon glyphicon-question-sign"
+                                data-container="body"
+                                title="Can be a path on the server's filesystem, or a URL."
+                                ></span>
+                            <input type="text" id="image_path" name="image_path" class="form-control autocomplete_path">
                         </div>
                         <div class="form-group">
                             <label for="image_file" class="control-label">Upload image</label>
@@ -152,8 +157,8 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                         </div>
                         <script type="text/javascript">
                             // When you fill in one field, the other gets blanked out
-                            $("#image_url").change(function() { $("#image_file").val(""); });
-                            $("#image_file").change(function() { $("#image_url").val(""); });
+                            $("#image_path").change(function() { $("#image_file").val(""); });
+                            $("#image_file").change(function() { $("#image_path").val(""); });
                         </script>
                         <div class="form-group">
                             <label for="show_visualizations">

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -136,8 +136,13 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                     <div class="col-sm-6">
                         <h3>Test a single image</h3>
                         <div class="form-group">
-                            <label for="image_url" class="control-label">Image URL</label>
-                            <input type="text" id="image_url" name="image_url" class="form-control">
+                            <label for="image_path" class="control-label">Image Path</label>
+                            <span name="image_path_explanation"
+                                class="explanation-tooltip glyphicon glyphicon-question-sign"
+                                data-container="body"
+                                title="Can be a path on the server's filesystem, or a URL."
+                                ></span>
+                            <input type="text" id="image_path" name="image_path" class="form-control autocomplete_path">
                         </div>
                         <div class="form-group">
                             <label for="image_file" class="control-label">Upload image</label>
@@ -145,8 +150,8 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                         </div>
                         <script type="text/javascript">
                             // When you fill in one field, the other gets blanked out
-                            $("#image_url").change(function() { $("#image_file").val(""); });
-                            $("#image_file").change(function() { $("#image_url").val(""); });
+                            $("#image_path").change(function() { $("#image_file").val(""); });
+                            $("#image_file").change(function() { $("#image_path").val(""); });
                         </script>
                         <div class="form-group">
                             <label for="show_visualizations">


### PR DESCRIPTION
Before this PR, you could manually enter a path to an image on the server for testing, but the image would be deleted afterwards!

Now you get autocomplete help for entering paths, and the image won't be deleted afterwards.