### PR TITLE
Retrieve caffe version from caffe.exe.

### DIFF
--- a/digits/templates/layout.html
+++ b/digits/templates/layout.html
@@ -51,7 +51,8 @@
                 {% if server_name %}
                 <li><span class="navbar-text">Server: {{server_name}}</span></li>
                 {% endif %}
-                <li><span class="navbar-text">Version: {{server_version}}</span></li>
+                <li><span class="navbar-text">DIGITS version: <br> {{server_version}}</span></li>
+                <li><span class="navbar-text">Caffe version: <br> {{caffe_version}}</span><li>
             </ul>
         </ul>
     </div>

--- a/digits/webapp.py
+++ b/digits/webapp.py
@@ -25,6 +25,7 @@ scheduler = digits.scheduler.Scheduler(config_value('gpu_list'), True)
 
 app.jinja_env.globals['server_name'] = config_value('server_name')
 app.jinja_env.globals['server_version'] = digits.__version__
+app.jinja_env.globals['caffe_version'] = str(config_value('caffe_root')['version'])
 app.jinja_env.filters['print_time'] = utils.time_filters.print_time
 app.jinja_env.filters['print_time_diff'] = utils.time_filters.print_time_diff
 app.jinja_env.filters['print_time_since'] = utils.time_filters.print_time_since


### PR DESCRIPTION
Try to retrieve caffe version from command line option '-version' and if caffe.exe is not built with such information, fallback to default (0,11,0).