### PR TITLE
Deselect with click outside the tables

### DIFF
--- a/digits/static/js/table_selection.js
+++ b/digits/static/js/table_selection.js
@@ -163,6 +163,17 @@ function TableSelection(table_id) {
         e.stopPropagation();
     });
 
+    // deselect when the mouse is cli
+    $(document).on('click', 'body', function(e) {
+        var tag = e.target.tagName.toLowerCase();
+        if (tag == 'input' || tag == 'textarea' || tag == 'button' || tag == 'a') {
+            return;
+        }
+
+        if (TableSelection.current_table == null) {
+            deselect($('tr'));
+        }
+    });
 
     // Let links continue to work.  Without this, a click would
     // only do a row selection.


### PR DESCRIPTION
Changing the behavior to deselect the table rows if the mouse is clicked outside of the table with the exception of `input`, `textarea`, `button`, and `a`