### PR TITLE
Data extension framework

### DIFF
--- a/digits/dataset/__init__.py
+++ b/digits/dataset/__init__.py
@@ -2,4 +2,5 @@
 from __future__ import absolute_import
 
 from .images import *
+from .generic import *
 from .job import DatasetJob

--- a/digits/dataset/generic/__init__.py
+++ b/digits/dataset/generic/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .job import GenericDatasetJob

--- a/digits/dataset/generic/forms.py
+++ b/digits/dataset/generic/forms.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import wtforms
+from wtforms import validators
+
+from ..forms import DatasetForm
+from digits import utils
+
+
+class GenericDatasetForm(DatasetForm):
+    """
+    Defines the form used to create a new GenericDatasetJob
+    """
+    # Generic dataset options
+    dsopts_feature_encoding = utils.forms.SelectField(
+        'Feature Encoding',
+        default='png',
+        choices=[('none', 'None'),
+                 ('png', 'PNG (lossless)'),
+                 ('jpg', 'JPEG (lossy, 90% quality)'),
+                 ],
+        tooltip="Using either of these compression formats can save disk"
+                " space, but can also require marginally more time for"
+                " training."
+        )
+
+    dsopts_label_encoding = utils.forms.SelectField(
+        'Label Encoding',
+        default='none',
+        choices=[
+            ('none', 'None'),
+            ('png', 'PNG (lossless)'),
+            ('jpg', 'JPEG (lossy, 90% quality)'),
+            ],
+        tooltip="Using either of these compression formats can save disk"
+                " space, but can also require marginally more time for"
+                " training."
+        )
+
+    dsopts_batch_size = utils.forms.IntegerField(
+        'Encoder batch size',
+        validators=[
+            validators.DataRequired(),
+            validators.NumberRange(min=1),
+            ],
+        default=32,
+        tooltip="Encode data in batches of specified number of entries"
+        )
+
+    dsopts_num_threads = utils.forms.IntegerField(
+        'Number of encoder threads',
+        validators=[
+            validators.DataRequired(),
+            validators.NumberRange(min=1),
+            ],
+        default=4,
+        tooltip="Use specified number of encoder threads"
+        )
+
+    dsopts_backend = wtforms.SelectField(
+        'DB backend',
+        choices=[
+            ('lmdb', 'LMDB'),
+            ],
+        default='lmdb',
+        )

--- a/digits/dataset/generic/job.py
+++ b/digits/dataset/generic/job.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from ..job import DatasetJob
+from digits.dataset import tasks
+from digits.utils import subclass, override, constants
+
+# NOTE: Increment this everytime the pickled object changes
+PICKLE_VERSION = 1
+
+
+@subclass
+class GenericDatasetJob(DatasetJob):
+    """
+    A Job that creates a dataset using a user-defined extension
+    """
+    def __init__(self,
+                 backend,
+                 feature_encoding,
+                 label_encoding,
+                 batch_size,
+                 num_threads,
+                 extension_id,
+                 extension_userdata,
+                 **kwargs
+                 ):
+        self.backend = backend
+        self.feature_encoding = feature_encoding
+        self.label_encoding = label_encoding
+        self.num_threads = num_threads
+        self.batch_size = batch_size
+        self.extension_id = extension_id
+        self.extension_userdata = extension_userdata
+
+        super(GenericDatasetJob, self).__init__(**kwargs)
+        self.pickver_job_dataset_extension = PICKLE_VERSION
+
+        # create tasks
+        for stage in [constants.TRAIN_DB, constants.VAL_DB, constants.TEST_DB]:
+            self.tasks.append(tasks.CreateGenericDbTask(
+                job_dir=self.dir(),
+                job=self,
+                backend=self.backend,
+                stage=stage,
+                )
+            )
+
+    def __setstate__(self, state):
+        super(GenericDatasetJob, self).__setstate__(state)
+        self.pickver_job_dataset_extension = PICKLE_VERSION
+
+    def create_db_task(self, stage):
+        for t in self.tasks:
+            if t.stage == stage:
+                return t
+        return None
+
+    def create_db_tasks(self):
+        return self.tasks
+
+    @override
+    def get_backend(self):
+        """
+        Return the DB backend used to create this dataset
+        """
+        return self.backend
+
+    @override
+    def get_entry_count(self, stage):
+        """
+        Return the number of entries in the DB matching the specified stage
+        """
+        return self.create_db_task(stage).entry_count
+
+    @override
+    def get_feature_db_path(self, stage):
+        """
+        Return the absolute feature DB path for the specified stage
+        """
+        return self.path(self.create_db_task(stage).dbs['features'])
+
+    @override
+    def get_feature_dims(self):
+        """
+        Return the shape of the feature N-D array
+        """
+        shape = self.create_db_task(constants.TRAIN_DB).feature_shape
+        if len(shape) == 3:
+            # assume image and convert CHW => HWC (numpy default for images)
+            shape = [shape[1], shape[2], shape[0]]
+        return shape
+
+    @override
+    def get_label_db_path(self, stage):
+        """
+        Return the absolute label DB path for the specified stage
+        """
+        return self.path(self.create_db_task(stage).dbs['labels'])
+
+    @override
+    def get_mean_file(self):
+        """
+        Return the mean file (if it exists, or None)
+        """
+        mean_file = self.create_db_task(constants.TRAIN_DB).mean_file
+        return self.path(mean_file) if mean_file else None
+
+    @override
+    def job_type(self):
+        return 'Generic Dataset'

--- a/digits/dataset/generic/test_views.py
+++ b/digits/dataset/generic/test_views.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import json
+
+from bs4 import BeautifulSoup
+
+import digits.test_views
+
+from digits import extensions
+
+# May be too short on a slow system
+TIMEOUT_DATASET = 45
+
+################################################################################
+# Base classes (they don't start with "Test" so nose won't run them)
+################################################################################
+
+
+class BaseViewsTest(digits.test_views.BaseViewsTest):
+    """
+    Provides some functions
+    """
+
+    @classmethod
+    def dataset_exists(cls, job_id):
+        return cls.job_exists(job_id, 'datasets')
+
+    @classmethod
+    def dataset_status(cls, job_id):
+        return cls.job_status(job_id, 'datasets')
+
+    @classmethod
+    def abort_dataset(cls, job_id):
+        return cls.abort_job(job_id, job_type='datasets')
+
+    @classmethod
+    def dataset_wait_completion(cls, job_id, **kwargs):
+        kwargs['job_type'] = 'datasets'
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = TIMEOUT_DATASET
+        return cls.job_wait_completion(job_id, **kwargs)
+
+    @classmethod
+    def delete_dataset(cls, job_id):
+        return cls.delete_job(job_id, job_type='datasets')
+
+
+class BaseViewsTestWithDataset(BaseViewsTest):
+    """
+    Provides some functions
+    """
+
+    @classmethod
+    def create_dataset(cls, **kwargs):
+        """
+        Create a dataset
+        Returns the job_id
+        Raises RuntimeError if job fails to create
+
+        Keyword arguments:
+        **kwargs -- data to be sent with POST request
+        """
+        data = {
+            'dataset_name': 'test_dataset',
+            }
+        data.update(kwargs)
+
+        request_json = data.pop('json', False)
+        url = '/datasets/generic/create/%s' % cls.EXTENSION_ID
+        if request_json:
+            url += '.json'
+
+        rv = cls.app.post(url, data=data)
+
+        if request_json:
+            if rv.status_code != 200:
+                raise RuntimeError(
+                    'Model creation failed with %s' % rv.status_code)
+            return json.loads(rv.data)['id']
+
+        # expect a redirect
+        if not 300 <= rv.status_code <= 310:
+            s = BeautifulSoup(rv.data, 'html.parser')
+            div = s.select('div.alert-danger')
+            if div:
+                print div[0]
+            else:
+                print rv.data
+            raise RuntimeError(
+                'Failed to create dataset - status %s' % rv.status_code)
+
+        job_id = cls.job_id_from_response(rv)
+
+        assert cls.dataset_exists(job_id), 'dataset not found after successful creation'
+
+        cls.created_datasets.append(job_id)
+        return job_id
+
+    @classmethod
+    def setUpClass(cls, **kwargs):
+        super(BaseViewsTestWithDataset, cls).setUpClass()
+        cls.dataset_id = cls.create_dataset(json=True, **kwargs)
+        assert cls.dataset_wait_completion(cls.dataset_id) == 'Done', 'create failed'
+
+
+class GenericViewsTest(BaseViewsTest):
+    def test_page_dataset_new(self):
+        rv = self.app.get('/datasets/generic/new/%s' % self.EXTENSION_ID)
+        assert rv.status_code == 200, 'page load failed with %s' % rv.status_code
+        assert extensions.data.get_extension(self.EXTENSION_ID).get_title() in rv.data, 'unexpected page format'
+
+    def test_nonexistent_dataset(self):
+        assert not self.dataset_exists('foo'), "dataset shouldn't exist"
+
+
+class GenericCreationTest(BaseViewsTestWithDataset):
+    """
+    Dataset creation tests
+    """
+
+    def test_create_json(self):
+        job_id = self.create_dataset(json=True)
+        self.abort_dataset(job_id)
+
+    def test_create_delete(self):
+        job_id = self.create_dataset()
+        assert self.delete_dataset(job_id) == 200, 'delete failed'
+        assert not self.dataset_exists(job_id), 'dataset exists after delete'
+
+    def test_create_abort_delete(self):
+        job_id = self.create_dataset()
+        assert self.abort_dataset(job_id) == 200, 'abort failed'
+        assert self.delete_dataset(job_id) == 200, 'delete failed'
+        assert not self.dataset_exists(job_id), 'dataset exists after delete'
+
+    def test_create_wait_delete(self):
+        job_id = self.create_dataset()
+        assert self.dataset_wait_completion(job_id) == 'Done', 'create failed'
+        assert self.delete_dataset(job_id) == 200, 'delete failed'
+        assert not self.dataset_exists(job_id), 'dataset exists after delete'
+
+    def test_invalid_number_of_reader_threads(self):
+        try:
+            self.create_dataset(
+                json=True,
+                dsopts_num_threads=0)
+            assert False
+        except RuntimeError:
+            # job is expected to fail with a RuntimeError
+            pass
+
+    def test_no_force_same_shape(self):
+        job_id = self.create_dataset(force_same_shape=0)
+        assert self.dataset_wait_completion(job_id) == 'Done', 'create failed'
+
+    def test_clone(self):
+        options_1 = {
+            'resize_channels': '1',
+        }
+
+        job1_id = self.create_dataset(**options_1)
+        assert self.dataset_wait_completion(job1_id) == 'Done', 'first job failed'
+        rv = self.app.get('/datasets/%s.json' % job1_id)
+        assert rv.status_code == 200, 'json load failed with %s' % rv.status_code
+        content1 = json.loads(rv.data)
+
+        ## Clone job1 as job2
+        options_2 = {
+            'clone': job1_id,
+        }
+
+        job2_id = self.create_dataset(**options_2)
+        assert self.dataset_wait_completion(job2_id) == 'Done', 'second job failed'
+        rv = self.app.get('/datasets/%s.json' % job2_id)
+        assert rv.status_code == 200, 'json load failed with %s' % rv.status_code
+        content2 = json.loads(rv.data)
+
+        ## These will be different
+        content1.pop('id')
+        content2.pop('id')
+        content1.pop('directory')
+        content2.pop('directory')
+        assert (content1 == content2), 'job content does not match'
+
+        job1 = digits.webapp.scheduler.get_job(job1_id)
+        job2 = digits.webapp.scheduler.get_job(job2_id)
+
+        assert (job1.form_data == job2.form_data), 'form content does not match'
+
+
+class GenericCreatedTest(BaseViewsTestWithDataset):
+    """
+    Tests on a dataset that has already been created
+    """
+    def test_index_json(self):
+        rv = self.app.get('/index.json')
+        assert rv.status_code == 200, 'page load failed with %s' % rv.status_code
+        content = json.loads(rv.data)
+        found = False
+        for d in content['datasets']:
+            if d['id'] == self.dataset_id:
+                found = True
+                break
+        assert found, 'dataset not found in list'
+
+    def test_dataset_json(self):
+        rv = self.app.get('/datasets/%s.json' % self.dataset_id)
+        assert rv.status_code == 200, 'page load failed with %s' % rv.status_code
+        content = json.loads(rv.data)
+        assert content['id'] == self.dataset_id, 'expected different job_id'
+
+    def test_edit_name(self):
+        status = self.edit_job(
+            self.dataset_id,
+            name='new name'
+            )
+        assert status == 200, 'failed with %s' % status
+        rv = self.app.get('/datasets/summary?job_id=%s' % self.dataset_id)
+        assert rv.status_code == 200
+        assert 'new name' in rv.data
+
+    def test_edit_notes(self):
+        status = self.edit_job(
+            self.dataset_id,
+            notes='new notes'
+            )
+        assert status == 200, 'failed with %s' % status
+
+################################################################################
+# Test classes
+################################################################################
+
+
+class TestImageGradientViews(GenericViewsTest):
+    """
+    Tests which don't require an imageset or a dataset
+    """
+    EXTENSION_ID = "image-gradients"
+
+
+class TestImageGradientCreation(GenericCreationTest):
+    """
+    Test that create datasets
+    """
+    EXTENSION_ID = "image-gradients"
+
+    @classmethod
+    def setUpClass(cls, **kwargs):
+        super(TestImageGradientCreation, cls).setUpClass(train_image_count=100)
+
+
+class TestImageGradientCreated(GenericCreatedTest):
+    """
+    Test that create datasets
+    """
+    EXTENSION_ID = "image-gradients"
+
+    @classmethod
+    def setUpClass(cls, **kwargs):
+        super(TestImageGradientCreated, cls).setUpClass(train_image_count=100)

--- a/digits/dataset/generic/views.py
+++ b/digits/dataset/generic/views.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import flask
+
+from .forms import GenericDatasetForm
+from .job import GenericDatasetJob
+
+from digits import extensions, utils
+from digits.utils.routing import request_wants_json
+from digits.webapp import scheduler
+
+blueprint = flask.Blueprint(__name__, __name__)
+
+
+@blueprint.route('/new/<extension_id>', methods=['GET'])
+@utils.auth.requires_login
+def new(extension_id):
+    """
+    Returns a form for a new GenericDatasetJob
+    """
+
+    form = GenericDatasetForm()
+
+    ## Is there a request to clone a job with ?clone=<job_id>
+    utils.forms.fill_form_if_cloned(form)
+
+    extension = extensions.data.get_extension(extension_id)
+    if extension is None:
+        raise ValueError("Unknown extension '%s'" % extension_id)
+    extension_form = extension.get_dataset_form()
+
+    ## Is there a request to clone a job with ?clone=<job_id>
+    utils.forms.fill_form_if_cloned(extension_form)
+
+    template, context = extension.get_dataset_template(extension_form)
+    rendered_extension = flask.render_template_string(template, **context)
+
+    return flask.render_template(
+        'datasets/generic/new.html',
+        extension_title=extension.get_title(),
+        extension_id=extension_id,
+        extension_html=rendered_extension,
+        form=form
+        )
+
+
+@blueprint.route('/create/<extension_id>.json', methods=['POST'])
+@blueprint.route('/create/<extension_id>',
+                 methods=['POST'],
+                 strict_slashes=False)
+@utils.auth.requires_login(redirect=False)
+def create(extension_id):
+    """
+    Creates a new GenericDatasetJob
+
+    Returns JSON when requested: {job_id,name,status} or {errors:[]}
+    """
+    form = GenericDatasetForm()
+    form_valid = form.validate_on_submit()
+
+    extension_class = extensions.data.get_extension(extension_id)
+    extension_form = extension_class.get_dataset_form()
+    extension_form_valid = extension_form.validate_on_submit()
+
+    if not (extension_form_valid and form_valid):
+        # merge errors
+        errors = form.errors.copy()
+        errors.update(extension_form.errors)
+
+        template, context = extension_class.get_dataset_template(
+            extension_form)
+        rendered_extension = flask.render_template_string(
+            template,
+            **context)
+
+        if request_wants_json():
+            return flask.jsonify({'errors': errors}), 400
+        else:
+            return flask.render_template(
+                'datasets/generic/new.html',
+                extension_title=extension_class.get_title(),
+                extension_id=extension_id,
+                extension_html=rendered_extension,
+                form=form,
+                errors=errors), 400
+
+    # create instance of extension class
+    extension = extension_class(**extension_form.data)
+
+    job = None
+    try:
+        # create job
+        job = GenericDatasetJob(
+            username=utils.auth.get_username(),
+            name=form.dataset_name.data,
+            backend=form.dsopts_backend.data,
+            feature_encoding=form.dsopts_feature_encoding.data,
+            label_encoding=form.dsopts_label_encoding.data,
+            batch_size=int(form.dsopts_batch_size.data),
+            num_threads=int(form.dsopts_num_threads.data),
+            extension_id=extension_id,
+            extension_userdata=extension.get_user_data(),
+            )
+
+        ## Save form data with the job so we can easily clone it later.
+        utils.forms.save_form_to_job(job, form)
+        utils.forms.save_form_to_job(job, extension_form)
+
+        # schedule tasks
+        scheduler.add_job(job)
+
+        if request_wants_json():
+            return flask.jsonify(job.json_dict())
+        else:
+            return flask.redirect(flask.url_for(
+                'digits.dataset.views.show',
+                job_id=job.id()))
+
+    except:
+        if job:
+            scheduler.delete_job(job)
+        raise
+
+
+def show(job):
+    """
+    Called from digits.dataset.views.show()
+    """
+    return flask.render_template('datasets/generic/show.html', job=job)
+
+
+def summary(job):
+    """
+    Return a short HTML summary of a GenericDatasetJob
+    """
+    return flask.render_template('datasets/generic/summary.html', dataset=job)

--- a/digits/dataset/images/classification/test_views.py
+++ b/digits/dataset/images/classification/test_views.py
@@ -472,11 +472,13 @@ class TestCreated(BaseViewsTestWithDataset):
         assert pil_image.size == (self.IMAGE_WIDTH, self.IMAGE_HEIGHT), 'image size is %s' % (pil_image.size,)
 
     def test_edit_name(self):
-        status = self.edit_job(
-                self.dataset_id,
-                name='new name'
-                )
+        status = self.edit_job(self.dataset_id,
+                               name='new name'
+                               )
         assert status == 200, 'failed with %s' % status
+        rv = self.app.get('/datasets/summary?job_id=%s' % self.dataset_id)
+        assert rv.status_code == 200
+        assert 'new name' in rv.data
 
     def test_edit_notes(self):
         status = self.edit_job(

--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -334,14 +334,14 @@ def show(job):
     """
     return flask.render_template('datasets/images/classification/show.html', job=job)
 
-@blueprint.route('/summary', methods=['GET'])
-def summary():
-    """
-    Return a short HTML summary of a DatasetJob
-    """
-    job = job_from_request()
 
-    return flask.render_template('datasets/images/classification/summary.html', dataset=job)
+def summary(job):
+    """
+    Return a short HTML summary of an ImageClassificationDatasetJob
+    """
+    return flask.render_template('datasets/images/classification/summary.html',
+                                 dataset=job)
+
 
 class DbReader(object):
     """

--- a/digits/dataset/images/generic/test_views.py
+++ b/digits/dataset/images/generic/test_views.py
@@ -255,6 +255,9 @@ class TestCreated(BaseViewsTestWithDataset):
                 name='new name'
                 )
         assert status == 200, 'failed with %s' % status
+        rv = self.app.get('/datasets/summary?job_id=%s' % self.dataset_id)
+        assert rv.status_code == 200
+        assert 'new name' in rv.data
 
     def test_edit_notes(self):
         status = self.edit_job(

--- a/digits/dataset/images/generic/views.py
+++ b/digits/dataset/images/generic/views.py
@@ -7,7 +7,7 @@ from .forms import GenericImageDatasetForm
 from .job import GenericImageDatasetJob
 from digits import utils
 from digits.dataset import tasks
-from digits.webapp import app, scheduler
+from digits.webapp import scheduler
 from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import request_wants_json, job_from_request
 
@@ -120,12 +120,10 @@ def show(job):
     """
     return flask.render_template('datasets/images/generic/show.html', job=job)
 
-@blueprint.route('/summary', methods=['GET'])
-def summary():
-    """
-    Return a short HTML summary of a DatasetJob
-    """
-    job = job_from_request()
 
-    return flask.render_template('datasets/images/generic/summary.html', dataset=job)
-
+def summary(job):
+    """
+    Return a short HTML summary of a GenericImageDatasetJob
+    """
+    return flask.render_template('datasets/images/generic/summary.html',
+                                 dataset=job)

--- a/digits/dataset/tasks/__init__.py
+++ b/digits/dataset/tasks/__init__.py
@@ -3,4 +3,5 @@ from __future__ import absolute_import
 
 from .analyze_db import AnalyzeDbTask
 from .create_db import CreateDbTask
+from .create_generic_db import CreateGenericDbTask
 from .parse_folder import ParseFolderTask

--- a/digits/dataset/tasks/create_generic_db.py
+++ b/digits/dataset/tasks/create_generic_db.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import os
+import re
+import sys
+
+import digits
+from digits.task import Task
+from digits.utils import subclass, override
+
+# NOTE: Increment this everytime the pickled version changes
+PICKLE_VERSION = 1
+
+
+@subclass
+class CreateGenericDbTask(Task):
+    """
+    A task to create a db using a user-defined extension
+    """
+
+    def __init__(self, job, backend, stage, **kwargs):
+        """
+        Arguments:
+        """
+        self.job = job
+        self.backend = backend
+        self.stage = stage
+        self.create_db_log_file = "create_%s_db.log" % stage
+        self.dbs = {'features': None, 'labels': None}
+        self.entry_count = 0
+        self.feature_shape = None
+        self.label_shape = None
+        self.mean_file = None
+        super(CreateGenericDbTask, self).__init__(**kwargs)
+        self.pickver_task_create_generic_db = PICKLE_VERSION
+
+    @override
+    def name(self):
+        return 'Create %s DB' % self.stage
+
+    @override
+    def __getstate__(self):
+        state = super(CreateGenericDbTask, self).__getstate__()
+        if 'create_db_log' in state:
+            # don't save file handle
+            del state['create_db_log']
+        return state
+
+    @override
+    def __setstate__(self, state):
+        super(CreateGenericDbTask, self).__setstate__(state)
+        self.pickver_task_create_generic_db = PICKLE_VERSION
+
+    @override
+    def before_run(self):
+        super(CreateGenericDbTask, self).before_run()
+        # create log file
+        self.create_db_log = open(self.path(self.create_db_log_file), 'a')
+        # save job before spawning sub-process
+        self.job.save()
+
+    @override
+    def process_output(self, line):
+        self.create_db_log.write('%s\n' % line)
+        self.create_db_log.flush()
+
+        timestamp, level, message = self.preprocess_output_digits(line)
+        if not message:
+            return False
+
+        # keep track of which databases were created
+        match = re.match(
+            r'Created (features|labels) db for stage %s in (.*)' % self.stage,
+            message)
+        if match:
+            db_type = match.group(1)
+            self.dbs[db_type] = match.group(2)
+            return True
+
+        # mean file
+        match = re.match(
+            r'Created mean file for stage %s in (.*)' % self.stage,
+            message)
+        if match:
+            self.mean_file = match.group(1)
+            return True
+
+        # entry counts
+        match = re.match(
+            r'Found (\d+) entries for stage %s' % self.stage,
+            message)
+        if match:
+            count = int(match.group(1))
+            self.entry_count = count
+            return True
+
+        # feature shape
+        match = re.match(
+            r'Feature shape for stage %s: (.*)' % self.stage,
+            message)
+        if match:
+            self.feature_shape = eval(match.group(1))
+            return True
+
+        # label shape
+        match = re.match(
+            r'Label shape for stage %s: (.*)' % self.stage,
+            message)
+        if match:
+            self.label_shape = eval(match.group(1))
+            return True
+
+        # progress
+        match = re.match(
+            r'Processed (\d+)\/(\d+)',
+            message)
+        if match:
+            self.progress = float(match.group(1))/int(match.group(2))
+            self.emit_progress_update()
+            return True
+
+        # errors, warnings
+        if level == 'warning':
+            self.logger.warning('%s: %s' % (self.name(), message))
+            return True
+        if level in ['error', 'critical']:
+            self.logger.error('%s: %s' % (self.name(), message))
+            self.exception = message
+            return True
+
+        return False
+
+    @override
+    def after_run(self):
+        super(CreateGenericDbTask, self).after_run()
+        self.create_db_log.close()
+
+    @override
+    def offer_resources(self, resources):
+        reserved_resources = {}
+        # we need one CPU resource from create_db_task_pool
+        cpu_key = 'create_db_task_pool'
+        if cpu_key not in resources:
+            return None
+        for resource in resources[cpu_key]:
+            if resource.remaining() >= 1:
+                reserved_resources[cpu_key] = [(resource.identifier, 1)]
+                return reserved_resources
+        return None
+
+    @override
+    def task_arguments(self, resources, env):
+        args = [
+            sys.executable,
+            os.path.join(
+                os.path.dirname(
+                    os.path.dirname(os.path.abspath(digits.__file__))),
+                'tools',
+                'create_generic_db.py'),
+            self.job.id(),
+            '--stage=%s' % self.stage,
+            '--jobs_dir=%s' % digits.config.config_value('jobs_dir'),
+            ]
+
+        return args

--- a/digits/dataset/views.py
+++ b/digits/dataset/views.py
@@ -5,8 +5,9 @@ import flask
 import werkzeug.exceptions
 
 from . import images as dataset_images
-from digits.utils.routing import request_wants_json
-from digits.webapp import app, scheduler
+from . import generic
+from digits.utils.routing import job_from_request, request_wants_json
+from digits.webapp import scheduler
 
 blueprint = flask.Blueprint(__name__, __name__)
 
@@ -30,6 +31,23 @@ def show(job_id):
             return dataset_images.classification.views.show(job)
         elif isinstance(job, dataset_images.GenericImageDatasetJob):
             return dataset_images.generic.views.show(job)
+        elif isinstance(job, generic.GenericDatasetJob):
+            return generic.views.show(job)
         else:
             raise werkzeug.exceptions.BadRequest('Invalid job type')
 
+
+@blueprint.route('/summary', methods=['GET'])
+def summary():
+    """
+    Return a short HTML summary of a DatasetJob
+    """
+    job = job_from_request()
+    if isinstance(job, dataset_images.ImageClassificationDatasetJob):
+        return dataset_images.classification.views.summary(job)
+    elif isinstance(job, dataset_images.GenericImageDatasetJob):
+        return dataset_images.generic.views.summary(job)
+    elif isinstance(job, generic.GenericDatasetJob):
+        return generic.views.summary(job)
+    else:
+        raise werkzeug.exceptions.BadRequest('Invalid job type')

--- a/digits/extensions/__init__.py
+++ b/digits/extensions/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .data import *

--- a/digits/extensions/data/__init__.py
+++ b/digits/extensions/data/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+data_extensions = {
+}
+
+def get_extensions():
+    """
+    return set of data data extensions
+    """
+    return [extension['class'] for extension in data_extensions if extension['show']]
+
+
+def get_extension(extension_id):
+    """
+    return extension associated with specified extension_id
+    """
+    for extension in data_extensions:
+        extension_class = extension['class']
+        if extension_class.get_id() == extension_id:
+            return extension_class
+    return None

--- a/digits/extensions/data/__init__.py
+++ b/digits/extensions/data/__init__.py
@@ -1,8 +1,13 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-data_extensions = {
-}
+from . import imageGradients
+
+data_extensions = [
+    # set show=True if extension should be listed in known extensions
+    {'class': imageGradients.DataIngestion, 'show': False},
+]
+
 
 def get_extensions():
     """

--- a/digits/extensions/data/imageGradients/__init__.py
+++ b/digits/extensions/data/imageGradients/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .data import DataIngestion

--- a/digits/extensions/data/imageGradients/data.py
+++ b/digits/extensions/data/imageGradients/data.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from digits.utils import subclass, override, constants
+from ..interface import DataIngestionInterface
+from .forms import DatasetForm
+
+import numpy as np
+import os
+
+TEMPLATE = "template.html"
+
+
+@subclass
+class DataIngestion(DataIngestionInterface):
+    """
+    A data ingestion extension for an image gradient dataset
+    """
+
+    def __init__(self, **kwargs):
+        super(DataIngestion, self).__init__(**kwargs)
+
+        # Used to calculate the gradients later
+        self.yy, self.xx = np.mgrid[:self.image_height,
+                                    :self.image_width].astype('float')
+
+    @override
+    def encode_entry(self, entry):
+        xslope, yslope = np.random.random_sample(2) - 0.5
+        label = np.array([xslope, yslope])
+        a = xslope * 255 / self.image_width
+        b = yslope * 255 / self.image_height
+        image = a * (self.xx - self.image_width/2) + b * (self.yy - self.image_height/2) + 127.5
+
+        image = image.astype('uint8')
+
+        # convert to 3D tensors
+        image = image[np.newaxis, ...]
+        label = label[np.newaxis, np.newaxis, ...]
+
+        return image, label
+
+    @staticmethod
+    @override
+    def get_category():
+        return "Images"
+
+    @staticmethod
+    @override
+    def get_id():
+        return "image-gradients"
+
+    @staticmethod
+    @override
+    def get_dataset_form():
+        return DatasetForm()
+
+    @staticmethod
+    @override
+    def get_dataset_template(form):
+        """
+        parameters:
+        - form: form returned by get_dataset_form(). This may be populated
+           with values if the job was cloned
+        return:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering dataset creation
+          options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        template = open(os.path.join(extension_dir, TEMPLATE), "r").read()
+        context = {'form': form}
+        return (template, context)
+
+    @staticmethod
+    @override
+    def get_title():
+        return "Gradients"
+
+    @override
+    def itemize_entries(self, stage):
+        if stage == constants.TRAIN_DB:
+            count = self.train_image_count
+        elif stage == constants.VAL_DB:
+            count = self.val_image_count
+        elif stage == constants.TEST_DB:
+            count = self.test_image_count
+        else:
+            raise ValueError('Unknown stage %s' % stage)
+        return xrange(count) if count > 0 else []

--- a/digits/extensions/data/imageGradients/forms.py
+++ b/digits/extensions/data/imageGradients/forms.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from digits import utils
+from digits.utils import subclass
+from flask.ext.wtf import Form
+import wtforms
+from wtforms import validators
+
+
+@subclass
+class DatasetForm(Form):
+    """
+    A form used to create an image gradient dataset
+    """
+
+    train_image_count = utils.forms.IntegerField(
+        'Train Image count',
+        validators=[
+            validators.DataRequired(),
+            validators.NumberRange(min=1),
+            ],
+        default=1000,
+        tooltip="Number of images to create in training set"
+        )
+
+    val_image_count = utils.forms.IntegerField(
+        'Validation Image count',
+        validators=[
+            validators.Optional(),
+            validators.NumberRange(min=0),
+            ],
+        default=250,
+        tooltip="Number of images to create in validation set"
+        )
+
+    test_image_count = utils.forms.IntegerField(
+        'Test Image count',
+        validators=[
+            validators.Optional(),
+            validators.NumberRange(min=0),
+            ],
+        default=0,
+        tooltip="Number of images to create in validation set"
+        )
+
+    image_width = wtforms.IntegerField(
+        u'Image Width',
+        default=32,
+        validators=[validators.DataRequired()]
+        )
+
+    image_height = wtforms.IntegerField(
+        u'Image Height',
+        default=32,
+        validators=[validators.DataRequired()]
+        )

--- a/digits/extensions/data/imageGradients/template.html
+++ b/digits/extensions/data/imageGradients/template.html
@@ -1,0 +1,39 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+<div class="form-group{{mark_errors([form.train_image_count])}}">
+    {{ form.train_image_count.label }}
+    {{ form.train_image_count.tooltip }}
+    {{ form.train_image_count(class='form-control') }}
+</div>
+
+<div class="form-group{{mark_errors([form.val_image_count])}}">
+    {{ form.val_image_count.label }}
+    {{ form.val_image_count.tooltip }}
+    {{ form.val_image_count(class='form-control') }}
+</div>
+
+<div class="form-group{{mark_errors([form.test_image_count])}}">
+    {{ form.test_image_count.label }}
+    {{ form.test_image_count.tooltip }}
+    {{ form.test_image_count(class='form-control') }}
+</div>
+
+<div class="form-group{{mark_errors([form.image_width, form.image_height])}}">
+    <label>Image size (Width x Height)</label>
+    <span name="size_dims_explanation"
+          class="explanation-tooltip glyphicon glyphicon-question-sign"
+          data-container="body"
+          title="Input images will be resized to fit."
+          ></span>
+    <div class="input-group">
+        {{ form.image_width(size=4, placeholder='width', class='form-control') }}
+        <span class="input-group-addon">x</span>
+        {{ form.image_height(size=4, placeholder='height', class='form-control') }}
+    </div>
+</div>
+
+

--- a/digits/extensions/data/interface.py
+++ b/digits/extensions/data/interface.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+
+class DataIngestionInterface(object):
+    """
+    A data ingestion extension
+    """
+
+    def __init__(self, **kwargs):
+        # save all data there - no other fields will be persisted
+        self.userdata = kwargs
+
+        # populate instance from userdata dictionary
+        for k, v in self.userdata.items():
+            setattr(self, k, v)
+
+    def encode_entry(self, entry):
+        """
+        Encode the entry associated with specified ID (returned by
+        itemize_entries())
+        Returns a tuble (feature, label)
+        Data are expected in HWC format
+        Color images are expected in RGB order
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_category():
+        raise NotImplementedError
+
+    @staticmethod
+    def get_dataset_form():
+        """
+        Return a Form object with all fields required to create the dataset
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_dataset_template(form):
+        """
+        Parameters:
+        - form: form returned by get_dataset_form(). This may be populated
+           with values if the job was cloned
+        return:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering dataset creation
+          options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_id():
+        """
+        Return unique ID
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_inference_form():
+        """
+        For later use
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_inference_template():
+        """
+        For later use
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_title():
+        """
+        Return get_title
+        """
+        raise NotImplementedError
+
+    def get_user_data(self):
+        """
+        Return serializable user data
+        The data will be persisted as part of the dataset job data
+        """
+        return self.userdata
+
+    def itemize_entries(self, stage):
+        """
+        Return a list of entry IDs to encode
+        This function is called on the main thread
+        The returned list will be spread across all reader threads
+        Reader threads will call encode_entry() with IDs returned by
+        this function in no particular order
+        """
+        raise NotImplementedError

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -10,27 +10,27 @@ import werkzeug.exceptions
 
 from .forms import GenericImageModelForm
 from .job import GenericImageModelJob
-from digits import frameworks
-from digits import utils
+from digits import extensions, frameworks, utils
 from digits.config import config_value
-from digits.dataset import GenericImageDatasetJob
+from digits.dataset import GenericDatasetJob, GenericImageDatasetJob
 from digits.inference import ImageInferenceJob
 from digits.status import Status
 from digits.utils import filesystem as fs
 from digits.utils.forms import fill_form_if_cloned, save_form_to_job
-from digits.utils.routing import request_wants_json, job_from_request
-from digits.webapp import app, scheduler
+from digits.utils.routing import get_request_arg, request_wants_json, job_from_request
+from digits.webapp import scheduler
 
 blueprint = flask.Blueprint(__name__, __name__)
 
 @blueprint.route('/new', methods=['GET'])
+@blueprint.route('/new/<extension_id>', methods=['GET'])
 @utils.auth.requires_login
-def new():
+def new(extension_id=None):
     """
     Return a form for a new GenericImageModelJob
     """
     form = GenericImageModelForm()
-    form.dataset.choices = get_datasets()
+    form.dataset.choices = get_datasets(extension_id)
     form.standard_networks.choices = []
     form.previous_networks.choices = get_previous_networks()
 
@@ -39,25 +39,31 @@ def new():
     ## Is there a request to clone a job with ?clone=<job_id>
     fill_form_if_cloned(form)
 
-    return flask.render_template('models/images/generic/new.html',
-            form = form,
-            frameworks = frameworks.get_frameworks(),
-            previous_network_snapshots = prev_network_snapshots,
-            previous_networks_fullinfo = get_previous_networks_fulldetails(),
-            multi_gpu = config_value('caffe_root')['multi_gpu'],
-            )
+    return flask.render_template(
+        'models/images/generic/new.html',
+        extension_id=extension_id,
+        extension_title=extensions.data.get_extension(extension_id).get_title() if extension_id else None,
+        form=form,
+        frameworks=frameworks.get_frameworks(),
+        previous_network_snapshots=prev_network_snapshots,
+        previous_networks_fullinfo=get_previous_networks_fulldetails(),
+        multi_gpu=config_value('caffe_root')['multi_gpu'],
+        )
 
+
+@blueprint.route('<extension_id>.json', methods=['POST'])
+@blueprint.route('<extension_id>', methods=['POST'], strict_slashes=False)
 @blueprint.route('.json', methods=['POST'])
 @blueprint.route('', methods=['POST'], strict_slashes=False)
 @utils.auth.requires_login(redirect=False)
-def create():
+def create(extension_id=None):
     """
     Create a new GenericImageModelJob
 
     Returns JSON when requested: {job_id,name,status} or {errors:[]}
     """
     form = GenericImageModelForm()
-    form.dataset.choices = get_datasets()
+    form.dataset.choices = get_datasets(extension_id)
     form.standard_networks.choices = []
     form.previous_networks.choices = get_previous_networks()
 
@@ -70,13 +76,16 @@ def create():
         if request_wants_json():
             return flask.jsonify({'errors': form.errors}), 400
         else:
-            return flask.render_template('models/images/generic/new.html',
-                    form = form,
-                    frameworks = frameworks.get_frameworks(),
-                    previous_network_snapshots = prev_network_snapshots,
-                    previous_networks_fullinfo = get_previous_networks_fulldetails(),
-                    multi_gpu = config_value('caffe_root')['multi_gpu'],
-                    ), 400
+            return flask.render_template(
+                'models/images/generic/new.html',
+                extension_id=extension_id,
+                extension_title=extensions.data.get_extension(extension_id).get_title() if extension_id else None,
+                form= form,
+                frameworks=frameworks.get_frameworks(),
+                previous_network_snapshots=prev_network_snapshots,
+                previous_networks_fullinfo=get_previous_networks_fulldetails(),
+                multi_gpu=config_value('caffe_root')['multi_gpu'],
+                ), 400
 
     datasetJob = scheduler.get_job(form.dataset.data)
     if not datasetJob:
@@ -488,12 +497,20 @@ def infer_many():
                 network_outputs = outputs,
                 )
 
-def get_datasets():
-    return [(j.id(), j.name()) for j in sorted(
-        [j for j in scheduler.jobs.values() if isinstance(j, GenericImageDatasetJob) and (j.status.is_running() or j.status == Status.DONE)],
-        cmp=lambda x,y: cmp(y.id(), x.id())
-        )
-        ]
+
+def get_datasets(extension_id):
+    if extension_id:
+        jobs = [j for j in scheduler.jobs.values()
+                if isinstance(j, GenericDatasetJob)
+                and j.extension_id == extension_id
+                and (j.status.is_running() or j.status == Status.DONE)]
+    else:
+        jobs = [j for j in scheduler.jobs.values()
+                if (isinstance(j, GenericImageDatasetJob) or isinstance(j, GenericDatasetJob))
+                and (j.status.is_running() or j.status == Status.DONE)]
+    return [(j.id(), j.name())
+            for j in sorted(jobs, cmp=lambda x, y: cmp(y.id(), x.id()))]
+
 
 def get_previous_networks():
     return [(j.id(), j.name()) for j in sorted(

--- a/digits/templates/datasets/generic/new.html
+++ b/digits/templates/datasets/generic/new.html
@@ -1,0 +1,75 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_combined_errors %}
+{% from "helper.html" import mark_errors %}
+
+{% extends "layout.html" %}
+
+{% block title %}
+New {{ extension_title }} Dataset
+{% endblock %}
+
+{% block nav %}
+<li class="active"><a href="{{url_for('digits.dataset.generic.views.new', extension_id=extension_id)}}">New Dataset</a></li>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1>New {{ extension_title }} Dataset</h1>
+</div>
+
+<form action="{{url_for('digits.dataset.generic.views.create', extension_id=extension_id)}}" enctype="multipart/form-data" method="post">
+
+    {{ form.hidden_tag() }}
+
+    {{ print_combined_errors(errors, warnings) }}
+
+    <div class="row">
+        <div class="col-sm-6 col-sm-offset-3 well">
+            {{ extension_html|safe }}
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-6 col-sm-offset-3 well">
+            <div class="form-group{{mark_errors([form.dsopts_feature_encoding])}}">
+                {{form.dsopts_feature_encoding.label}}
+                {{form.dsopts_feature_encoding.tooltip}}
+                {{form.dsopts_feature_encoding(class='form-control')}}
+            </div>
+            <div class="form-group{{mark_errors([form.dsopts_label_encoding])}}">
+                {{form.dsopts_label_encoding.label}}
+                {{form.dsopts_label_encoding.tooltip}}
+                {{form.dsopts_label_encoding(class='form-control')}}
+            </div>
+            <div class="form-group{{mark_errors([form.dsopts_batch_size])}}">
+                {{ form.dsopts_batch_size.label }}
+                {{ form.dsopts_batch_size.tooltip }}
+                {{ form.dsopts_batch_size(class='form-control') }}
+            </div>
+            <div class="form-group{{mark_errors([form.dsopts_num_threads])}}">
+                {{ form.dsopts_num_threads.label }}
+                {{ form.dsopts_num_threads.tooltip }}
+                {{ form.dsopts_num_threads(class='form-control') }}
+            </div>
+            <div class="form-group{{mark_errors([form.dsopts_backend])}}">
+                {{ form.dsopts_backend.label }}
+                {{ form.dsopts_backend.tooltip }}
+                {{ form.dsopts_backend(class='form-control') }}
+            </div>
+            <div class="form-group{{mark_errors([form.dataset_name])}}">
+                {{ form.dataset_name.label }}
+                {{ form.dataset_name(class='form-control') }}
+            </div>
+            <input type="submit" name="create-dataset" class="btn btn-primary" value="Create">
+        </div>
+    </div>
+
+</form>
+
+<script>
+$(".explanation-tooltip").tooltip();
+</script>
+
+{% endblock %}

--- a/digits/templates/datasets/generic/show.html
+++ b/digits/templates/datasets/generic/show.html
@@ -1,0 +1,75 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% extends "job.html" %}
+{% from "helper.html" import serve_file %}
+
+{% macro print_create_db_task(task) %}
+<div class="panel-heading">
+    <h4>{{task.name()}}</h4>
+</div>
+<div class="panel-body">
+    <dl>
+        <dt>Entry Count</dt>
+        <dd>
+        {{ task.entry_count }}
+        </dd>
+        {% if task.entry_count > 0 %}
+            <dt>Feature shape</dt>
+            <dd>
+            {{ task.feature_shape }}
+            </dd>
+            <dt>Label shape</dt>
+            <dd>
+            {{ task.label_shape }}
+            </dd>
+            {% for name,path in task.dbs.iteritems() %}
+                <dt>{{ name }} DB</dt>
+                <dd>
+                {{ job.path(path) }}
+                </dd>
+            {% endfor %}
+        {% endif %}
+        {% if task.create_db_log_file %}
+        <dt>DB create log file</dt>
+        <dd>{{serve_file(task, task.create_db_log_file)}}</dd>
+        {% endif %}
+        {% if task.mean_file %}
+        <dt>Mean file</dt>
+        <dd>{{serve_file(task, task.mean_file)}}</dd>
+        {% endif %}
+    </dl>
+</div>
+{% endmacro %}
+
+{% block job_content %}
+
+<div class="row">
+    <div class="col-sm-12">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4>Job Information</h4>
+            </div>
+            <div class="panel-body">
+                <dl>
+                    <dt>Job Directory</dt>
+                    <dd>{{job.dir()}}</dd>
+                    <dt>Dataset size</dt>
+                    <dd>{{job.disk_size_fmt()}}</dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% for task in job.create_db_tasks() %}
+<div class="row">
+    <div class="col-sm-12">
+        <div id="{{task.html_id()}}" class="panel panel-default">
+            {{ print_create_db_task(task) }}
+        </div>
+    </div>
+</div>
+{% endfor %}
+
+{% endblock %}
+

--- a/digits/templates/datasets/generic/summary.html
+++ b/digits/templates/datasets/generic/summary.html
@@ -1,0 +1,29 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+<h4>
+    <a href="{{url_for('digits.views.show_job', job_id=dataset.id())}}" target="_blank">
+        {{dataset.name()}}
+    </a>
+</h4>
+<p>
+<span class="text -{{dataset.status.css}}">{{dataset.status.name}}</span>
+{% if not dataset.status.is_running() %}
+<small>
+    {{dataset.status_history[-1][1]|print_time}}
+</small>
+{% endif %}
+</p>
+<ul>
+    <li>DB backend: {{dataset.get_backend()}}</li>
+    {% for task in dataset.create_db_tasks() %}
+        {% if task.entry_count > 0 %}
+            <li>{{task.name()}}</li>
+            <ul>
+                <li><b>Entry Count:</b> {{ task.entry_count }}</li>
+                <li><b>Feature shape</b> {{ task.feature_shape }}</li>
+                <li><b>Label shape</b> {{ task.label_shape }}</li>
+            </ul>
+        {% endif %}
+    {% endfor %}
+</ul>
+

--- a/digits/templates/helper.html
+++ b/digits/templates/helper.html
@@ -45,6 +45,35 @@
     {% endif %}
 {% endmacro %}
 
+{% macro print_combined_errors(errors, warnings) %}
+    {% if errors %}
+        <div class="alert alert-danger">
+            {% for field_name, field in errors.iteritems() %}
+                <li><label>{{ field_name }}</label>
+                    <ul>
+                        {% for e in field %}
+                            <li>{{ e }}</li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endfor %}
+        </div>
+    {% endif %}
+    {% if warnings %}
+        <div class="alert alert-warning">
+            {% for field_name, field in warnings.iteritems() %}
+                <li><label>{{ field.label.text }}</label>
+                    <ul>
+                        {% for e in field %}
+                            <li>{{ e }}</li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
 {% macro mark_errors(list) %}
     {% for form in list %}
         {{ ' has-error' if form.errors else '' }}

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -86,7 +86,7 @@ function syncAceEditor(){
 
 $("#dataset").change(function() {
     if ($(this).val()) {
-        $.ajax("/datasets/images/classification/summary?job_id=" + $(this).val(),
+        $.ajax("/datasets/summary?job_id=" + $(this).val(),
             {
                 type: "GET",
                 }

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -35,10 +35,22 @@
     <div class="col-sm-6">
         <div class="well">
             <h4 class='text-center'>Dataset</h4>
+            <div id="dataset-summary"></div>
             {% if job.dataset %}
-            {% with dataset = job.dataset %}
-            {% include 'datasets/images/classification/summary.html' %}
-            {% endwith %}
+            <script>
+            $.ajax("/datasets/summary?job_id={{ job.dataset.id() }}",
+            {
+                type: "GET",
+                }
+            )
+            .done(function(data) {
+                $("#dataset-summary").html(data);
+                })
+            .fail(function(data) {
+                $("#dataset-summary").html("");
+                errorAlert(data);
+                });
+            </script>
             {% endif %}
         </div>
     </div>

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -7,16 +7,16 @@
 {% extends "layout.html" %}
 
 {% block title %}
-New Image Model
+New {% if extension_title %}{{ extension_title }}{% else %}Image{% endif %} Model
 {% endblock %}
 
 {% block nav %}
-<li class="active"><a href="{{url_for('digits.model.images.generic.views.new')}}">New Model</a></li>
+<li class="active"><a href="{{url_for('digits.model.images.generic.views.new', extension_id=extension_id)}}">New Model</a></li>
 {% endblock %}
 
 {% block content %}
 <div class="page-header">
-    <h1>New Image Model</h1>
+    <h1>New {% if extension_title %}{{ extension_title }}{% else %}Image{% endif %} Model</h1>
 </div>
 
 <script>
@@ -26,7 +26,7 @@ function syncAceEditor(){
 }
 </script>
 
-<form onsubmit="syncAceEditor();" id="model-form" action="{{url_for('digits.model.images.generic.views.create')}}" enctype="multipart/form-data" method="post">
+<form onsubmit="syncAceEditor();" id="model-form" action="{{url_for('digits.model.images.generic.views.create', extension_id=extension_id)}}" enctype="multipart/form-data" method="post">
     {{ form.hidden_tag() }}
 
     {{ print_errors(form) }}
@@ -85,7 +85,7 @@ function syncAceEditor(){
 
 $("#dataset").change(function() {
     if ($(this).val()) {
-        $.ajax("/datasets/images/generic/summary?job_id=" + $(this).val(),
+        $.ajax("/datasets/summary?job_id=" + $(this).val(),
             {
                 type: "GET",
                 }

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -35,10 +35,22 @@
     <div class="col-sm-6">
         <div class="well">
             <h4 class='text-center'>Dataset</h4>
+            <div id="dataset-summary"></div>
             {% if job.dataset %}
-            {% with dataset = job.dataset %}
-            {% include 'datasets/images/generic/summary.html' %}
-            {% endwith %}
+            <script>
+            $.ajax("/datasets/summary?job_id={{ job.dataset.id() }}",
+            {
+                type: "GET",
+                }
+            )
+            .done(function(data) {
+                $("#dataset-summary").html(data);
+                })
+            .fail(function(data) {
+                $("#dataset-summary").html("");
+                errorAlert(data);
+                });
+            </script>
             {% endif %}
         </div>
     </div>

--- a/digits/webapp.py
+++ b/digits/webapp.py
@@ -37,6 +37,8 @@ import digits.views
 app.register_blueprint(digits.views.blueprint)
 import digits.dataset.views
 app.register_blueprint(digits.dataset.views.blueprint, url_prefix='/datasets')
+import digits.dataset.generic.views
+app.register_blueprint(digits.dataset.generic.views.blueprint, url_prefix='/datasets/generic')
 import digits.dataset.images.views
 app.register_blueprint(digits.dataset.images.views.blueprint, url_prefix='/datasets/images')
 import digits.dataset.images.classification.views

--- a/tools/create_generic_db.py
+++ b/tools/create_generic_db.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python2
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+
+import argparse
+# Find the best implementation available
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
+import lmdb
+import logging
+import numpy as np
+import os
+import PIL.Image
+import Queue
+import sys
+import threading
+
+# Add path for DIGITS package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import digits.config
+digits.config.load_config()
+from digits import extensions, log
+from digits.job import Job
+
+# Run load_config() first to set the path to Caffe
+import caffe.io
+import caffe_pb2
+
+logger = logging.getLogger('digits.tools.create_dataset')
+
+
+class DbWriter(threading.Thread):
+    """
+    Abstract class for writing to databases
+    """
+
+    def __init__(self, output_dir, total_records=None):
+        self._dir = output_dir
+        self.write_queue = Queue.Queue(10)
+        # sequence number
+        self.seqn = 0
+        self.total_records = total_records
+        self.done = False
+        threading.Thread.__init__(self)
+
+    def write_batch_threadsafe(self, batch):
+        """
+        This function writes a batch of data into the database
+        This may be called from multiple threads
+        """
+        self.write_queue.put(batch)
+
+    def set_done(self):
+        """
+        Instructs writer thread to complete after queue becomes empty
+        """
+        self.done = True
+
+    def run(self):
+        """
+        DB Writer thread entry point
+        """
+        while True:
+            try:
+                batch = self.write_queue.get(timeout=0.1)
+            except Queue.Empty:
+                if self.done:
+                    # break out of main loop and terminate
+                    break
+                else:
+                    # just keep looping
+                    continue
+            self.write_batch_threadunsafe(batch)
+
+
+class LmdbWriter(DbWriter):
+
+    def __init__(self,
+                 dataset_dir,
+                 stage,
+                 feature_encoding,
+                 label_encoding,
+                 **kwargs):
+        self.stage = stage
+        db_dir = os.path.join(dataset_dir, stage)
+        if not os.path.exists(db_dir):
+            os.makedirs(db_dir)
+        super(LmdbWriter, self).__init__(dataset_dir, **kwargs)
+
+        # create LMDB for features
+        self.feature_db = self.create_lmdb("features")
+        # will create LMDB for labels later if necessary
+        self.label_db = None
+        # encoding
+        self.feature_encoding = feature_encoding
+        self.label_encoding = label_encoding
+
+    def create_lmdb(self, db_type):
+        sub_dir = os.path.join(self.stage, db_type)
+        db_dir = os.path.join(self._dir, sub_dir)
+        db = lmdb.open(
+            db_dir,
+            map_async=True,
+            max_dbs=0)
+        logger.info('Created %s db for stage %s in %s' % (db_type,
+                                                          self.stage,
+                                                          sub_dir))
+        return db
+
+    def array_to_datum(self, data, scalar_label, encoding):
+        if data.ndim != 3:
+            raise ValueError('Invalid number of dimensions: %d' % data.ndim)
+        if data.shape[0] == 3:
+            # RGB to BGR
+            # XXX see issue #59
+            data = data[[2, 1, 0], ...]
+        if encoding == 'none':
+            datum = caffe.io.array_to_datum(data, scalar_label)
+        else:
+            # Transpose to (height, width, channel)
+            data = data.transpose((1, 2, 0))
+            if data.shape[2] == 1:
+                # grayscale
+                data = data[:, :, 0]
+            datum = caffe_pb2.Datum()
+            datum.height = data.shape[0]
+            datum.width = data.shape[1]
+            datum.label = scalar_label
+            s = StringIO()
+            if encoding == 'png':
+                PIL.Image.fromarray(data).save(s, format='PNG')
+            elif encoding == 'jpg':
+                PIL.Image.fromarray(data).save(s, format='JPEG', quality=90)
+            else:
+                raise ValueError('Invalid encoding type')
+            datum.data = s.getvalue()
+            datum.encoded = True
+        return datum
+
+    def write_batch(self, batch):
+        """
+        encode data into datum objects
+        this may be called from multiple encoder threads
+        """
+        datums = []
+        for (feature, label) in batch:
+            # restrict features to 3D data (Caffe Datum objects)
+            assert feature.ndim == 3, "LMDB/Caffe expect 3D data"
+            # restrict labels to 3D data (Caffe Datum objects) or scalars
+            assert label.ndim == 3 or label.size == 1, "LMDB/Caffe expect 3D or scalar label"
+            if label.size > 1:
+                label_datum = self.array_to_datum(
+                    label,
+                    0,
+                    self.label_encoding)
+                # setting label to 0 - it will be unused as there is
+                # a dedicated label DB
+                label = 0
+            else:
+                label = label[0]
+                label_datum = None
+            feature_datum = self.array_to_datum(
+                feature,
+                label,
+                self.feature_encoding)
+            datums.append(
+                (feature_datum.SerializeToString(),
+                 label_datum.SerializeToString() if label_datum else None))
+        self.write_batch_threadsafe(datums)
+
+    def write_batch_threadunsafe(self, batch):
+        """
+        Write batch do DB, this must only be called from the writer thread
+        """
+        feature_datums = []
+        label_datums = []
+        for (feature, label) in batch:
+            key = "%09d" % self.seqn
+            if label is not None:
+                if self.label_db is None:
+                    self.label_db = self.create_lmdb("labels")
+                label_datums.append((key, label))
+            feature_datums.append((key, feature))
+            self.seqn += 1
+        self.write_datums(self.feature_db, feature_datums)
+        if len(label_datums) > 0:
+            self.write_datums(self.label_db, label_datums)
+        logger.info('Processed %d/%d' % (self.seqn, self.total_records))
+
+    def write_datums(self, db, batch):
+        try:
+            with db.begin(write=True) as lmdb_txn:
+                for key, datum in batch:
+                    lmdb_txn.put(key, datum)
+        except lmdb.MapFullError:
+            # double the map_size
+            curr_limit = db.info()['map_size']
+            new_limit = curr_limit*2
+            logger.info(
+                'Doubling LMDB map size to %sMB ...' % (new_limit >> 20,))
+            try:
+                db.set_mapsize(new_limit)  # double it
+            except AttributeError as e:
+                version = tuple(int(x) for x in lmdb.__version__.split('.'))
+                if version < (0, 87):
+                    raise ValueError('py-lmdb is out of date (%s vs 0.87)' % lmdb.__version__)
+                else:
+                    raise e
+            # try again
+            self.write_datums(db, batch)
+
+
+class Encoder(threading.Thread):
+    def __init__(self, queue, writer, extension, error_queue):
+        self.extension = extension
+        self.queue = queue
+        self.writer = writer
+        self.label_shape = None
+        self.feature_shape = None
+        self.feature_sum = None
+        self.processed_count = 0
+        self.error_queue = error_queue
+        threading.Thread.__init__(self)
+
+    def run(self):
+        data = []
+        while True:
+            # get entry ID
+            # don't block- if the queue is empty then we're done
+            try:
+                batch = self.queue.get_nowait()
+            except Queue.Empty:
+                # break out of main loop and terminate
+                break
+
+            try:
+                data = []
+                for entry_id in batch:
+                    # call into extension to format entry into number arrays
+                    feature, label = self.extension.encode_entry(entry_id)
+
+                    # check feature and label shapes
+                    if self.feature_shape is None:
+                        self.feature_shape = feature.shape
+                        self.feature_sum = np.zeros(self.feature_shape, np.float64)
+                    else:
+                        assert self.feature_shape == feature.shape
+                    if self.label_shape is None:
+                        self.label_shape = label.shape
+                    else:
+                        assert self.label_shape == label.shape
+
+                    # accumulate sum for mean file calculation
+                    self.feature_sum += feature
+
+                    # aggregate data
+                    data.append((feature, label))
+
+                    self.processed_count += 1
+
+                if len(data) >= 0:
+                    # write data
+                    self.writer.write_batch(data)
+            except Exception as e:
+                self.error_queue.put('%s: %s' % (type(e).__name__, e.message))
+                raise
+
+class DbCreator(object):
+
+    def create_db(self, extension, stage, dataset_dir, batch_size, num_threads, feature_encoding, label_encoding):
+        # retrieve itemized list of entries
+        entry_ids = extension.itemize_entries(stage)
+        entry_count = len(entry_ids)
+
+        if entry_count > 0:
+            # create a queue to write errors to
+            error_queue = Queue.Queue()
+
+            # create db writer
+            writer = LmdbWriter(
+                dataset_dir,
+                stage,
+                total_records=entry_count,
+                feature_encoding=feature_encoding,
+                label_encoding=label_encoding)
+            writer.daemon = True
+            writer.start()
+
+            # create and fill encoder queue
+            encoder_queue = Queue.Queue()
+            batch = []
+            for entry_id in entry_ids:
+                batch.append(entry_id)
+                if len(batch) >= batch_size:
+                    # queue this batch
+                    encoder_queue.put(batch)
+                    batch = []
+            if len(batch) > 0:
+                # queue any remaining entries
+                encoder_queue.put(batch)
+
+            # create encoder threads
+            encoders = []
+            for _ in xrange(num_threads):
+                encoder = Encoder(encoder_queue, writer, extension, error_queue)
+                encoder.daemon = True
+                encoder.start()
+                encoders.append(encoder)
+
+            # wait for all encoder threads to complete and aggregate data
+            feature_sum = None
+            processed_count = 0
+            feature_shape = None
+            label_shape = None
+            for encoder in encoders:
+                encoder.join()
+                if feature_sum is None:
+                    feature_sum = encoder.feature_sum
+                elif encoder.feature_sum is not None:
+                    feature_sum += encoder.feature_sum
+                if feature_shape is None:
+                    feature_shape = encoder.feature_shape
+                    logger.info('Feature shape for stage %s: %s' % (stage, repr(feature_shape)))
+                elif encoder.feature_shape is not None:
+                    assert feature_shape == encoder.feature_shape
+                if label_shape is None:
+                    label_shape = encoder.label_shape
+                    logger.info('Label shape for stage %s: %s' % (stage, repr(label_shape)))
+                elif encoder.label_shape is not None:
+                    assert label_shape == encoder.label_shape
+                processed_count += encoder.processed_count
+
+            # write mean file
+            if feature_sum is not None:
+                self.save_mean(feature_sum, processed_count, dataset_dir, stage)
+
+            # wait for writer thread to complete
+            writer.set_done()
+            writer.join()
+
+            # catch errors that may have occurred in reader threads
+            if not error_queue.empty():
+                while not error_queue.empty():
+                    err = error_queue.get()
+                    logger.error(err)
+                raise Exception(err)
+
+            if processed_count != entry_count:
+                # TODO: handle this more gracefully
+                raise ValueError('Number of processed entries (%d) does not match entry count (%d)' % (processed_count, entry_count))
+
+            logger.info('Found %d entries for stage %s' % (processed_count, stage))
+
+
+    def save_mean(self, feature_sum, entry_count, dataset_dir, stage):
+        """
+        Save mean to file
+        """
+        data = np.around(feature_sum / entry_count).astype(np.uint8)
+        mean_file = os.path.join(stage, 'mean.binaryproto')
+        # Transform to caffe's format requirements
+        if data.ndim == 3:
+            if data.shape[0] == 3:
+                # channel swap
+                # XXX see issue #59
+                data = data[[2, 1, 0], ...]
+        elif data.ndim == 2:
+            # Add a channels axis
+            data = data[np.newaxis, :, :]
+
+        blob = caffe_pb2.BlobProto()
+        blob.num = 1
+        blob.channels, blob.height, blob.width = data.shape
+        blob.data.extend(data.astype(float).flat)
+
+        with open(os.path.join(dataset_dir, mean_file), 'wb') as outfile:
+            outfile.write(blob.SerializeToString())
+
+        logger.info('Created mean file for stage %s in %s' % (stage, mean_file))
+
+
+def create_generic_db(jobs_dir, dataset_id, stage):
+    """
+    Create a generic DB
+    """
+
+    # job directory defaults to that defined in DIGITS config
+    if jobs_dir == 'none':
+        jobs_dir = digits.config.config_value('jobs_dir')
+
+    # load dataset job
+    dataset_dir = os.path.join(jobs_dir, dataset_id)
+    assert os.path.isdir(dataset_dir), "Dataset dir %s does not exist" % dataset_dir
+    dataset = Job.load(dataset_dir)
+
+    # create instance of extension
+    extension_id = dataset.extension_id
+    extension_class = extensions.data.get_extension(extension_id)
+    extension = extension_class(**dataset.extension_userdata)
+
+    # encoding
+    feature_encoding = dataset.feature_encoding
+    label_encoding = dataset.label_encoding
+
+    batch_size = dataset.batch_size
+    num_threads = dataset.num_threads
+
+    # create main DB creator object and execute main method
+    db_creator = DbCreator()
+    db_creator.create_db(
+        extension,
+        stage,
+        dataset_dir,
+        batch_size,
+        num_threads,
+        feature_encoding,
+        label_encoding)
+
+    logger.info('Generic DB creation Done')
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='DB creation tool - DIGITS')
+
+    ### Positional arguments
+
+    parser.add_argument(
+        'dataset',
+        help='Dataset Job ID')
+
+    ### Optional arguments
+    parser.add_argument(
+        '-j',
+        '--jobs_dir',
+        default='none',
+        help='Jobs directory (default: from DIGITS config)',
+        )
+
+    parser.add_argument(
+        '-s',
+        '--stage',
+        default='train',
+        help='Stage (train, val, test)',
+        )
+
+    args = vars(parser.parse_args())
+
+    try:
+        create_generic_db(
+            args['jobs_dir'],
+            args['dataset'],
+            args['stage']
+            )
+    except Exception as e:
+        logger.error('%s: %s' % (type(e).__name__, e.message))
+        raise

--- a/tools/test_create_generic_db.py
+++ b/tools/test_create_generic_db.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+
+import shutil
+import tempfile
+
+from . import create_generic_db
+from digits import extensions
+from digits.utils import constants
+
+
+class BaseTest():
+
+    FEATURE_ENCODING = "png"
+    LABEL_ENCODING = "none"
+    BATCH_SIZE = 256
+    NUM_THREADS = 2
+
+    """
+    Provides some helpful files and utilities
+    """
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset_dir = tempfile.mkdtemp()
+        cls.extension_class = extensions.data.get_extension(cls.EXTENSION_ID)
+        cls.extension = cls.extension_class(**cls.EXTENSION_PARAMS)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            shutil.rmtree(cls.dataset_dir)
+        except OSError:
+            raise
+
+
+class TestGradientsExtension(BaseTest):
+    """
+    Create databases for the gradient extension
+    """
+
+    EXTENSION_ID = "image-gradients"
+    EXTENSION_PARAMS = {
+        "train_image_count": 10000,
+        "val_image_count": 50,
+        "test_image_count": 10,
+        "image_width": 256,
+        "image_height": 128
+        }
+
+    def create_db(self, stage):
+        # create main DB creator object and execute main method
+        db_creator = create_generic_db.DbCreator()
+        db_creator.create_db(
+            self.extension,
+            stage,
+            self.dataset_dir,
+            self.BATCH_SIZE,
+            self.NUM_THREADS,
+            self.FEATURE_ENCODING,
+            self.LABEL_ENCODING)
+
+    def test_create_stages(self):
+        for stage in (constants.TRAIN_DB, constants.VAL_DB, constants.TEST_DB):
+            yield self.create_db, stage


### PR DESCRIPTION
### Summary ###

This adds a data extension framework along the lines of:

![data-classes](https://cloud.githubusercontent.com/assets/3889770/15247252/385aab1c-1913-11e6-9b70-5d39f805736e.png)


This also adds an image gradient extension (same as this [tutorial](https://github.com/NVIDIA/DIGITS/tree/digits-3.0/examples/regression) )

Samples extensions will be added in separate pull requests.

This pull requests depends on #723 

### Progress ###

- [x] add data extension framework
- [x] add templates
- [x] add views
- [x] rebase to tip of master branch / squash commits
- [x] add sample extension
- [x] add tests

Documentation may be added later when we want to advertise the feature.
