### PR TITLE
Add parameter sweep to learning rate and batch size

### DIFF
--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -120,10 +120,10 @@ class ModelForm(Form):
             tooltip = "If you provide a random seed, then back-to-back runs with the same model and dataset should give identical results."
             )
 
-    batch_size = utils.forms.IntegerField('Batch size',
+    batch_size = utils.forms.MultiIntegerField('Batch size',
             validators = [
-                validators.NumberRange(min=1),
-                validators.Optional(),
+                utils.forms.MultiNumberRange(min=1),
+                utils.forms.MultiOptional(),
                 ],
             tooltip = "How many images to process at once. If blank, values are used from the network definition."
             )
@@ -153,10 +153,10 @@ class ModelForm(Form):
 
     ### Learning rate
 
-    learning_rate = utils.forms.FloatField('Base Learning Rate',
+    learning_rate = utils.forms.MultiFloatField('Base Learning Rate',
             default = 0.01,
             validators = [
-                validators.NumberRange(min=0),
+                utils.forms.MultiNumberRange(min=0),
                 ],
             tooltip = "Affects how quickly the network learns. If you are getting NaN for your loss, you probably need to lower this value."
             )

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -128,6 +128,7 @@ def create():
     add_batch_size = len(form.batch_size.data) > 1
     n_jobs = len(sweeps)
 
+    jobs = []
     for sweep in sweeps:
         # Populate the form with swept data to be used in saving and
         # launching jobs.
@@ -275,6 +276,7 @@ def create():
             ## Save form data with the job so we can easily clone it later.
             save_form_to_job(job, form)
 
+            jobs.append(job)
             scheduler.add_job(job)
             if n_jobs == 1:
                 if request_wants_json():
@@ -286,6 +288,9 @@ def create():
             if job:
                 scheduler.delete_job(job)
             raise
+
+    if request_wants_json():
+        return flask.jsonify(jobs=[job.json_dict() for job in jobs])
 
     # If there are multiple jobs launched, go to the home page.
     return flask.redirect('/')

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -83,137 +83,164 @@ def create():
         raise werkzeug.exceptions.BadRequest(
                 'Unknown dataset job_id "%s"' % form.dataset.data)
 
-    job = None
-    try:
-        job = GenericImageModelJob(
-                username    = utils.auth.get_username(),
-                name        = form.model_name.data,
-                dataset_id  = datasetJob.id(),
-                )
+    # sweeps will be a list of the the permutations of swept fields
+    # Get swept learning_rate
+    sweeps = [{'learning_rate': v} for v in form.learning_rate.data]
+    add_learning_rate = len(form.learning_rate.data) > 1
 
-        # get framework (hard-coded to caffe for now)
-        fw = frameworks.get_framework_by_id(form.framework.data)
+    # Add swept batch_size
+    sweeps = [dict(s.items() + [('batch_size', bs)]) for bs in form.batch_size.data for s in sweeps[:]]
+    add_batch_size = len(form.batch_size.data) > 1
+    n_jobs = len(sweeps)
 
-        pretrained_model = None
-        #if form.method.data == 'standard':
-        if form.method.data == 'previous':
-            old_job = scheduler.get_job(form.previous_networks.data)
-            if not old_job:
-                raise werkzeug.exceptions.BadRequest(
-                        'Job not found: %s' % form.previous_networks.data)
+    for sweep in sweeps:
+        # Populate the form with swept data to be used in saving and
+        # launching jobs.
+        form.learning_rate.data = sweep['learning_rate']
+        form.batch_size.data = sweep['batch_size']
 
-            use_same_dataset = (old_job.dataset_id == job.dataset_id)
-            network = fw.get_network_from_previous(old_job.train_task().network, use_same_dataset)
+        # Augment Job Name
+        extra = ''
+        if add_learning_rate:
+            extra += ' learning_rate:%s' % str(form.learning_rate.data[0])
+        if add_batch_size:
+            extra += ' batch_size:%d' % form.batch_size.data[0]
 
-            for choice in form.previous_networks.choices:
-                if choice[0] == form.previous_networks.data:
-                    epoch = float(flask.request.form['%s-snapshot' % form.previous_networks.data])
-                    if epoch == 0:
-                        pass
-                    elif epoch == -1:
-                        pretrained_model = old_job.train_task().pretrained_model
-                    else:
-                        for filename, e in old_job.train_task().snapshots:
-                            if e == epoch:
-                                pretrained_model = filename
-                                break
-
-                        if pretrained_model is None:
-                            raise werkzeug.exceptions.BadRequest(
-                                    "For the job %s, selected pretrained_model for epoch %d is invalid!"
-                                    % (form.previous_networks.data, epoch))
-                        if not (os.path.exists(pretrained_model)):
-                            raise werkzeug.exceptions.BadRequest(
-                                    "Pretrained_model for the selected epoch doesn't exists. May be deleted by another user/process. Please restart the server to load the correct pretrained_model details")
-                    break
-
-        elif form.method.data == 'custom':
-            network = fw.get_network_from_desc(form.custom_network.data)
-            pretrained_model = form.custom_network_snapshot.data.strip()
-        else:
-            raise werkzeug.exceptions.BadRequest(
-                    'Unrecognized method: "%s"' % form.method.data)
-
-        policy = {'policy': form.lr_policy.data}
-        if form.lr_policy.data == 'fixed':
-            pass
-        elif form.lr_policy.data == 'step':
-            policy['stepsize'] = form.lr_step_size.data
-            policy['gamma'] = form.lr_step_gamma.data
-        elif form.lr_policy.data == 'multistep':
-            policy['stepvalue'] = form.lr_multistep_values.data
-            policy['gamma'] = form.lr_multistep_gamma.data
-        elif form.lr_policy.data == 'exp':
-            policy['gamma'] = form.lr_exp_gamma.data
-        elif form.lr_policy.data == 'inv':
-            policy['gamma'] = form.lr_inv_gamma.data
-            policy['power'] = form.lr_inv_power.data
-        elif form.lr_policy.data == 'poly':
-            policy['power'] = form.lr_poly_power.data
-        elif form.lr_policy.data == 'sigmoid':
-            policy['stepsize'] = form.lr_sigmoid_step.data
-            policy['gamma'] = form.lr_sigmoid_gamma.data
-        else:
-            raise werkzeug.exceptions.BadRequest(
-                    'Invalid learning rate policy')
-
-        if config_value('caffe_root')['multi_gpu']:
-            if form.select_gpu_count.data:
-                gpu_count = form.select_gpu_count.data
-                selected_gpus = None
-            else:
-                selected_gpus = [str(gpu) for gpu in form.select_gpus.data]
-                gpu_count = None
-        else:
-            if form.select_gpu.data == 'next':
-                gpu_count = 1
-                selected_gpus = None
-            else:
-                selected_gpus = [str(form.select_gpu.data)]
-                gpu_count = None
-
-        # Python Layer File may be on the server or copied from the client.
-        fs.copy_python_layer_file(
-            bool(form.python_layer_from_client.data),
-            job.dir(),
-            (flask.request.files[form.python_layer_client_file.name]
-             if form.python_layer_client_file.name in flask.request.files
-             else ''), form.python_layer_server_file.data)
-
-        job.tasks.append(fw.create_train_task(
-                    job_dir         = job.dir(),
-                    dataset         = datasetJob,
-                    train_epochs    = form.train_epochs.data,
-                    snapshot_interval   = form.snapshot_interval.data,
-                    learning_rate   = form.learning_rate.data,
-                    lr_policy       = policy,
-                    gpu_count       = gpu_count,
-                    selected_gpus   = selected_gpus,
-                    batch_size      = form.batch_size.data,
-                    val_interval    = form.val_interval.data,
-                    pretrained_model= pretrained_model,
-                    crop_size       = form.crop_size.data,
-                    use_mean        = form.use_mean.data,
-                    network         = network,
-                    random_seed     = form.random_seed.data,
-                    solver_type     = form.solver_type.data,
-                    shuffle         = form.shuffle.data,
+        job = None
+        try:
+            job = GenericImageModelJob(
+                    username    = utils.auth.get_username(),
+                    name        = form.model_name.data + extra,
+                    dataset_id  = datasetJob.id(),
                     )
-                )
 
-        ## Save form data with the job so we can easily clone it later.
-        save_form_to_job(job, form)
+            # get framework (hard-coded to caffe for now)
+            fw = frameworks.get_framework_by_id(form.framework.data)
 
-        scheduler.add_job(job)
-        if request_wants_json():
-            return flask.jsonify(job.json_dict())
-        else:
-            return flask.redirect(flask.url_for('digits.model.views.show', job_id=job.id()))
+            pretrained_model = None
+            #if form.method.data == 'standard':
+            if form.method.data == 'previous':
+                old_job = scheduler.get_job(form.previous_networks.data)
+                if not old_job:
+                    raise werkzeug.exceptions.BadRequest(
+                            'Job not found: %s' % form.previous_networks.data)
 
-    except:
-        if job:
-            scheduler.delete_job(job)
-        raise
+                use_same_dataset = (old_job.dataset_id == job.dataset_id)
+                network = fw.get_network_from_previous(old_job.train_task().network, use_same_dataset)
+
+                for choice in form.previous_networks.choices:
+                    if choice[0] == form.previous_networks.data:
+                        epoch = float(flask.request.form['%s-snapshot' % form.previous_networks.data])
+                        if epoch == 0:
+                            pass
+                        elif epoch == -1:
+                            pretrained_model = old_job.train_task().pretrained_model
+                        else:
+                            for filename, e in old_job.train_task().snapshots:
+                                if e == epoch:
+                                    pretrained_model = filename
+                                    break
+
+                            if pretrained_model is None:
+                                raise werkzeug.exceptions.BadRequest(
+                                        "For the job %s, selected pretrained_model for epoch %d is invalid!"
+                                        % (form.previous_networks.data, epoch))
+                            if not (os.path.exists(pretrained_model)):
+                                raise werkzeug.exceptions.BadRequest(
+                                        "Pretrained_model for the selected epoch doesn't exists. May be deleted by another user/process. Please restart the server to load the correct pretrained_model details")
+                        break
+
+            elif form.method.data == 'custom':
+                network = fw.get_network_from_desc(form.custom_network.data)
+                pretrained_model = form.custom_network_snapshot.data.strip()
+            else:
+                raise werkzeug.exceptions.BadRequest(
+                        'Unrecognized method: "%s"' % form.method.data)
+
+            policy = {'policy': form.lr_policy.data}
+            if form.lr_policy.data == 'fixed':
+                pass
+            elif form.lr_policy.data == 'step':
+                policy['stepsize'] = form.lr_step_size.data
+                policy['gamma'] = form.lr_step_gamma.data
+            elif form.lr_policy.data == 'multistep':
+                policy['stepvalue'] = form.lr_multistep_values.data
+                policy['gamma'] = form.lr_multistep_gamma.data
+            elif form.lr_policy.data == 'exp':
+                policy['gamma'] = form.lr_exp_gamma.data
+            elif form.lr_policy.data == 'inv':
+                policy['gamma'] = form.lr_inv_gamma.data
+                policy['power'] = form.lr_inv_power.data
+            elif form.lr_policy.data == 'poly':
+                policy['power'] = form.lr_poly_power.data
+            elif form.lr_policy.data == 'sigmoid':
+                policy['stepsize'] = form.lr_sigmoid_step.data
+                policy['gamma'] = form.lr_sigmoid_gamma.data
+            else:
+                raise werkzeug.exceptions.BadRequest(
+                        'Invalid learning rate policy')
+
+            if config_value('caffe_root')['multi_gpu']:
+                if form.select_gpu_count.data:
+                    gpu_count = form.select_gpu_count.data
+                    selected_gpus = None
+                else:
+                    selected_gpus = [str(gpu) for gpu in form.select_gpus.data]
+                    gpu_count = None
+            else:
+                if form.select_gpu.data == 'next':
+                    gpu_count = 1
+                    selected_gpus = None
+                else:
+                    selected_gpus = [str(form.select_gpu.data)]
+                    gpu_count = None
+
+            # Python Layer File may be on the server or copied from the client.
+            fs.copy_python_layer_file(
+                bool(form.python_layer_from_client.data),
+                job.dir(),
+                (flask.request.files[form.python_layer_client_file.name]
+                 if form.python_layer_client_file.name in flask.request.files
+                 else ''), form.python_layer_server_file.data)
+
+            job.tasks.append(fw.create_train_task(
+                        job_dir         = job.dir(),
+                        dataset         = datasetJob,
+                        train_epochs    = form.train_epochs.data,
+                        snapshot_interval   = form.snapshot_interval.data,
+                        learning_rate   = form.learning_rate.data[0],
+                        lr_policy       = policy,
+                        gpu_count       = gpu_count,
+                        selected_gpus   = selected_gpus,
+                        batch_size      = form.batch_size.data[0],
+                        val_interval    = form.val_interval.data,
+                        pretrained_model= pretrained_model,
+                        crop_size       = form.crop_size.data,
+                        use_mean        = form.use_mean.data,
+                        network         = network,
+                        random_seed     = form.random_seed.data,
+                        solver_type     = form.solver_type.data,
+                        shuffle         = form.shuffle.data,
+                        )
+                    )
+
+            ## Save form data with the job so we can easily clone it later.
+            save_form_to_job(job, form)
+
+            scheduler.add_job(job)
+            if n_jobs == 1:
+                if request_wants_json():
+                    return flask.jsonify(job.json_dict())
+                else:
+                    return flask.redirect(flask.url_for('digits.model.views.show', job_id=job.id()))
+
+        except:
+            if job:
+                scheduler.delete_job(job)
+            raise
+
+    # If there are multiple jobs launched, go to the home page.
+    return flask.redirect('/')
 
 def show(job):
     """

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -93,6 +93,7 @@ def create():
     add_batch_size = len(form.batch_size.data) > 1
     n_jobs = len(sweeps)
 
+    jobs = []
     for sweep in sweeps:
         # Populate the form with swept data to be used in saving and
         # launching jobs.
@@ -227,6 +228,7 @@ def create():
             ## Save form data with the job so we can easily clone it later.
             save_form_to_job(job, form)
 
+            jobs.append(job)
             scheduler.add_job(job)
             if n_jobs == 1:
                 if request_wants_json():
@@ -238,6 +240,9 @@ def create():
             if job:
                 scheduler.delete_job(job)
             raise
+
+    if request_wants_json():
+        return flask.jsonify(jobs=[job.json_dict() for job in jobs])
 
     # If there are multiple jobs launched, go to the home page.
     return flask.redirect('/')

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -152,6 +152,9 @@ $("#dataset").change(function() {
                 <div class="form-group{{mark_errors([form.batch_size])}}">
                     {{form.batch_size.label}}
                     {{form.batch_size.tooltip}}
+                    <small class="pull-right">
+                        {{form.batch_size.small_text}}
+                    </small>
                     {{form.batch_size(class='form-control', placeholder='[network defaults]')}}
                 </div>
                 <div class="form-group{{mark_errors([form.solver_type])}}">
@@ -162,6 +165,9 @@ $("#dataset").change(function() {
                 <div class="form-group{{mark_errors([form.learning_rate])}}">
                     {{form.learning_rate.label}}
                     {{form.learning_rate.tooltip}}
+                    <small class="pull-right">
+                        {{form.learning_rate.small_text}}
+                    </small>
                     {{form.learning_rate(class='form-control learning-rate-option')}}
                 </div>
 

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -152,6 +152,9 @@ $("#dataset").change(function() {
                 <div class="form-group{{mark_errors([form.batch_size])}}">
                     {{form.batch_size.label}}
                     {{form.batch_size.tooltip}}
+                    <small class="pull-right">
+                        {{form.batch_size.small_text}}
+                    </small>
                     {{form.batch_size(class='form-control', placeholder='[network defaults]')}}
                 </div>
                 <div class="form-group{{mark_errors([form.solver_type])}}">
@@ -162,6 +165,9 @@ $("#dataset").change(function() {
                 <div class="form-group{{mark_errors([form.learning_rate])}}">
                     {{form.learning_rate.label}}
                     {{form.learning_rate.tooltip}}
+                    <small class="pull-right">
+                        {{form.learning_rate.small_text}}
+                    </small>
                     {{form.learning_rate(class='form-control learning-rate-option')}}
                 </div>
 

--- a/digits/utils/forms.py
+++ b/digits/utils/forms.py
@@ -263,7 +263,10 @@ class MultiIntegerField(wtforms.Field):
     def process_formdata(self, valuelist):
         if valuelist:
             try:
-                self.data = [int(float(datum)) for datum in valuelist[0].split(',')]
+                valuelist[0] = valuelist[0].replace('[', '')
+                valuelist[0] = valuelist[0].replace(']', '')
+                valuelist[0] = valuelist[0].split(',')
+                self.data = [int(float(datum)) for datum in valuelist[0]]
             except ValueError:
                 self.data = [None]
                 raise ValueError(self.gettext('Not a valid integer value'))
@@ -305,7 +308,10 @@ class MultiFloatField(wtforms.Field):
     def process_formdata(self, valuelist):
         if valuelist:
             try:
-                self.data = [float(datum) for datum in valuelist[0].split(',')]
+                valuelist[0] = valuelist[0].replace('[', '')
+                valuelist[0] = valuelist[0].replace(']', '')
+                valuelist[0] = valuelist[0].split(',')
+                self.data = [float(datum) for datum in valuelist[0]]
             except ValueError:
                 self.data = [None]
                 raise ValueError(self.gettext('Not a valid float value'))


### PR DESCRIPTION
Adding the ability to sweep Batch Size and Learning Rate.  Their entry fields now accept multiple values.

![image](https://cloud.githubusercontent.com/assets/13259615/14834899/c6592cf0-0bbb-11e6-884d-d6c5b4881a25.png)

![image](https://cloud.githubusercontent.com/assets/13259615/14834928/e91da8ce-0bbb-11e6-9994-eb891d37afd9.png)

Each permutation of the swept fields will generate one job. With Batch Size [1,2] and Learning Rate [0.01, 0.015, 0.02], six jobs will be created.  The job names are augmented by the swept field value.  When multiple jobs are launched, the page is redirected to the home page rather than a job page.

![image](https://cloud.githubusercontent.com/assets/13259615/14835051/b133e5b2-0bbc-11e6-9781-a94e19132feb.png)

If you were to clone one of these jobs, it will only have the values of that particular job. The clone data is saved per job.