### PR TITLE
Device query updates

### DIFF
--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -274,13 +274,15 @@ class ModelForm(Form):
     select_gpu = wtforms.RadioField('Select which GPU you would like to use',
             choices = [('next', 'Next available')] + [(
                 index,
-                '#%s - %s%s' % (
+                '#%s - %s (%s memory)' % (
                     index,
                     get_device(index).name,
-                    ' (%s memory)' % sizeof_fmt(get_nvml_info(index)['memory']['total'])
-                        if get_nvml_info(index) and 'memory' in get_nvml_info(index) else '',
-                    ),
-                ) for index in config_value('gpu_list').split(',') if index],
+                    sizeof_fmt(
+                        get_nvml_info(index)['memory']['total']
+                        if get_nvml_info(index) and 'memory' in get_nvml_info(index)
+                        else get_device(index).totalGlobalMem)
+                ),
+            ) for index in config_value('gpu_list').split(',') if index],
             default = 'next',
             )
 
@@ -288,13 +290,15 @@ class ModelForm(Form):
     select_gpus = utils.forms.SelectMultipleField('Select which GPU[s] you would like to use',
             choices = [(
                 index,
-                '#%s - %s%s' % (
+                '#%s - %s (%s memory)' % (
                     index,
                     get_device(index).name,
-                    ' (%s memory)' % sizeof_fmt(get_nvml_info(index)['memory']['total'])
-                        if get_nvml_info(index) and 'memory' in get_nvml_info(index) else '',
-                    ),
-                ) for index in config_value('gpu_list').split(',') if index],
+                    sizeof_fmt(
+                        get_nvml_info(index)['memory']['total']
+                        if get_nvml_info(index) and 'memory' in get_nvml_info(index)
+                        else get_device(index).totalGlobalMem)
+                ),
+            ) for index in config_value('gpu_list').split(',') if index],
             tooltip = "The job won't start until all of the chosen GPUs are available."
             )
 


### PR DESCRIPTION
**Versioned DSOs**
We really shouldn't ever load unversioned DSOs because you shouldn't need dev files to run any application. I ran into this issue when using `nvidia-docker`, which doesn't include `libnvidia-ml.so` by default.

**Displaying GPU memory**
We could just display CUDA info only - there's no clear reason to call NVML here - but I have a vague recollection of CUDA being unable to query the memory available for newer, fancier GPUs sometimes. So I'm just adding it as a fallback path.

I can't test this on Windows, but I've attempted to preserve @crohkohl's changes from #199.