### PR TITLE
Update batch sizes for standard torch networks

### DIFF
--- a/digits/standard-networks/torch/ImageNet-Training/alexnet.lua
+++ b/digits/standard-networks/torch/ImageNet-Training/alexnet.lua
@@ -77,8 +77,8 @@ return function(params)
     return {
         model = createModel(params.ngpus, channels, nclasses),
         croplen = 224,
-        trainBatchSize = 100,
-        validationBatchSize = 100,
+        trainBatchSize = 128,
+        validationBatchSize = 32,
     }
 end
 

--- a/digits/standard-networks/torch/ImageNet-Training/googlenet.lua
+++ b/digits/standard-networks/torch/ImageNet-Training/googlenet.lua
@@ -131,8 +131,8 @@ return function(params)
     return {
         model = createModel(params.ngpus, channels, nclasses),
         croplen = 224,
-        trainBatchSize = 24,
-        validationBatchSize = 24,
+        trainBatchSize = 32,
+        validationBatchSize = 16,
     }
 end
 

--- a/digits/standard-networks/torch/lenet.lua
+++ b/digits/standard-networks/torch/lenet.lua
@@ -61,7 +61,7 @@ return function(params)
         model = model,
         loss = nn.ClassNLLCriterion(),
         trainBatchSize = 64,
-        validationBatchSize = 100,
+        validationBatchSize = 32,
     }
 end
 


### PR DESCRIPTION
Make them match Caffe's from https://github.com/NVIDIA/DIGITS/pull/733.

I tested them all on a GTX 980 (4GB card) and none ran out of memory.