### PR TITLE
Fix Torch validation batch size import from net desc

### DIFF
--- a/tools/torch/main.lua
+++ b/tools/torch/main.lua
@@ -300,7 +300,7 @@ local valBatchSize
 if opt.batchSize==0 then
     local defaultBatchSize = 16
     trainBatchSize = network.trainBatchSize or defaultBatchSize
-    valBatchSize = network.validBatchSize or defaultBatchSize
+    valBatchSize = network.validationBatchSize or defaultBatchSize
 else
     trainBatchSize = opt.batchSize
     valBatchSize = opt.batchSize


### PR DESCRIPTION
Fix type of Lua wrapper for Torch. Validation batch size is coming in a field named `validationBatchSize` as mentioned on the [doc](https://github.com/NVIDIA/DIGITS/blob/v3.2.0/docs/GettingStartedTorch.md#internal-parameters).