### PR TITLE
Ignore classification outputs without corresponding label

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -904,6 +904,45 @@ class TestCaffeCreation(BaseTestCreation):
 class TestCaffeCreated(BaseTestCreated):
     FRAMEWORK = 'caffe'
 
+class TestCaffeCreatedMoreNumOutput(BaseTestCreated):
+    FRAMEWORK = 'caffe'
+
+    CAFFE_NETWORK = \
+"""
+layer {
+    name: "hidden"
+    type: 'InnerProduct'
+    bottom: "data"
+    top: "output"
+    inner_product_param {
+        num_output: 1000
+    }
+}
+layer {
+    name: "loss"
+    type: "SoftmaxWithLoss"
+    bottom: "output"
+    bottom: "label"
+    top: "loss"
+    exclude { stage: "deploy" }
+}
+layer {
+    name: "accuracy"
+    type: "Accuracy"
+    bottom: "output"
+    bottom: "label"
+    top: "accuracy"
+    include { stage: "val" }
+}
+layer {
+    name: "softmax"
+    type: "Softmax"
+    bottom: "output"
+    top: "softmax"
+    include { stage: "deploy" }
+}
+"""
+
 class TestCaffeDatasetModelInteractions(BaseTestDatasetModelInteractions):
     FRAMEWORK = 'caffe'
 


### PR DESCRIPTION
Since #628 DIGITS does not overwrite the number of outputs in the last fully-connected layer if it is already set to a value.
If the user accidentally specifies too large a `num_output` then inference will fail as reported on #678.
This change causes classification outputs to be ignored if there is no corresponding label.

close #678