### PR TITLE
Torch Data Augmentation

### DIFF
--- a/digits/frameworks/caffe_framework.py
+++ b/digits/frameworks/caffe_framework.py
@@ -46,6 +46,9 @@ class CaffeFramework(Framework):
     else:
         raise ValueError('Unknown flavor.  Support NVIDIA and BVLC flavors only.')
 
+    SUPPORTED_DATA_TRANSFORMATION_TYPES = ['MEAN_SUBTRACTION', 'CROPPING']
+    SUPPORTED_DATA_AUGMENTATION_TYPES = []
+
     @override
     def __init__(self):
         super(CaffeFramework, self).__init__()

--- a/digits/frameworks/torch_framework.py
+++ b/digits/frameworks/torch_framework.py
@@ -36,6 +36,10 @@ class TorchFramework(Framework):
     SUPPORTED_SOLVER_TYPES = ['SGD', 'NESTEROV', 'ADAGRAD',
                               'RMSPROP', 'ADADELTA', 'ADAM']
 
+    SUPPORTED_DATA_TRANSFORMATION_TYPES = ['MEAN_SUBTRACTION', 'CROPPING']
+    SUPPORTED_DATA_AUGMENTATION_TYPES = ['FLIPPING', 'QUAD_ROTATION', 'ARBITRARY_ROTATION', 
+                                          'SCALING', 'NOISE', 'HSV_SHIFTING']
+
     def __init__(self):
         super(TorchFramework, self).__init__()
         # id must be unique

--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -145,6 +145,15 @@ class BaseViewsTestWithDataset(BaseViewsTest,
     LR_POLICY = None
     LR_MULTISTEP_VALUES = None
     LEARNING_RATE = None
+    AUG_FLIP = None
+    AUG_QUAD_ROT = None
+    AUG_ROT = None
+    AUG_SCALE = None
+    AUG_NOISE = None
+    AUG_HSV_USE = None
+    AUG_HSV_H = None
+    AUG_HSV_S = None
+    AUG_HSV_V = None
 
     @classmethod
     def setUpClass(cls):
@@ -189,6 +198,26 @@ class BaseViewsTestWithDataset(BaseViewsTest,
             data['learning_rate'] = cls.LEARNING_RATE
         if cls.LR_MULTISTEP_VALUES is not None:
             data['lr_multistep_values'] = cls.LR_MULTISTEP_VALUES
+
+        if cls.AUG_FLIP is not None:
+            data['aug_flip'] = cls.AUG_FLIP
+        if cls.AUG_QUAD_ROT is not None:
+            data['aug_quad_rot'] = cls.AUG_QUAD_ROT
+        if cls.AUG_ROT is not None:
+            data['aug_rot'] = cls.AUG_ROT
+        if cls.AUG_SCALE is not None:
+            data['aug_scale'] = cls.AUG_SCALE
+        if cls.AUG_NOISE is not None:
+            data['aug_noise'] = cls.AUG_NOISE
+        if cls.AUG_HSV_USE is not None:
+            data['aug_hsv_use'] = cls.AUG_HSV_USE
+        if cls.AUG_HSV_H is not None:
+            data['aug_hsv_h'] = cls.AUG_HSV_H
+        if cls.AUG_HSV_S is not None:
+            data['aug_hsv_s'] = cls.AUG_HSV_S
+        if cls.AUG_HSV_V is not None:
+            data['aug_hsv_v'] = cls.AUG_HSV_V
+
         data.update(kwargs)
 
         request_json = data.pop('json', False)
@@ -820,6 +849,17 @@ class BaseTestCreatedTall(BaseTestCreated):
 class BaseTestCreatedCropInForm(BaseTestCreated):
     CROP_SIZE = 8
 
+class BaseTestCreatedDataAug(BaseTestCreatedTall):
+    AUG_FLIP = 'fliplrud'
+    AUG_QUAD_ROT = 'rotall'
+    AUG_ROT = 45
+    AUG_SCALE = 0.07
+    AUG_NOISE = 0.03
+    AUG_HSV_USE = True
+    AUG_HSV_H = 0.02
+    AUG_HSV_S = 0.04
+    AUG_HSV_V = 0.06
+
 class BaseTestCreatedCropInNetwork(BaseTestCreated):
     CAFFE_NETWORK = \
 """
@@ -995,6 +1035,9 @@ class TestCaffeLeNet(BaseTestCreated):
             ).read()
 
 class TestTorchCreatedCropInForm(BaseTestCreatedCropInForm):
+    FRAMEWORK = 'torch'
+
+class TestTorchCreatedDataAug(BaseTestCreatedDataAug):
     FRAMEWORK = 'torch'
 
 class TestTorchCreatedCropInNetwork(BaseTestCreatedCropInNetwork):

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -244,6 +244,18 @@ def create():
                     selected_gpus = [str(form.select_gpu.data)]
                     gpu_count = None
 
+            # Set up data augmentation structure
+            data_aug = {}
+            data_aug['flip']     = form.aug_flip.data
+            data_aug['quad_rot'] = form.aug_quad_rot.data
+            data_aug['rot']      = form.aug_rot.data
+            data_aug['scale']    = form.aug_scale.data
+            data_aug['noise']    = form.aug_noise.data
+            data_aug['hsv_use']  = form.aug_hsv_use.data
+            data_aug['hsv_h']    = form.aug_hsv_h.data
+            data_aug['hsv_s']    = form.aug_hsv_s.data
+            data_aug['hsv_v']    = form.aug_hsv_v.data
+
             # Python Layer File may be on the server or copied from the client.
             fs.copy_python_layer_file(
                 bool(form.python_layer_from_client.data),
@@ -271,6 +283,7 @@ def create():
                         random_seed = form.random_seed.data,
                         solver_type = form.solver_type.data,
                         shuffle = form.shuffle.data,
+                        data_aug = data_aug,
                         )
                     )
 

--- a/digits/model/images/forms.py
+++ b/digits/model/images/forms.py
@@ -20,10 +20,6 @@ class ImageModelForm(ModelForm):
             tooltip = "If specified, during training a random square crop will be taken from the input image before using as input for the network."
             )
 
-    # Can't use a BooleanField here because HTML doesn't submit anything
-    # for an unchecked checkbox. Since we want to use a REST API and have
-    # this default to True when nothing is supplied, we have to use a
-    # SelectField
     use_mean = utils.forms.SelectField('Subtract Mean',
             choices = [
                 ('none', 'None'),
@@ -32,5 +28,79 @@ class ImageModelForm(ModelForm):
                 ],
             default='image',
             tooltip = "Subtract the mean file or mean pixel for this dataset from each image."
+            )
+
+    aug_flip = utils.forms.SelectField('Flipping',
+            choices = [
+                ('none', 'None'),
+                ('fliplr', 'Horizontal'),
+                ('flipud', 'Vertical'),
+                ('fliplrud', 'Horizontal and/or Vertical'),
+                ],
+            default='none',
+            tooltip = "Randomly flips each image during batch preprocessing."
+            )
+
+    aug_quad_rot = utils.forms.SelectField('Quadrilateral Rotation',
+            choices = [
+                ('none', 'None'),
+                ('rot90', '0, 90 or 270 degrees'),
+                ('rot180', '0 or 180 degrees'),
+                ('rotall', '0, 90, 180 or 270 degrees.'),
+                ],
+            default='none',
+            tooltip = "Randomly rotates (90 degree steps) each image during batch preprocessing."
+            )
+
+    aug_rot = utils.forms.IntegerField('Rotation (+- deg)',
+            default=0,
+            validators=[ 
+                validators.NumberRange(min=0, max=180)
+                ],
+            tooltip = "The uniform-random rotation angle that will be performed during batch preprocessing."
+            )
+
+    aug_scale = utils.forms.FloatField('Rescale (stddev)',
+            default=0,
+            validators=[ 
+                validators.NumberRange(min=0, max=1)
+                ],
+            tooltip = "Retaining image size, the image is rescaled with a +-stddev of this parameter. Suggested value is 0.07."
+            )
+
+    aug_noise = utils.forms.FloatField('Noise (stddev)',
+            default=0,
+            validators=[ 
+                validators.NumberRange(min=0, max=1)
+                ],
+            tooltip = "Adds AWGN (Additive White Gaussian Noise) during batch preprocessing, assuming [0 1] pixel-value range. Suggested value is 0.03."
+            )
+
+    aug_hsv_use = utils.forms.BooleanField('HSV Shifting',
+            default = False,
+            tooltip = "Augmentation by normal-distributed random shifts in HSV color space, assuming [0 1] pixel-value range.",
+            validators=[ 
+                ]
+            )
+    aug_hsv_h = utils.forms.FloatField('Hue',
+            default=0.02,
+            validators=[ 
+                validators.NumberRange(min=0, max=0.5)
+                ],
+            tooltip = "Standard deviation of a shift that will be performed during preprocessing, assuming [0 1] pixel-value range."
+            )
+    aug_hsv_s = utils.forms.FloatField('Saturation',
+            default=0.04,
+            validators=[ 
+                validators.NumberRange(min=0, max=0.5)
+                ],
+            tooltip = "Standard deviation of a shift that will be performed during preprocessing, assuming [0 1] pixel-value range."
+            )
+    aug_hsv_v = utils.forms.FloatField('Value',
+            default=0.06,
+            validators=[ 
+                validators.NumberRange(min=0, max=0.5)
+                ],
+            tooltip = "Standard deviation of a shift that will be performed during preprocessing, assuming [0 1] pixel-value range."
             )
 

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -205,6 +205,18 @@ def create(extension_id=None):
                     selected_gpus = [str(form.select_gpu.data)]
                     gpu_count = None
 
+            # Set up data augmentation structure
+            data_aug = {}
+            data_aug['flip']     = form.aug_flip.data
+            data_aug['quad_rot'] = form.aug_quad_rot.data
+            data_aug['rot']      = form.aug_rot.data
+            data_aug['scale']    = form.aug_scale.data
+            data_aug['noise']    = form.aug_noise.data
+            data_aug['hsv_use']  = form.aug_hsv_use.data
+            data_aug['hsv_h']    = form.aug_hsv_h.data
+            data_aug['hsv_s']    = form.aug_hsv_s.data
+            data_aug['hsv_v']    = form.aug_hsv_v.data
+
             # Python Layer File may be on the server or copied from the client.
             fs.copy_python_layer_file(
                 bool(form.python_layer_from_client.data),
@@ -232,6 +244,7 @@ def create(extension_id=None):
                         random_seed = form.random_seed.data,
                         solver_type = form.solver_type.data,
                         shuffle = form.shuffle.data,
+                        data_aug = data_aug,
                         )
                     )
 

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -252,6 +252,31 @@ class TorchTrainTask(TrainTask):
         if self.pretrained_model:
             args.append('--weights=%s' % self.path(self.pretrained_model))
 
+        # Augmentations
+        assert self.data_aug['flip'] in ['none', 'fliplr', 'flipud', 'fliplrud'], 'Bad or unknown flag "flip"'
+        args.append('--augFlip=%s' % self.data_aug['flip'])
+
+        assert self.data_aug['quad_rot'] in ['none', 'rot90', 'rot180', 'rotall'], 'Bad or unknown flag "quad_rot"'
+        args.append('--augQuadRot=%s' % self.data_aug['quad_rot'])
+
+        if self.data_aug['rot']:
+            args.append('--augRot=%s' % self.data_aug['rot'])
+
+        if self.data_aug['scale']:
+            args.append('--augScale=%s' % self.data_aug['scale'])
+
+        if self.data_aug['noise']:
+            args.append('--augNoise=%s' % self.data_aug['noise'])
+
+        if self.data_aug['hsv_use']:
+            args.append('--augHSVh=%s' % self.data_aug['hsv_h'])
+            args.append('--augHSVs=%s' % self.data_aug['hsv_s'])
+            args.append('--augHSVv=%s' % self.data_aug['hsv_v'])
+        else:
+            args.append('--augHSVh=0')
+            args.append('--augHSVs=0')
+            args.append('--augHSVv=0')
+
         return args
 
     @override

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -44,6 +44,7 @@ class TrainTask(Task):
         crop_size -- crop each image down to a square of this size
         use_mean -- subtract the dataset's mean file or mean pixel
         random_seed -- optional random seed
+        data_aug -- data augmentation options
         """
         self.gpu_count = kwargs.pop('gpu_count', None)
         self.selected_gpus = kwargs.pop('selected_gpus', None)
@@ -58,6 +59,7 @@ class TrainTask(Task):
         self.shuffle = kwargs.pop('shuffle', None)
         self.network = kwargs.pop('network', None)
         self.framework_id = kwargs.pop('framework_id', None)
+        self.data_aug = kwargs.pop('data_aug', None)
 
         super(TrainTask, self).__init__(job_dir = job.dir(), **kwargs)
         self.pickver_task_train = PICKLE_VERSION

--- a/digits/static/css/style.css
+++ b/digits/static/css/style.css
@@ -22,6 +22,10 @@ path.c3-line {
     stroke-width: 2px;
 }
 
+/* Hide all data transformation and augmentation by default */
+.data_transformation_input{ display:none; } 
+.data_augmentation_input{ display:none; } 
+
 .autocomplete-suggestions { border: 1px solid #999; background: #FFF; overflow: auto; }
 .autocomplete-suggestion { padding: 2px 5px; white-space: nowrap; overflow: visible; }
 .autocomplete-selected { background: #F0F0F0; }

--- a/digits/templates/models/data_augmentation.html
+++ b/digits/templates/models/data_augmentation.html
@@ -1,0 +1,67 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+<div class="form-group{{mark_errors([form.aug_flip])}} data-augmentation-input" id="FLIPPING">
+    {{form.aug_flip.label}}
+    {{form.aug_flip.tooltip}}
+    {{form.aug_flip(class='form-control')}}
+</div>
+
+<div class="form-group{{mark_errors([form.aug_quad_rot])}} data-augmentation-input" id="QUAD_ROTATION">
+    {{form.aug_quad_rot.label}}
+    {{form.aug_quad_rot.tooltip}}
+    {{form.aug_quad_rot(class='form-control')}}
+</div>
+
+<div class="form-group{{mark_errors([form.aug_rot])}} data-augmentation-input" id="ARBITRARY_ROTATION">
+    {{ form.aug_rot.label }}
+    {{ form.aug_rot.tooltip}}
+    {{ form.aug_rot(class='form-control')}}
+</div>
+
+<div class="form-group{{mark_errors([form.aug_scale])}} data-augmentation-input" id="SCALING">
+    {{ form.aug_scale.label }}
+    {{ form.aug_scale.tooltip}}
+    {{ form.aug_scale(class='form-control')}}
+</div>
+
+<div class="form-group{{mark_errors([form.aug_noise])}} data-augmentation-input" id="NOISE">
+    {{ form.aug_noise.label }}
+    {{ form.aug_noise.tooltip}}
+    {{ form.aug_noise(class='form-control')}}
+</div>
+
+<div class="data-augmentation-input" id="HSV_SHIFTING">
+    {{form.aug_hsv_use}}
+    {{form.aug_hsv_use.label}}
+    {{form.aug_hsv_use.tooltip}} 
+    <div class="row cl-augmentation-hsv">
+        <div class="form-group col-sm-4{{ ' has-error' if form.aug_hsv_h.errors else '' }}">
+            {{form.aug_hsv_h.label }}
+            {{form.aug_hsv_h(class='form-control')}}
+        </div>
+
+        <div class="form-group col-sm-4{{ ' has-error' if form.aug_hsv_s.errors else '' }}">
+            {{form.aug_hsv_s.label }}
+            {{form.aug_hsv_s(class='form-control')}}
+        </div>
+   
+        <div class="form-group col-sm-4{{ ' has-error' if form.aug_hsv_v.errors else '' }}">
+            {{form.aug_hsv_v.label }}
+            {{form.aug_hsv_v(class='form-control')}}
+        </div>
+    </div>
+</div>
+
+<script>
+function syncCheckboxToVisibility(checkbox_id, visibility_id) {
+    if ($(checkbox_id).prop("checked")){
+        $(visibility_id).show();
+    } else {
+        $(visibility_id).hide();
+    }
+}
+
+$("#aug_hsv_use"  ).click(function() { syncCheckboxToVisibility("#aug_hsv_use",   ".cl-augmentation-hsv"); });
+syncCheckboxToVisibility("#aug_hsv_use",   ".cl-augmentation-hsv");
+
+</script>

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -354,18 +354,22 @@ showHideAdvancedLROptions();
         </div>
 
         <div class="col-sm-4">
-            <div class="well">
+            <div class="well" id="data-transformation">
                 <h4>Data Transformations</h4>
-                <div class="form-group{{mark_errors([form.crop_size])}}">
-                    {{form.crop_size.label}}
-                    {{form.crop_size.tooltip}}
-                    {{form.crop_size(class='form-control', placeholder='none')}}
-                </div>
-                <div class="form-group{{mark_errors([form.use_mean])}}">
+                <div class="form-group{{mark_errors([form.use_mean])}} data-transformation-input" id="MEAN_SUBTRACTION">
                     {{form.use_mean.label}}
                     {{form.use_mean.tooltip}}
                     {{form.use_mean(class='form-control')}}
                 </div>
+                <div class="form-group{{mark_errors([form.crop_size])}} data-transformation-input" id="CROPPING">
+                    {{form.crop_size.label}}
+                    {{form.crop_size.tooltip}}
+                    {{form.crop_size(class='form-control', placeholder='none')}}
+                </div>
+            </div>
+            <div class="well" id="data-augmentation" style="display:none;">
+                <h4>Data Augmentations</h4>
+                {% include "/models/data_augmentation.html" %}
             </div>
         </div>
     </div>
@@ -423,6 +427,8 @@ framework = {
     name : '{{ fw.get_name() }}',
     can_shuffle : '{{ fw.can_shuffle_data() }}'=='True',
     can_accumulate_gradients : '{{ fw.can_accumulate_gradients() }}'=='True',
+    data_aug_types : [{% for dttype in fw.SUPPORTED_DATA_TRANSFORMATION_TYPES %} '{{dttype}}' {% if not loop.last %} , {% endif %} {% endfor %}],
+    data_trans_types : [{% for datype in fw.SUPPORTED_DATA_AUGMENTATION_TYPES %} '{{datype}}' {% if not loop.last %} , {% endif %} {% endfor %}],
     };
 frameworks['{{ fw.get_id() }}'] = framework;
 {% endfor %}
@@ -440,6 +446,25 @@ function setFramework(fwid)
     if (! $("select[name=solver_type] > option:selected").hasClass(fwid)) {
         $("select[name=solver_type] > option:selected").prop("selected", false);
     }
+
+    $(".data-transformation-input").hide();
+    $(".data-augmentation-input").hide();
+    $.each(frameworks[fwid].data_trans_types, function( index, value ) {
+        $("#"+value).show();
+    });
+    $.each(frameworks[fwid].data_aug_types, function( index, value ) {
+        $("#"+value).show();
+    });
+
+    // Hide the entire box including title when none is available
+    if (frameworks[fwid].data_aug_types.length)
+        $("#data-transformation").show();
+    else
+        $("#data-transformation").hide();
+    if (frameworks[fwid].data_trans_types.length)
+        $("#data-augmentation").show();
+    else
+        $("#data-augmentation").hide();
 
     if (fwid == 'torch'){
         $("#torch-warning").show();

--- a/digits/templates/models/images/generic/new.html
+++ b/digits/templates/models/images/generic/new.html
@@ -351,18 +351,22 @@ showHideAdvancedLROptions();
             </div>
         </div>
         <div class="col-sm-4">
-            <div class="well">
+            <div class="well" id="data-transformation">
                 <h4>Data Transformations</h4>
-                <div class="form-group{{mark_errors([form.crop_size])}}">
-                    {{form.crop_size.label}}
-                    {{form.crop_size.tooltip}}
-                    {{form.crop_size(class='form-control', placeholder='none')}}
-                </div>
-                <div class="form-group{{mark_errors([form.use_mean])}}">
+                <div class="form-group{{mark_errors([form.use_mean])}} data-transformation-input" id="MEAN_SUBTRACTION">
                     {{form.use_mean.label}}
                     {{form.use_mean.tooltip}}
                     {{form.use_mean(class='form-control')}}
                 </div>
+                <div class="form-group{{mark_errors([form.crop_size])}} data-transformation-input" id="CROPPING">
+                    {{form.crop_size.label}}
+                    {{form.crop_size.tooltip}}
+                    {{form.crop_size(class='form-control', placeholder='none')}}
+                </div>
+            </div>
+            <div class="well" id="data-augmentation" style="display:none;">
+                <h4>Data Augmentations</h4>
+                {% include "/models/data_augmentation.html" %}
             </div>
         </div>
     </div>
@@ -418,6 +422,8 @@ framework = {
     name : '{{ fw.get_name() }}',
     can_shuffle : '{{ fw.can_shuffle_data() }}'=='True',
     can_accumulate_gradients : '{{ fw.can_accumulate_gradients() }}'=='True',
+    data_aug_types : [{% for dttype in fw.SUPPORTED_DATA_TRANSFORMATION_TYPES %} '{{dttype}}' {% if not loop.last %} , {% endif %} {% endfor %}],
+    data_trans_types : [{% for datype in fw.SUPPORTED_DATA_AUGMENTATION_TYPES %} '{{datype}}' {% if not loop.last %} , {% endif %} {% endfor %}],
     };
 frameworks['{{ fw.get_id() }}'] = framework;
 {% endfor %}
@@ -434,6 +440,25 @@ function setFramework(fwid)
     if (! $("select[name=solver_type] > option:selected").hasClass(fwid)) {
         $("select[name=solver_type] > option:selected").prop("selected", false);
     }
+
+    $(".data-transformation-input").hide();
+    $(".data-augmentation-input").hide();
+    $.each(frameworks[fwid].data_trans_types, function( index, value ) {
+        $("#"+value).show();
+    });
+    $.each(frameworks[fwid].data_aug_types, function( index, value ) {
+        $("#"+value).show();
+    });
+
+    // Hide the entire box including title when none is available
+    if (frameworks[fwid].data_aug_types.length)
+        $("#data-transformation").show();
+    else
+        $("#data-transformation").hide();
+    if (frameworks[fwid].data_trans_types.length)
+        $("#data-augmentation").show();
+    else
+        $("#data-augmentation").hide();
 
     if (fwid == 'torch'){
         $("#torch-warning").show();

--- a/tools/torch/main.lua
+++ b/tools/torch/main.lua
@@ -23,12 +23,11 @@ local utils = require 'utils'
 
 opt = lapp[[
 Usage details:
--a,--threads            (default 8)              number of threads
+-a,--threads (default 8) number of threads
 -b,--batchSize (default 0) batch size
 -c,--learningRateDecay (default 1e-6) learning rate decay (in # samples)
 -e,--epoch (default 1) number of epochs to train -1 for unbounded
 -f,--shuffle (default no) shuffle records before train
--g,--mirror (default no) If this option is 'yes', then some of the images are randomly mirrored
 -i,--interval (default 1) number of train epochs to complete, to perform one validation
 -k,--crop (default no) If this option is 'yes', all the images are randomly cropped into square image. And croplength is provided as --croplen parameter
 -l,--croplen (default 0) crop length. This is required parameter when crop option is provided
@@ -41,6 +40,15 @@ Usage details:
 -t,--train (default '') location in which train db exists. This parameter may be omitted only if visualizeModel is 'yes'.
 -v,--validation (default '') location in which validation db exists.
 -w,--weightDecay (default 1e-4) L2 penalty on the weights
+
+--augFlip (default none) options {none, fliplr, flipud, fliplrud} as random pre-processing augmentation
+--augQuadRot (default none) options {none, rot90, rot180, rotall} as random pre-processing augmentation
+--augRot (default 0.0) min and max rotation (degrees) of arbitrary uniform-rotation as pre-processing augmentation
+--augScale (default 0.0) stddev of Scale as pre-processing augmentation
+--augNoise (default 0.0) stddev of Noise in AWGN as pre-processing augmentation
+--augHSVh (default 0.0) stddev of HSV's Hue shift as pre-processing  augmentation
+--augHSVs (default 0.0) stddev of HSV's Saturation shift as pre-processing  augmentation
+--augHSVv (default 0.0) stddev of HSV's Value shift as pre-processing augmentation
 
 --train_labels (default '') location in which train labels db exists. Optional, use this if train db does not contain target labels.
 --validation_labels (default '') location in which validation labels db exists. Optional, use this if validation db does not contain target labels.
@@ -96,7 +104,6 @@ COMPUTE_TRAIN_ACCURACY = false
 
 -- Convert boolean options
 opt.crop = opt.crop == 'yes' or false
-opt.mirror = opt.mirror == 'yes' or false
 opt.shuffle = opt.shuffle == 'yes' or false
 opt.visualizeModel = opt.visualizeModel == 'yes' or false
 
@@ -215,13 +222,15 @@ logmessage.display(0,'creating data readers')
 local trainDataLoader, trainSize, inputTensorShape
 local valDataLoader, valSize
 
+local num_threads_data_loader = 4
+
 if opt.train ~= '' then
     -- create data loader for training dataset
     trainDataLoader = DataLoader:new(
-            4, -- num threads
+            num_threads_data_loader, -- num threads
             package.path,
             opt.dbbackend, opt.train, opt.train_labels,
-            opt.mirror, meanTensor,
+            meanTensor,
             true, -- train
             opt.shuffle,
             classes ~= nil -- whether this is a classification task
@@ -232,10 +241,9 @@ if opt.train ~= '' then
     if opt.validation ~= '' then
         local shape
         valDataLoader = DataLoader:new(
-                4, -- num threads
+                num_threads_data_loader, -- num threads
                 package.path,
                 opt.dbbackend, opt.validation, opt.validation_labels,
-                false, -- no need to do random mirrorring
                 meanTensor,
                 false, -- train
                 false, -- shuffle
@@ -275,7 +283,7 @@ assert(type(network_func)=='function', "Network definition should return a Lua f
 local parameters = {
         nclasses = (classes ~= nil) and #classes or nil,
         ngpus = nGpus,
-        inputShape = inputTensorShape,
+        inputShape = inputTensorShape
     }
 network = network_func(parameters)
 local model = network.model
@@ -315,10 +323,6 @@ if opt.visualizeModel then
     print('\nCriterion: \n' .. loss:__tostring())
     logmessage.display(0,'Network definition ends')
     os.exit(-1)
-end
-
-if opt.mirror then
-    logmessage.display(0,'mirror option was selected, so during training for some of the random images, mirror view will be considered instead of original image view')
 end
 
 -- NOTE: currently randomState option wasn't used in DIGITS. This option was provided to be used from command line, if required.
@@ -429,13 +433,25 @@ end
 
 -- validate "crop length" input parameter
 if opt.crop and inputTensorShape then
-    -- make sure crop length is not bigger than image height or width
-    opt.croplen = math.min(opt.croplen, inputTensorShape[2], inputTensorShape[3])
-    -- set crop length in data readers
-    trainDataLoader:setCropLen(opt.croplen)
-    if valDataLoader then
-        valDataLoader:setCropLen(opt.croplen)
-    end
+    assert(opt.croplen <= math.min(inputTensorShape[2], inputTensorShape[3]), 'croplen parameter is bigger than input image size')
+end
+
+-- Set up augmentation options
+augOpt = { augFlip = opt.augFlip,
+           augQuadRot = opt.augQuadRot,
+           augRot = opt.augRot,
+           augScale = opt.augScale,
+           augNoise = opt.augNoise,
+           augHSV = {H=opt.augHSVh, S=opt.augHSVs, V=opt.augHSVv},
+           crop = {use=opt.crop, Y=-1, X=-1, len=opt.croplen},
+         }
+
+logmessage.display(0, 'augOpt:' .. table.concat(augOpt))
+
+trainDataLoader:setDataAugmentation(augOpt)
+if valDataLoader then
+    -- Note the valDataLoader will automatically nullify certain augmentation options because it knows it is the validation loader due to the test parameter
+    valDataLoader:setDataAugmentation(augOpt)
 end
 
 --modifying total sizes of train and validation dbs to be the exact multiple of 32, when cc2 is used

--- a/tools/torch/test.lua
+++ b/tools/torch/test.lua
@@ -192,12 +192,10 @@ end
 local function preprocess(im, mean, croplen)
 
     -- Depending on the function arguments, image preprocess may include conversion from RGB to BGR and mean subtraction, image resize after mean subtraction
-    local image_preprocessed = data.PreProcess(im, -- input image
-                                               mean, -- mean
-                                               false, -- do not mirror
-                                               false, -- do not crop
+    local image_preprocessed = data.PreProcess(im,    -- input image
                                                false, -- test mode
-                                               nil, nil, nil -- crop parameters (all nil)
+                                               mean,  -- mean
+                                               {}     -- augOpt
                                                )
 
     -- crop to match network expected input dimensions
@@ -206,11 +204,9 @@ local function preprocess(im, mean, croplen)
         assert(image_size[2] >= croplen and image_size[3] >= croplen, "Image must be larger than crop length in all spatial dimensions")
         c = (image_size[2]-croplen)/2 + 1
         image_preprocessed = data.PreProcess(image_preprocessed, -- input image
-                                             nil, -- no mean subtraction (this was done before)
-                                             false, -- do not mirror
-                                             true, -- crop
-                                             false, -- test mode
-                                             c, c, croplen -- crop parameters
+                                             false, --test mode
+                                             nil,   -- no mean subtraction (this was done before)
+                                             {crop={use=true,X=c,Y=c,len=croplen}}
                                              )
     end
     return image_preprocessed


### PR DESCRIPTION
Data augmentation needs little introduction I recon. It counters overfitting and makes your model generalize better, yielding better validation accuracies; or alternatively, allows you to use smaller datasets with similar performance. 

In the Zoo that's the internet, I see many implementations of different augmentations, of which few are proper and nicely portable. A part from Digits yielding a great UI; ease of use; and deep learning turn-key solution, I strongly feel we can expand to the functional side as well to make this a deep learning killer-app.

For torch, I have made an implementation _during lua preprocessing_ from frontend to backend to enable Digits to do so. In #330 there was already an attempt for augmentation, which happened on the dataset-creation side; something I am strongly against. Resizing and cropping I would consider a transformation, while I consider augmenting the data in its container an augmentation. I think therefore it's fine to resize during dataset loading (and squashing/filling/etc), but I would probably leave it at that.

Anyway, I set up a more dynamic structure to pass around these options on the torch side; instead of adding a dozen of arguments to each function, I am just adding a table.

Implements the following (screenshot): 
![image](https://cloud.githubusercontent.com/assets/7721540/15505758/258affe0-21c5-11e6-9b10-0142559ad1ef.png)

I have iterated through many augmentation types but these were the most useful. Almost done, now running elaborate tests.

# Progress

The code is already functional, though see progress below.
See code, shoot!

### Features
- [x] Make UI data transforms only visible for the Torch framework (invisible for Caffe)
- [x] ~~Implement UI option for normalization (scales the [0 255] to [0 1])~~
- [x] Data Augmentation UI
- [x] Flips (mirrors)
- [x] Quadrilateral rotations
- [x] Arbitrary rotations
- [x] Arbitrary scales
- [x] Augmenting in HSV space
- [x] Augmenting with noise (Thoughts?)
- [x] [Travis] Tests
- [x] Use Data Augmentation Template: `data_augmentation.html`

### Testing
- [x] No augmentation
- [x] Flips (mirrors)
- [x] Quadrilateral rotations
- [x] Arbitrary rotations
- [x] Arbitrary scales
- [x] Arbitrary rotations & arbitrary scales
- [x] Augmenting in HSV space
- [x] Augmenting with noise
- [x] All Augmentations & benchmark speed; identify bottlenecks
- [x] Verify models reporting a slower learning/less overfitting trade-off : more generalization.