### PR TITLE
Remove unnecessary installs

### DIFF
--- a/docs/BuildTorch.md
+++ b/docs/BuildTorch.md
@@ -61,7 +61,6 @@ If you haven't done so already, install the HDF5 package:
 
 Install extra luarocks packages:
 ```sh
-% luarocks install image
 % luarocks install "https://raw.github.com/deepmind/torch-hdf5/master/hdf5-0-0.rockspec"
 % luarocks install tds
 ```

--- a/scripts/travis/install-torch.sh
+++ b/scripts/travis/install-torch.sh
@@ -19,8 +19,6 @@ git clone https://github.com/torch/distro.git $INSTALL_DIR --recursive
 cd $INSTALL_DIR; ./install.sh -b
 
 # install custom packages
-${INSTALL_DIR}/install/bin/luarocks install sys
-${INSTALL_DIR}/install/bin/luarocks install image
 ${INSTALL_DIR}/install/bin/luarocks install tds
 ${INSTALL_DIR}/install/bin/luarocks install "https://raw.github.com/deepmind/torch-hdf5/master/hdf5-0-0.rockspec"
 ${INSTALL_DIR}/install/bin/luarocks install "https://raw.github.com/Sravan2j/lua-pb/master/lua-pb-scm-0.rockspec"


### PR DESCRIPTION
`sys` and `image` modules are automatically installed as part of the default Torch7 install.