### PR TITLE
Allow BVLC/caffe and caffe-on-windows

### DIFF
--- a/digits/frameworks/caffe_framework.py
+++ b/digits/frameworks/caffe_framework.py
@@ -34,11 +34,17 @@ class CaffeFramework(Framework):
     # whether this framework can shuffle data during training
     CAN_SHUFFLE_DATA = False
 
-    if config_value('caffe_root')['version'] > parse_version('0.14.0-alpha'):
+    if config_value('caffe_root')['flavor'] == 'NVIDIA':
+        if config_value('caffe_root')['version'] > parse_version('0.14.0-alpha'):
+            SUPPORTED_SOLVER_TYPES = ['SGD', 'NESTEROV', 'ADAGRAD',
+                                      'RMSPROP', 'ADADELTA', 'ADAM']
+        else:
+            SUPPORTED_SOLVER_TYPES = ['SGD', 'NESTEROV', 'ADAGRAD']
+    elif config_value('caffe_root')['flavor'] == 'BVLC':
         SUPPORTED_SOLVER_TYPES = ['SGD', 'NESTEROV', 'ADAGRAD',
                                   'RMSPROP', 'ADADELTA', 'ADAM']
     else:
-        SUPPORTED_SOLVER_TYPES = ['SGD', 'NESTEROV', 'ADAGRAD']
+        raise ValueError('Unknown flavor.  Support NVIDIA and BVLC flavors only.')
 
     @override
     def __init__(self):
@@ -123,6 +129,10 @@ class CaffeFramework(Framework):
 
     @override
     def can_accumulate_gradients(self):
-        return (config_value('caffe_root')['version']
-                > parse_version('0.14.0-alpha'))
+        if config_value('caffe_root')['flavor'] == 'BVLC':
+            return True
+        elif config_value('caffe_root')['flavor'] == 'NVIDIA':
+            return config_value('caffe_root')['version'] > parse_version('0.14.0-alpha')
+        else:
+            raise ValueError('Unknown flavor.  Support NVIDIA and BVLC flavors only.')
 

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -824,11 +824,16 @@ class CaffeTrainTask(TrainTask):
             if len(identifiers) == 1:
                 args.append('--gpu=%s' % identifiers[0])
             elif len(identifiers) > 1:
-                if config_value('caffe_root')['version'] < utils.parse_version('0.14.0-alpha'):
-                    # Prior to version 0.14, NVcaffe used the --gpus switch
-                    args.append('--gpus=%s' % ','.join(identifiers))
-                else:
+                if config_value('caffe_root')['flavor'] == 'NVIDIA':
+                    if config_value('caffe_root')['version'] < utils.parse_version('0.14.0-alpha'):
+                        # Prior to version 0.14, NVcaffe used the --gpus switch
+                        args.append('--gpus=%s' % ','.join(identifiers))
+                    else:
+                        args.append('--gpu=%s' % ','.join(identifiers))
+                elif config_value('caffe_root')['flavor'] == 'BVLC':
                     args.append('--gpu=%s' % ','.join(identifiers))
+                else:
+                    raise ValueError('Unknown flavor.  Support NVIDIA and BVLC flavors only.')
         if self.pretrained_model:
             args.append('--weights=%s' % ','.join(map(lambda x: self.path(x), self.pretrained_model.split(':'))))
         return args

--- a/digits/templates/layout.html
+++ b/digits/templates/layout.html
@@ -53,6 +53,7 @@
                 {% endif %}
                 <li><span class="navbar-text">DIGITS version: <br> {{server_version}}</span></li>
                 <li><span class="navbar-text">Caffe version: <br> {{caffe_version}}</span><li>
+                <li><span class="navbar-text">Caffe flavor: <br> {{caffe_flavor}}</span><li>
             </ul>
         </ul>
     </div>

--- a/digits/utils/errors.py
+++ b/digits/utils/errors.py
@@ -18,3 +18,8 @@ class LoadImageError(DigitsError):
     """
     pass
 
+class UnsupportedPlatformError(DigitsError):
+    """
+    Errors that occur while performing tasks in unsupported platforms
+    """
+    pass

--- a/digits/webapp.py
+++ b/digits/webapp.py
@@ -25,7 +25,8 @@ scheduler = digits.scheduler.Scheduler(config_value('gpu_list'), True)
 
 app.jinja_env.globals['server_name'] = config_value('server_name')
 app.jinja_env.globals['server_version'] = digits.__version__
-app.jinja_env.globals['caffe_version'] = str(config_value('caffe_root')['version'])
+app.jinja_env.globals['caffe_version'] = config_value('caffe_root')['ver_str']
+app.jinja_env.globals['caffe_flavor'] = config_value('caffe_root')['flavor']
 app.jinja_env.filters['print_time'] = utils.time_filters.print_time
 app.jinja_env.filters['print_time_diff'] = utils.time_filters.print_time_diff
 app.jinja_env.filters['print_time_since'] = utils.time_filters.print_time_since


### PR DESCRIPTION
1. parse_version may return ('00000001','*','00000003','*final'), which is hard to to convert back to '1.0.0-rc3.'  Therefore, storing the original version string as a backup for Info menu.

2. Flavor will be NVIDIA if libcaffe.so is built with NVIDIA enhancement (Linux only).  In other cases, flavor is BVLC.

3. Store information in CaffeOption class so no need to query caffe for linked libraries twice.