### PR TITLE
Fix fine-tune example softmax bottom

### DIFF
--- a/examples/fine-tuning/lenet-fine-tune.prototxt
+++ b/examples/fine-tuning/lenet-fine-tune.prototxt
@@ -187,7 +187,7 @@ layer {
 layer {
   name: "softmax"
   type: "Softmax"
-  bottom: "ip2"
+  bottom: "ip2_odd_even"
   top: "softmax"
   include { stage: "deploy" }
 }


### PR DESCRIPTION
The softmax layer in the fine-tine example for Caffe was pointing to the `ip2` bottom.
It should point to `ip2_odd_even` instead.

close #689