### PR TITLE
Move Datasets and Models into tab view

### DIFF
--- a/digits/static/js/home_app.js
+++ b/digits/static/js/home_app.js
@@ -38,7 +38,7 @@ function populate_completed_jobs() {
     var app = angular.module('home_app', []);
 
     app.controller('tab_controller', function () {
-        this.tab = 2;
+        this.tab = 1;
 
         this.setTab = function (tabId) {
             this.tab = tabId;

--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -28,7 +28,7 @@
 {% include 'job_management.html' %}
 
 <div class="row">
-    <section ng-app="home_app">
+    <section ng-app="home_app" ng-controller="tab_controller as tab">
         <style>
          .table {
              width: 100%;
@@ -56,9 +56,14 @@
 
         </style>
         
+        <ul class="nav nav-tabs" role="tablist">
+            <li ng-class="{active:tab.isSet(1)}"><a href ng-click="tab.setTab(1)">Datasets</a></li>
+            <li ng-class="{active:tab.isSet(2)}"><a href ng-click="tab.setTab(2)">Models</a></li>
+        </ul>
+
         <div class="row">
             <!-- Datasets -->
-            <div class="col-md-6">
+            <div ng-show="tab.isSet(1)">
                 <div class="well">
                     <div ng-controller="datasets_controller">
                         <div class="row">
@@ -89,7 +94,7 @@
                             </div>
                         </div>
                         <div class="row">
-                            <div class="col-md-6 pull-right">
+                            <div class="col-md-4 pull-right">
                                 <form>
                                     <div class="form-group">
                                         <div class="input-group">
@@ -99,7 +104,7 @@
                                     </div>
                                 </form>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-8">
                                 <a class="btn btn btn-danger" ng-click="delete_jobs();">Delete</a>
                             </div>
                         </div>
@@ -166,7 +171,7 @@
                 </div>
             </div>
             <!-- Models -->
-            <div class="col-md-6">
+            <div ng-show="tab.isSet(2)">
                 <div class="well">
                     <div ng-controller="models_controller">
                         <div class="row">
@@ -197,7 +202,7 @@
                             </div>
                         </div>
                         <div class="row">
-                            <div class="col-md-6 pull-right">
+                            <div class="col-md-4 pull-right">
                                 <form>
                                     <div class="form-group">
                                         <div class="input-group">
@@ -207,7 +212,7 @@
                                     </div>
                                 </form>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-8">
                                 <a class="btn btn btn-danger" ng-click="delete_jobs();">Delete</a>
                             </div>
                         </div>


### PR DESCRIPTION
This is an option for dealing with the length of job names on the front page. The Datasets and Models are in tabs. One upside of not putting them in tabs is the potential to show to dependencies between models and datasets.