### PR TITLE
Fix channels in encoded Datum

### DIFF
--- a/tools/create_generic_db.py
+++ b/tools/create_generic_db.py
@@ -120,13 +120,14 @@ class LmdbWriter(DbWriter):
         else:
             # Transpose to (height, width, channel)
             data = data.transpose((1, 2, 0))
-            if data.shape[2] == 1:
-                # grayscale
-                data = data[:, :, 0]
             datum = caffe_pb2.Datum()
             datum.height = data.shape[0]
             datum.width = data.shape[1]
+            datum.channels = data.shape[2]
             datum.label = scalar_label
+            if data.shape[2] == 1:
+                # grayscale
+                data = data[:, :, 0]
             s = StringIO()
             if encoding == 'png':
                 PIL.Image.fromarray(data).save(s, format='PNG')


### PR DESCRIPTION
Encoded Datum objects can have the data shape specified through `width`, `height` and `channels` fields.
DIGITS wrappers for Torch relies on this to determine the shape of the input data.
The `channels` field was previously left uninitialized.
This change fixes this.