### PR TITLE
New Torch multi-GPU programming model

### DIFF
--- a/tools/torch/main.lua
+++ b/tools/torch/main.lua
@@ -394,6 +394,10 @@ if opt.weights ~= '' then
         else
             -- the full model was saved
             assert(string.find(opt.weights, '_Model'))
+            if nn.DataParallelTable then
+                -- set number of GPUs to use when deserializing model
+                nn.DataParallelTable.deserializeNGPUs = nGpus
+            end
             model = torch.load(opt.weights)
             network.model = model
         end
@@ -757,9 +761,6 @@ local function Train(epoch, dataLoader)
             end
 
             _,learningrate,_,trainerr = optimizer:optimize(inputs, targets)
-
-            -- DataParallelTable's syncParameters
-            model:apply(function(m) if m.syncParameters then m:syncParameters() end end)
 
             -- adding the loss values of each mini batch and also maintaining the counter for number of batches, so that average loss value can be found at the time of logging details
             loss_sum = loss_sum + trainerr[1]

--- a/tools/torch/test.lua
+++ b/tools/torch/test.lua
@@ -107,6 +107,10 @@ function loadNetwork(dir, name, labels, weightsFile, tensorType, inputTensorShap
         nclasses = (labels ~= nil) and #labels or nil,
         inputShape = inputTensorShape,
     }
+    if nn.DataParallelTable then
+        -- set number of GPUs to use when deserializing model
+        nn.DataParallelTable.deserializeNGPUs = parameters.ngpus
+    end
     local network = require (name)(parameters)
 
     local model


### PR DESCRIPTION
Datapoints:

MNIST+LeNet (30 epochs)
1 GPU: 56s
2 GPUs: 2m51s
(not unexpected due to communication overhead)

Upscaled CIFAR + Alexnet (10 epochs):
1 GPU: 13m11s
2 GPUs: 13m7s

Upscaled CIFAR + Googlenet (2 epochs):
1 GPU: 16m20s
2 GPUs: 11m13s