### PR TITLE
View extension framework

### DIFF
--- a/digits/extensions/view/__init__.py
+++ b/digits/extensions/view/__init__.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from . import rawData
+
+view_extensions = [
+    # set show=True if extension should be listed in known extensions
+    {'class': rawData.Visualization, 'show': True},
+]
+
+
+def get_default_extension():
+    """
+    return the default view extension
+    """
+    return rawData.Visualization
+
+
+def get_extensions():
+    """
+    return set of data data extensions
+    """
+    return [extension['class'] for extension
+            in view_extensions if extension['show']]
+
+
+def get_extension(extension_id):
+    """
+    return extension associated with specified extension_id
+    """
+    for extension in view_extensions:
+        extension_class = extension['class']
+        if extension_class.get_id() == extension_id:
+            return extension_class
+    return None

--- a/digits/extensions/view/interface.py
+++ b/digits/extensions/view/interface.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+
+class VisualizationInterface(object):
+    """
+    A visualization extension
+    """
+
+    def __init__(self, **kwargs):
+        pass
+
+    @staticmethod
+    def get_config_form():
+        """
+        Return a form to be used to configure visualization options
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_config_template(form):
+        """
+        The config template shows a form with view config options
+        Parameters:
+        - form: form returned by get_config_form(). This may be populated
+          with values if the job was cloned
+        Returns:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering config options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_id():
+        """
+        Returns a unique ID
+        """
+        raise NotImplementedError
+
+    def get_summary_template(self):
+        """
+        This returns a summary of the job. This method is called after all
+        entries have been processed.
+        Returns:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering the summary,
+          or None if there is no summary to display
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        return None, None
+
+    @staticmethod
+    def get_title():
+        """
+        Returns a title
+        """
+        raise NotImplementedError
+
+    def get_view_template(self, data):
+        """
+        The view template shows the visualization of one inference output
+        Parameters:
+        - data: the data returned by process_data()
+        Returns:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering config options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        raise NotImplementedError
+
+    def process_data(
+            self,
+            dataset,
+            input_data,
+            inference_data,
+            ground_truth=None):
+        """
+        Process one inference output
+        Parameters:
+        - dataset: dataset used during training
+        - input_data: input to the network
+        - inference_data: network output
+        - ground_truth: Ground truth. Format is application specific.
+          None if absent.
+        Returns:
+        - an object reprensenting the processed data
+        """
+        raise NotImplementedError

--- a/digits/extensions/view/rawData/__init__.py
+++ b/digits/extensions/view/rawData/__init__.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from .data import *
-from .view import *
+from .view import Visualization

--- a/digits/extensions/view/rawData/config_template.html
+++ b/digits/extensions/view/rawData/config_template.html
@@ -1,0 +1,7 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+<small>This visualization has no configuration options</small>

--- a/digits/extensions/view/rawData/forms.py
+++ b/digits/extensions/view/rawData/forms.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from digits.utils import subclass
+from flask.ext.wtf import Form
+
+
+@subclass
+class ConfigForm(Form):
+    pass

--- a/digits/extensions/view/rawData/view.py
+++ b/digits/extensions/view/rawData/view.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import os
+
+from digits.utils import subclass, override
+from .forms import ConfigForm
+from ..interface import VisualizationInterface
+
+CONFIG_TEMPLATE = "config_template.html"
+VIEW_TEMPLATE = "view_template.html"
+
+
+@subclass
+class Visualization(VisualizationInterface):
+    """
+    A visualization extension to display raw data
+    """
+
+    def __init__(self, dataset, **kwargs):
+        # memorize view template for later use
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        self.view_template = open(
+            os.path.join(extension_dir, VIEW_TEMPLATE), "r").read()
+
+    @staticmethod
+    def get_config_form():
+        return ConfigForm()
+
+    @staticmethod
+    def get_config_template(form):
+        """
+        parameters:
+        - form: form returned by get_config_form(). This may be populated
+        with values if the job was cloned
+        return:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering config options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        template = open(
+            os.path.join(extension_dir, CONFIG_TEMPLATE), "r").read()
+        return (template, {})
+
+    @staticmethod
+    def get_id():
+        return 'all-raw-data'
+
+    @staticmethod
+    def get_title():
+        return 'Raw Data'
+
+    @override
+    def get_view_template(self, data):
+        """
+        return:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering config options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        return self.view_template, {'data': data}
+
+    @override
+    def process_data(
+            self,
+            dataset,
+            input_data,
+            inference_data,
+            ground_truth=None):
+        """
+        Process one inference output
+        Parameters:
+        - dataset: dataset used during training
+        - input_data: input to the network
+        - inference_data: network output
+        - ground_truth: Ground truth. Format is application specific.
+          None if absent.
+        Returns:
+        - an object reprensenting the processed data
+        """
+        # just return the same data and ignore ground truth
+        return inference_data

--- a/digits/extensions/view/rawData/view_template.html
+++ b/digits/extensions/view/rawData/view_template.html
@@ -1,0 +1,10 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+{% for key, val in data.iteritems() %}
+	<td>{{key}}</td>
+	<td>{{data[key]}}</td>
+{% endfor %}

--- a/digits/model/views.py
+++ b/digits/model/views.py
@@ -11,14 +11,12 @@ import zipfile
 import flask
 import werkzeug.exceptions
 
-from . import forms
 from . import images as model_images
 from . import ModelJob
-import digits
-from digits import frameworks
+from digits import frameworks, extensions
 from digits.utils import time_filters
 from digits.utils.routing import request_wants_json
-from digits.webapp import app, scheduler
+from digits.webapp import scheduler
 
 blueprint = flask.Blueprint(__name__, __name__)
 
@@ -141,6 +139,20 @@ def customize():
             'network': job.train_task().get_network_desc(),
             'snapshot': snapshot
             })
+
+
+@blueprint.route('/view-config/<extension_id>', methods=['GET'])
+def view_config(extension_id):
+    """
+    Returns a rendering of a view extension configuration template
+    """
+    extension = extensions.view.get_extension(extension_id)
+    if extension is None:
+        raise ValueError("Unknown extension '%s'" % extension_id)
+    config_form = extension.get_config_form()
+    template, context = extension.get_config_template(config_form)
+    return flask.render_template_string(template, **context)
+
 
 @blueprint.route('/visualize-network', methods=['POST'])
 def visualize_network():

--- a/digits/templates/models/images/generic/infer_db.html
+++ b/digits/templates/models/images/generic/infer_db.html
@@ -17,7 +17,7 @@
     </h1>
 </div>
 
-{% if not network_outputs %}
+{% if not keys %}
 <div class="alert alert-danger">
     <p>Inference failed, see job log</p>
 </div>
@@ -27,26 +27,34 @@
 
 {% block job_content_details %}
 
-{% if network_outputs %}
-<table class="table">
-    <tr>
-        <th>Index</th>
-        <th>Key</th>
-        {% for key in network_outputs.keys() %}
-        <th>{{key}}</th>
+{% if summary_html %}
+<div class="row">
+    <h3>Summary</h3>
+    {{summary_html|safe}}
+</div>
+{% endif %}
+
+{% if inference_views_html %}
+<div class="row">
+    <h3>Visualizations</h3>
+    <table class="table">
+        <tr>
+            <th>Index</th>
+            <th>Key</th>
+            <th>Data</th>
+        </tr>
+        {% for key in keys %}
+        <tr>
+            <td>{{loop.index}}</td>
+            <td>{{key}}</td>
+            <td>
+                {% set index=loop.index0 %}
+                {{ inference_views_html[index]|safe }}
+            </td>
+        </tr>
         {% endfor %}
-    </tr>
-    {% for key in keys %}
-    <tr>
-        <td>{{loop.index}}</td>
-        <td>{{key}}</td>
-        {% set index=loop.index0 %}
-        {% for key, val in network_outputs.iteritems() %}
-        <td>{{network_outputs[key][index]}}</td>
-        {% endfor %}
-    </tr>
-    {% endfor %}
-</table>
+    </table>
+</div>
 {% endif %}
 
 {% endblock %}

--- a/digits/templates/models/images/generic/infer_many.html
+++ b/digits/templates/models/images/generic/infer_many.html
@@ -17,7 +17,7 @@
     </h1>
 </div>
 
-{% if not network_outputs %}
+{% if not paths %}
 <div class="alert alert-danger">
     <p>Inference failed, see job log</p>
 </div>
@@ -27,26 +27,32 @@
 
 {% block job_content_details %}
 
-{% if network_outputs %}
-<table class="table">
-    <tr>
-        <td></td>
-        <th>Image</th>
-        {% for key in network_outputs.keys() %}
-        <th>{{key}}</th>
+{% if summary_html %}
+<div class="row">
+    <h3>Summary</h3>
+    {{summary_html|safe}}
+</div>
+{% endif %}
+
+{% if paths %}
+<div class="row">
+    <h3>Visualizations</h3>
+    <table class="table">
+        <tr>
+            <td></td>
+            <th>Image</th>
+            <th>Data</th>
+        </tr>
+        {% for path in paths %}
+        <tr>
+            <td>{{loop.index}}</td>
+            <td>{{path}}</td>
+            {% set index=loop.index0 %}
+            <td>{{inference_views_html[index]|safe}}</td>
+        </tr>
         {% endfor %}
-    </tr>
-    {% for path in paths %}
-    <tr>
-        <td>{{loop.index}}</td>
-        <td>{{path}}</td>
-        {% set index=loop.index0 %}
-        {% for key, val in network_outputs.iteritems() %}
-        <td>{{network_outputs[key][index]}}</td>
-        {% endfor %}
-    </tr>
-    {% endfor %}
-</table>
+    </table>
+</div>
 {% endif %}
 
 {% endblock %}

--- a/digits/templates/models/images/generic/infer_one.html
+++ b/digits/templates/models/images/generic/infer_one.html
@@ -19,25 +19,22 @@
     </h1>
 </div>
 
-
+{% if image_src %}
 <div class="row">
-    {% if image_src %}
-    <div class="col-sm-6">
-        <img src="{{image_src}}" style="max-width:100%;" />
-    </div>
-
-    <div class="col-sm-6">
-        {% for name, blob in network_outputs.iteritems() %}
-        <h4>{{name}}</h4>
-        {{blob}}
-        {% endfor %}
-    </div>
-    {% else %}
+    <h3>Source image</h3>
+    <img src="{{image_src}}" style="max-width:100%;" />
+</div>
+<div class="row">
+    <h3>Inference visualization</h3>
+    {{ inference_view_html|safe }}
+</div>
+{% else %}
+<div class="row">
     <div class="alert alert-danger">
         <p>Inference failed, see job log</p>
     </div>
-    {% endif %}
 </div>
+{% endif %}
 
 {% endblock %}
 

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -146,6 +146,43 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                 </div>
                 <div class="row">
                     <div class="col-sm-6">
+                        <h3>Select Visualization Method</h3>
+                        <div class="form-group">
+                            <select id="view_extension_id" name="view_extension_id" class="form-control">
+                                {% for key in view_extensions.keys()|sort %}
+                                    <option value="{{ key }}">{{ view_extensions[key] }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <h3>Visualization Options</h3>
+                        <div id="view_extension-details">
+                        </div>
+                    </div>
+                    <script>
+                        $("#view_extension_id").change(function() {
+                            if ($(this).val()) {
+                                $.ajax("/models/view-config/" + $(this).val(),
+                                    {
+                                        type: "GET",
+                                        }
+                                    )
+                                .done(function(data) {
+                                    $("#view_extension-details").html(data);
+                                    })
+                                .fail(function(data) {
+                                    $("#view_extension-details").html("");
+                                    errorAlert(data);
+                                    });
+                                }
+                            });
+                        $("#view_extension_id").change();
+                    </script>
+                </div>
+
+                <div class="row">
+                    <div class="col-sm-6">
                         <h3>Test a single image</h3>
                         <div class="form-group">
                             <label for="image_path" class="control-label">Image Path</label>


### PR DESCRIPTION
This implements a visualization framework along the lines of:

![data-classes](https://cloud.githubusercontent.com/assets/3889770/15364536/357f5fce-1d1d-11e6-94ca-c4f83393349e.png)

Depends on #731 

A `rawData` view extension is added and selected by default to show the network output in the same way as in the original generic type of networks.

