### PR TITLE
Image dimension hint

### DIFF
--- a/digits/templates/datasets/images/classification/new.html
+++ b/digits/templates/datasets/images/classification/new.html
@@ -36,7 +36,7 @@ New Image Classification Dataset
             </div>
             <div class="row">
                 <div class="form-group{{mark_errors([form.resize_width, form.resize_height])}}">
-                    <label>Image size</label>
+                    <label>Image size (Width x Height)</label>
                     <span name="resize_dims_explanation"
                           class="explanation-tooltip glyphicon glyphicon-question-sign"
                           data-container="body"

--- a/digits/templates/datasets/images/classification/show.html
+++ b/digits/templates/datasets/images/classification/show.html
@@ -14,7 +14,7 @@
     </dl>
     <dl>
         <dt>Image Dimensions</dt>
-        <dd>{{job.image_dims[1]}}x{{job.image_dims[0]}}</dd>
+        <dd>{{job.image_dims[1]}}x{{job.image_dims[0]}} (Width x Height)</dd>
         <dt>Image Type</dt>
         <dd>{{'Color' if job.image_dims[2] == 3 else 'Grayscale'}}</dd>
         <dt>Resize Transformation</dt>


### PR DESCRIPTION
The dataset creation form does not explicitly state which of the image dimension fields is the width and which is the height.
Though this can be inferred through `See example` it would probably help to make this explicit.
See #693