### PR TITLE
fix bug in solver_type selector

### DIFF
--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -175,7 +175,7 @@ $("#dataset").change(function() {
 {% for choice in form.solver_type.choices %}
 {% for fw in frameworks %}
 {% if fw.supports_solver_type(choice[0]) %}
-$("select[name=solver_type] > option[value={{choice[0]}}").addClass("{{fw.get_id()}}");
+$("select[name=solver_type] > option[value={{choice[0]}}]").addClass("{{fw.get_id()}}");
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -175,7 +175,7 @@ $("#dataset").change(function() {
 {% for choice in form.solver_type.choices %}
 {% for fw in frameworks %}
 {% if fw.supports_solver_type(choice[0]) %}
-$("select[name=solver_type] > option[value={{choice[0]}}").addClass("{{fw.get_id()}}");
+$("select[name=solver_type] > option[value={{choice[0]}}]").addClass("{{fw.get_id()}}");
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
This selector, although missing a closing bracket, works in chrome and firefox, but not in safari. Seemed like a good thing to fix just in case browsers become more picky in the future.