### PR TITLE
Use relative symlinks in Cifar100 download tool

### DIFF
--- a/tools/download_data/cifar100.py
+++ b/tools/download_data/cifar100.py
@@ -118,7 +118,7 @@ class Cifar100Downloader(DataDownloader):
         for fine, coarse in fine_to_coarse.iteritems():
             self.mkdir(os.path.join(coarse_dirname, coarse))
             os.symlink(
-                    os.path.join(fine_dirname, fine),
-                    os.path.join(coarse_dirname, coarse, fine)
-                    )
-
+                # Create relative symlinks for portability
+                os.path.join('..', '..', '..', 'fine', phase, fine),
+                os.path.join(coarse_dirname, coarse, fine)
+            )


### PR DESCRIPTION
Before:
```
/home/lyeager/cifar100/coarse/test/vehicles_2:
total 0
lrwxrwxrwx 1 lyeager lyeager 43 Apr 18 17:22 lawn_mower -> /home/lyeager/cifar100/fine/test/lawn_mower
lrwxrwxrwx 1 lyeager lyeager 39 Apr 18 17:22 rocket -> /home/lyeager/cifar100/fine/test/rocket
lrwxrwxrwx 1 lyeager lyeager 42 Apr 18 17:22 streetcar -> /home/lyeager/cifar100/fine/test/streetcar
lrwxrwxrwx 1 lyeager lyeager 37 Apr 18 17:22 tank -> /home/lyeager/cifar100/fine/test/tank
lrwxrwxrwx 1 lyeager lyeager 40 Apr 18 17:22 tractor -> /home/lyeager/cifar100/fine/test/tractor
```
After:
```
/home/lyeager/cifar100/coarse/test/vehicles_2:
total 0
lrwxrwxrwx 1 lyeager lyeager 29 Apr 18 17:20 lawn_mower -> ../../../fine/test/lawn_mower
lrwxrwxrwx 1 lyeager lyeager 25 Apr 18 17:20 rocket -> ../../../fine/test/rocket
lrwxrwxrwx 1 lyeager lyeager 28 Apr 18 17:20 streetcar -> ../../../fine/test/streetcar
lrwxrwxrwx 1 lyeager lyeager 23 Apr 18 17:20 tank -> ../../../fine/test/tank
lrwxrwxrwx 1 lyeager lyeager 26 Apr 18 17:20 tractor -> ../../../fine/test/tractor
```

As it turns out, it's still pretty hard to copy a directory full of relative symlinks. But this still seems like a (minor) improvement. It will help when mounting Docker volumes, at least.