### PR TITLE
Improve error reporting from Torch threads

### DIFF
--- a/tools/torch/data.lua
+++ b/tools/torch/data.lua
@@ -610,12 +610,12 @@ end
 
 -- wait until next data loader job completes
 function DataLoader:waitNext()
+    -- wait for next data loader job to complete
+    self.threadPool:dojob()
     -- check for errors in loader threads
     if self.threadPool:haserror() then -- check for errors
         self.threadPool:synchronize() -- finish everything and throw error
     end
-    -- wait for next data loader job to complete
-    self.threadPool:dojob()
 end
 
 -- free data loader resources

--- a/tools/torch/data.lua
+++ b/tools/torch/data.lua
@@ -278,7 +278,7 @@ function DBSource:new (backend, db_path, labels_db_path, mirror, meanTensor, isT
         end
     end
 
-    logmessage.display(0,'Image channels are ' .. self.ImageChannels .. ', Image width is ' .. self.ImageSizeY .. ' and Image height is ' .. self.ImageSizeX)
+    logmessage.display(0,'Image channels are ' .. self.ImageChannels .. ', Image width is ' .. self.ImageSizeX .. ' and Image height is ' .. self.ImageSizeY)
 
     self.mirror = mirror
     self.train = isTrain


### PR DESCRIPTION
Errors in Torch threads are propagated to the main thread since https://github.com/torch/threads/commit/a9d4eca0ebb412a886cdc736a6e92a16851211a9. For those using older versions this commit moves the error checking in DIGITS data loader threads to after `dojob()`.

Also fix log message that shows image width/height.