### PR TITLE
Add tooltips and round the time values

### DIFF
--- a/digits/static/js/home_app.js
+++ b/digits/static/js/home_app.js
@@ -137,6 +137,10 @@ function populate_completed_jobs() {
             return print_time_diff_terse(diff);
         }
 
+        $scope.print_time_diff = function(diff) {
+            return print_time_diff(diff);
+        }
+
         $scope.is_today = function(date) {
             // return true if the date is from today
             var t0 = new Date(date * 1000).setHours(0, 0, 0, 0);

--- a/digits/static/js/jquery.time_filters.js
+++ b/digits/static/js/jquery.time_filters.js
@@ -5,10 +5,10 @@ function print_time_diff(diff) {
         return 'Negative Time';
     }
     var total_seconds = Math.floor(diff);
-    var days = Math.floor(total_seconds/(24*3600));
-    var hours = Math.floor((total_seconds % (24*3600))/3600);
-    var minutes = Math.floor((total_seconds % 3600)/60);
-    var seconds = Math.floor(total_seconds % 60);
+    var days = total_seconds/(24*3600);
+    var hours = (total_seconds % (24*3600))/3600;
+    var minutes = (total_seconds % 3600)/60;
+    var seconds = total_seconds % 60;
 
     function plural(number, name) {
         return number + ' ' + name + (number == 1 ? '' : 's');
@@ -22,12 +22,12 @@ function print_time_diff(diff) {
     }
 
     if (days >= 1)
-        return pair(days, 'day', hours, 'hour');
+        return pair(Math.floor(days), 'day', Math.round(hours), 'hour');
     else if (hours >= 1)
-        return pair(hours, 'hour', minutes, 'minute');
+        return pair(Math.floor(hours), 'hour', Math.round(minutes), 'minute');
     else if (minutes >= 1)
-        return pair(minutes, 'minute', seconds, 'second');
-    return plural(seconds, 'second');
+        return pair(Math.floor(minutes), 'minute', Math.round(seconds), 'second');
+    return plural(Math.round(seconds), 'second');
 }
 
 function print_time_diff_simple(diff, min_unit) {
@@ -39,22 +39,22 @@ function print_time_diff_simple(diff, min_unit) {
     if (typeof(min_unit)==='undefined') min_unit = 'second';
 
     var total_seconds = Math.floor(diff);
-    var days = Math.floor(total_seconds/(24*3600));
-    var hours = Math.floor((total_seconds % (24*3600))/3600);
-    var minutes = Math.floor((total_seconds % 3600)/60);
-    var seconds = Math.floor(total_seconds % 60);
+    var days = total_seconds/(24*3600);
+    var hours = (total_seconds % (24*3600))/3600;
+    var minutes = (total_seconds % 3600)/60;
+    var seconds = total_seconds % 60;
 
     function plural(number, name) {
         return number + ' ' + name + (number == 1 ? '' : 's');
     }
 
     if (days >= 1 || min_unit == 'day')
-        return plural(days, 'day');
+        return plural(Math.round(days), 'day');
     else if (hours >= 1 || min_unit == 'hour')
-        return plural(hours, 'hour');
+        return plural(Math.round(hours), 'hour');
     else if (minutes >= 1 || min_unit == 'minute')
-        return plural(minutes, 'minute');
-    return plural(seconds, 'second');
+        return plural(Math.round(minutes), 'minute');
+    return plural(Math.round(seconds), 'second');
 }
 
 function print_time_diff_terse(diff, min_unit) {
@@ -66,18 +66,18 @@ function print_time_diff_terse(diff, min_unit) {
     if (typeof(min_unit)==='undefined') min_unit = 'second';
 
     var total_seconds = Math.floor(diff);
-    var days = Math.floor(total_seconds/(24*3600));
-    var hours = Math.floor((total_seconds % (24*3600))/3600);
-    var minutes = Math.floor((total_seconds % 3600)/60);
-    var seconds = Math.floor(total_seconds % 60);
+    var days = total_seconds/(24*3600);
+    var hours = (total_seconds % (24*3600))/3600;
+    var minutes = (total_seconds % 3600)/60;
+    var seconds = total_seconds % 60;
 
     if (days >= 1 || min_unit == 'day')
-        return days + 'd'
+        return Math.round(days) + 'd'
     else if (hours >= 1 || min_unit == 'hour')
-        return hours + 'h'
+        return Math.round(hours) + 'h'
     else if (minutes >= 1 || min_unit == 'minute')
-        return minutes + 'm'
-    return seconds + 's'
+        return Math.round(minutes) + 'm'
+    return Math.round(seconds) + 's'
 }
 
 function print_time_diff_ago(start, min_unit) {

--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -123,7 +123,7 @@
                                 <!-- Table -->
                                 <tr ng-attr-id="{[ job.id ]}" ng-repeat="job in jobs | orderBy:sort.active:sort.descending | filter:search_text">
                                     <td>
-                                        <a href="/datasets/{[ job.id ]}">
+                                        <a href="/datasets/{[ job.id ]}" title="{[job.name]}">
                                             {[ job.name | major_name ]}
                                         </a>
                                         <small>
@@ -140,13 +140,15 @@
                                         {[ job.status ]}
                                     </td>
                                     <td start="{[job.elapsed]}">
-                                        {[ print_time_diff_terse(job.elapsed) ]}
+                                        <small title="{[ print_time_diff(job.elapsed) ]}">
+                                            {[ print_time_diff_terse(job.elapsed) ]}
+                                        </small>
                                     </td>
                                     <td start="{[job.submitted]}">
-                                        <small ng-if="!is_today(job.submitted)">
+                                        <small ng-if="!is_today(job.submitted)" title="{[ job.submitted * 1000 | date:'medium' ]}">
                                             {[ job.submitted * 1000 | date:'MMM d, yy' ]}
                                         </small>
-                                        <small ng-if="is_today(job.submitted)">
+                                        <small ng-if="is_today(job.submitted)" title="{[ job.submitted * 1000 | date:'medium' ]}">
                                             {[ job.submitted * 1000 | date:'h:mm a' ]}
                                         </small>
                                     </td>
@@ -230,7 +232,7 @@
                             <tbody ng-if="jobs.length">
                                 <tr ng-attr-id="{[ job.id ]}" ng-repeat="job in jobs | orderBy:sort.active:sort.descending | filter:search_text">
                                     <td>
-                                        <a href="/models/{[ job.id ]}">
+                                        <a href="/models/{[ job.id ]}" title="{[job.name]}">
                                             {[ job.name | major_name ]}
                                         </a>
                                         <small>
@@ -244,13 +246,15 @@
                                         {[ job.status ]}
                                     </td>
                                     <td start="{[job.elapsed]}">
-                                        {[ print_time_diff_terse(job.elapsed) ]}
+                                        <small title="{[ print_time_diff(job.elapsed) ]}">
+                                            {[ print_time_diff_terse(job.elapsed) ]}
+                                        </small>
                                     </td>
                                     <td start="{[job.submitted]}">
-                                        <small ng-if="!is_today(job.submitted)">
+                                        <small ng-if="!is_today(job.submitted)" title="{[ job.submitted * 1000 | date:'medium' ]}">
                                             {[ job.submitted * 1000 | date:'MMM d, yy' ]}
                                         </small>
-                                        <small ng-if="is_today(job.submitted)">
+                                        <small ng-if="is_today(job.submitted)" title="{[ job.submitted * 1000 | date:'medium' ]}">
                                             {[ job.submitted * 1000 | date:'h:mm a' ]}
                                         </small>
                                     </td>


### PR DESCRIPTION
Adding tooltips to the job name in case the overrun and ellipsis appear as well as to the elapsed and submitted times to get a little more information. If the elapsed time is 4m, the tooltip will unpack that a bit to 3 minutes, 43 seconds or 4 minutes, 13 seconds.  To that end, the time functions are changing from flooring to rounding of the least significant value.