### PR TITLE
Update standard networks for Caffe

### DIFF
--- a/digits/standard-networks/caffe/alexnet.prototxt
+++ b/digits/standard-networks/caffe/alexnet.prototxt
@@ -10,7 +10,7 @@ layer {
     crop_size: 227
   }
   data_param {
-    batch_size: 100
+    batch_size: 128
   }
   include { stage: "train" }
 }
@@ -23,7 +23,7 @@ layer {
     crop_size: 227
   }
   data_param {
-    batch_size: 100
+    batch_size: 32
   }
   include { stage: "val" }
 }

--- a/digits/standard-networks/caffe/alexnet.prototxt
+++ b/digits/standard-networks/caffe/alexnet.prototxt
@@ -1,13 +1,10 @@
 # AlexNet
 name: "AlexNet"
 layer {
-  name: "data"
+  name: "train-data"
   type: "Data"
   top: "data"
   top: "label"
-  include {
-    phase: TRAIN
-  }
   transform_param {
     mirror: true
     crop_size: 227
@@ -15,21 +12,20 @@ layer {
   data_param {
     batch_size: 100
   }
+  include { stage: "train" }
 }
 layer {
-  name: "data"
+  name: "val-data"
   type: "Data"
   top: "data"
   top: "label"
-  include {
-    phase: TEST
-  }
   transform_param {
     crop_size: 227
   }
   data_param {
     batch_size: 100
   }
+  include { stage: "val" }
 }
 layer {
   name: "conv1"

--- a/digits/standard-networks/caffe/googlenet.prototxt
+++ b/digits/standard-networks/caffe/googlenet.prototxt
@@ -10,7 +10,7 @@ layer {
     crop_size: 224
   }
   data_param {
-    batch_size: 24
+    batch_size: 32
   }
   include { stage: "train" }
 }
@@ -24,7 +24,7 @@ layer {
     crop_size: 224
   }
   data_param {
-    batch_size: 24
+    batch_size: 16
   }
   include { stage: "val" }
 }

--- a/digits/standard-networks/caffe/googlenet.prototxt
+++ b/digits/standard-networks/caffe/googlenet.prototxt
@@ -1,13 +1,10 @@
 # GoogLeNet
 name: "GoogleNet"
 layer {
-  name: "data"
+  name: "train-data"
   type: "Data"
   top: "data"
   top: "label"
-  include {
-    phase: TRAIN
-  }
   transform_param {
     mirror: true
     crop_size: 224
@@ -15,15 +12,13 @@ layer {
   data_param {
     batch_size: 24
   }
+  include { stage: "train" }
 }
 layer {
-  name: "data"
+  name: "val-data"
   type: "Data"
   top: "data"
   top: "label"
-  include {
-    phase: TEST
-  }
   transform_param {
     mirror: false
     crop_size: 224
@@ -31,6 +26,7 @@ layer {
   data_param {
     batch_size: 24
   }
+  include { stage: "val" }
 }
 layer {
   name: "conv1/7x7_s2"

--- a/digits/standard-networks/caffe/lenet.prototxt
+++ b/digits/standard-networks/caffe/lenet.prototxt
@@ -1,13 +1,10 @@
 # LeNet
 name: "LeNet"
 layer {
-  name: "mnist"
+  name: "train-data"
   type: "Data"
   top: "scaled"
   top: "label"
-  include {
-    phase: TRAIN
-  }
   transform_param {
     # 1/(standard deviation)
     scale: 0.0125
@@ -15,15 +12,13 @@ layer {
   data_param {
     batch_size: 64
   }
+  include { stage: "train" }
 }
 layer {
-  name: "mnist"
+  name: "val-data"
   type: "Data"
   top: "scaled"
   top: "label"
-  include {
-    phase: TEST
-  }
   transform_param {
     # 1/(standard deviation)
     scale: 0.0125
@@ -31,6 +26,7 @@ layer {
   data_param {
     batch_size: 100
   }
+  include { stage: "val" }
 }
 layer {
   # Use Power layer in deploy phase for input scaling

--- a/digits/standard-networks/caffe/lenet.prototxt
+++ b/digits/standard-networks/caffe/lenet.prototxt
@@ -3,10 +3,14 @@ name: "LeNet"
 layer {
   name: "mnist"
   type: "Data"
-  top: "data"
+  top: "scaled"
   top: "label"
   include {
     phase: TRAIN
+  }
+  transform_param {
+    # 1/(standard deviation)
+    scale: 0.0125
   }
   data_param {
     batch_size: 64
@@ -15,29 +19,35 @@ layer {
 layer {
   name: "mnist"
   type: "Data"
-  top: "data"
+  top: "scaled"
   top: "label"
   include {
     phase: TEST
+  }
+  transform_param {
+    # 1/(standard deviation)
+    scale: 0.0125
   }
   data_param {
     batch_size: 100
   }
 }
 layer {
+  # Use Power layer in deploy phase for input scaling
   name: "scale"
   bottom: "data"
-  top: "scale"
+  top: "scaled"
   type: "Power"
   power_param {
     # 1/(standard deviation)
     scale: 0.0125
   }
+  include { stage: "deploy" }
 }
 layer {
   name: "conv1"
   type: "Convolution"
-  bottom: "scale"
+  bottom: "scaled"
   top: "conv1"
   param {
     lr_mult: 1

--- a/digits/standard-networks/caffe/lenet.prototxt
+++ b/digits/standard-networks/caffe/lenet.prototxt
@@ -24,7 +24,7 @@ layer {
     scale: 0.0125
   }
   data_param {
-    batch_size: 100
+    batch_size: 32
   }
   include { stage: "val" }
 }


### PR DESCRIPTION
This pull request makes 3 updates to the Caffe standard networks:

1. Give unique names to the `train`/`val` `Data` layers in each network, and use stage for include rules instead of phase

1. Change LeNet to use the `Data` layer for input scaling during `train`/`val`, but still use a `Power` layer during `deploy`.

1. Update the batch sizes

  * All are now powers of two
  * AlexNet and GoogLeNet use the training batch sizes that were used in their original papers

The first change is purely cosmetic. The second may have a slight but negligible improvement in performance. I made the third change because cuDNN typically prefers batch sizes that are even powers of two.