### PR TITLE
Calculate status and runtime for job from tasks

### DIFF
--- a/digits/task.py
+++ b/digits/task.py
@@ -110,6 +110,11 @@ class Task(StatusCls):
                 room=self.job_id,
                 )
 
+        from digits.webapp import scheduler
+        job = scheduler.get_job(self.job_id)
+        if job:
+            job.on_status_update()
+
     def path(self, filename, relative=False):
         """
         Returns a path to the given file

--- a/digits/templates/job_row.html
+++ b/digits/templates/job_row.html
@@ -24,7 +24,7 @@
     </td>
     <td>{{job.status_history[0][1]|print_time}}</td>
     <td>
-        <span id="status" class="text-{{job.status.css}}">{{job.status.name}}
+        <span id="status" class="text-{{job.status_of_tasks().css}}">{{job.status_of_tasks().name}}
         </span>
     </td>
     <td style="width:200px">

--- a/digits/views.py
+++ b/digits/views.py
@@ -104,10 +104,10 @@ def completed_jobs():
         d = {
             'id': job.id(),
             'name': job.name(),
-            'status': job.status.name,
-            'status_css': job.status.css,
+            'status': job.status_of_tasks().name,
+            'status_css': job.status_of_tasks().css,
             'submitted': job.status_history[0][1],
-            'elapsed': job.status_history[-1][1]-job.status_history[-2][1],
+            'elapsed': job.runtime_of_tasks(),
         }
 
         if 'train_db_task' in dir(job):


### PR DESCRIPTION
*Close #706, close #729*
*Fix #709, replace #739*

@pansk @TimZaman @jmancewicz @mpbrigham - Thanks for the bug reports and proposed fixes!

Is everyone happy with this solution? Check the docstring for how `runtime_of_tasks()` is calculated:
```py
    def runtime_of_tasks(self):
        """
        Returns the time (in sec) between when the first task started and when the last task stopped
        NOTE: this may not be what you're expecting if there was some WAIT time in-between
        """
```