### PR TITLE
Allocate LMDB keys in tcs.Vec object

### DIFF
--- a/docs/BuildTorch.md
+++ b/docs/BuildTorch.md
@@ -63,6 +63,7 @@ Install extra luarocks packages:
 ```sh
 % luarocks install image
 % luarocks install "https://raw.github.com/deepmind/torch-hdf5/master/hdf5-0-0.rockspec"
+% luarocks install tds
 ```
 
 ## LMDB support

--- a/scripts/travis/install-torch.sh
+++ b/scripts/travis/install-torch.sh
@@ -21,6 +21,7 @@ cd $INSTALL_DIR; ./install.sh -b
 # install custom packages
 ${INSTALL_DIR}/install/bin/luarocks install sys
 ${INSTALL_DIR}/install/bin/luarocks install image
+${INSTALL_DIR}/install/bin/luarocks install tds
 ${INSTALL_DIR}/install/bin/luarocks install "https://raw.github.com/deepmind/torch-hdf5/master/hdf5-0-0.rockspec"
 ${INSTALL_DIR}/install/bin/luarocks install "https://raw.github.com/Sravan2j/lua-pb/master/lua-pb-scm-0.rockspec"
 ${INSTALL_DIR}/install/bin/luarocks install lightningmdb LMDB_INCDIR=/usr/local/include LMDB_LIBDIR=/usr/local/lib

--- a/tools/torch/data.lua
+++ b/tools/torch/data.lua
@@ -11,6 +11,8 @@ package.path = debug.getinfo(1, "S").source:match[[^@?(.*[\/])[^\/]-$]] .."?.lua
 require 'logmessage'
 local ffi = require 'ffi'
 
+local tds = check_require 'tds'
+
 -- enable shared serialization to speed up Tensor passing between threads
 threads.Threads.serialization('threads.sharedserialize')
 
@@ -320,7 +322,7 @@ end
 
 -- Derived class method lmdb_getKeys
 function DBSource:lmdb_getKeys ()
-    local Keys = {}
+    local Keys = tds.Vec()
     local i=0
     local key=nil
     for k,v in all_keys(self.lmdb_data.c,nil,self.lightningmdb.MDB_NEXT) do


### PR DESCRIPTION
Luajit heap size must be located in the lower 2GB of addressable memory.
There is therefore a limit of 2GB on heap size when using Luajit.
This change moves LMDB keys to a tds.Vec object, where memory does not rely on the Lua allocator.

close #659