### PR TITLE
Fixed ctrl-click and job count

### DIFF
--- a/digits/static/js/table_selection.js
+++ b/digits/static/js/table_selection.js
@@ -163,7 +163,7 @@ function TableSelection(table_id) {
         e.stopPropagation();
     });
 
-    // deselect when the mouse is cli
+    // deselect when the mouse is clicked outside the table
     $(document).on('click', 'body', function(e) {
         var tag = e.target.tagName.toLowerCase();
         if (tag == 'input' || tag == 'textarea' || tag == 'button' || tag == 'a') {
@@ -173,12 +173,6 @@ function TableSelection(table_id) {
         if (TableSelection.current_table == null) {
             deselect($('tr'));
         }
-    });
-
-    // Let links continue to work.  Without this, a click would
-    // only do a row selection.
-    $(table_id).on('click', 'a', function(e) {
-        location.href = $(this).attr('href');
     });
 
     // Because the key event is global, only register once.

--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -84,7 +84,7 @@
                                 </div>
                                 <h2>
                                     {[title]}
-                                    <small>({[jobs.length]})</small>
+                                    <small>({[(jobs | filter:search_text).length]})</small>
                                 </h2>
                             </div>
                         </div>
@@ -119,9 +119,9 @@
                                     </th>
                                 </tr>
                             </thead>
-                            <tbody ng-if="jobs.length">
+                            <tbody ng-if="(jobs | filter:search_text).length">
                                 <!-- Table -->
-                                <tr ng-attr-id="{[ job.id ]}" ng-repeat="job in jobs | orderBy:sort.active:sort.descending | filter:search_text">
+                                <tr ng-attr-id="{[ job.id ]}" ng-repeat="job in jobs | filter:search_text | orderBy:sort.active:sort.descending">
                                     <td>
                                         <a href="/datasets/{[ job.id ]}">
                                             {[ job.name | major_name ]}
@@ -152,7 +152,7 @@
                                     </td>
                                 </tr>
                             </tbody>
-                            <tbody ng-if="jobs.length == 0">
+                            <tbody ng-if="(jobs | filter:search_text).length == 0">
                                 <tr>
                                     <td colspan="{[fields.length]}">
                                         <h5>
@@ -192,7 +192,7 @@
                                 </div>
                                 <h2>
                                     {[title]}
-                                    <small>({[jobs.length]})</small>
+                                    <small>({[(jobs | filter:search_text).length]})</small>
                                 </h2>
                             </div>
                         </div>
@@ -227,8 +227,8 @@
                                     </th>
                                 </tr>
                             </thead>
-                            <tbody ng-if="jobs.length">
-                                <tr ng-attr-id="{[ job.id ]}" ng-repeat="job in jobs | orderBy:sort.active:sort.descending | filter:search_text">
+                            <tbody ng-if="(jobs | filter:search_text).length">
+                                <tr ng-attr-id="{[ job.id ]}" ng-repeat="job in jobs | filter:search_text | orderBy:sort.active:sort.descending">
                                     <td>
                                         <a href="/models/{[ job.id ]}">
                                             {[ job.name | major_name ]}
@@ -256,7 +256,7 @@
                                     </td>
                                 </tr>
                             </tbody>
-                            <tbody ng-if="jobs.length == 0">
+                            <tbody ng-if="(jobs | filter:search_text).length == 0">
                                 <tr>
                                     <td colspan="{[fields.length]}">
                                         <h5>


### PR DESCRIPTION
Changed the parenthetical job counts on the front pages to represent the filtered list.
ctrl-click had been opening a new tab AND redirecting the current page. Removed code that is no longer needed for selection.