### PR TITLE
Cache Caffe and Torch builds in Travis for 1 week

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ env:
     global:
         - NUM_THREADS=4
 
+cache:
+    timeout: 604800  # 1 week
+    apt: true
+    directories:
+        - ~/caffe
+        - ~/torch
+
 before_install:
     # undo all of TravisCI's "helpful" Python shenanigans on 14.04
     - deactivate

--- a/scripts/travis/install-caffe.sh
+++ b/scripts/travis/install-caffe.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
 set -e

--- a/scripts/travis/install-caffe.sh
+++ b/scripts/travis/install-caffe.sh
@@ -9,16 +9,21 @@ then
     echo "Usage: $0 INSTALL_DIR"
     exit 1
 fi
+
 INSTALL_DIR=$1
-
 NUM_THREADS=${NUM_THREADS-4}
-
 CAFFE_URL=https://github.com/NVIDIA/caffe.git
 CAFFE_BRANCH=caffe-0.14
 
+if [ -d "$INSTALL_DIR" ] && [ -e "$INSTALL_DIR/build/tools/caffe" ]; then
+    echo "Using cached build at $INSTALL_DIR ..."
+    exit 0
+fi
+
+rm -rf $INSTALL_DIR
+
 # get source
-git clone --branch ${CAFFE_BRANCH} --depth 1 \
-    ${CAFFE_URL} ${INSTALL_DIR}
+git clone --branch ${CAFFE_BRANCH} --depth 1 ${CAFFE_URL} ${INSTALL_DIR}
 
 # configure project
 mkdir -p ${INSTALL_DIR}/build

--- a/scripts/travis/install-torch-wrapper.sh
+++ b/scripts/travis/install-torch-wrapper.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#/bin/bash
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
 set -e

--- a/scripts/travis/install-torch.sh
+++ b/scripts/travis/install-torch.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#/bin/bash
 # Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved.
 
 set -e

--- a/scripts/travis/install-torch.sh
+++ b/scripts/travis/install-torch.sh
@@ -10,6 +10,13 @@ then
     exit 1
 fi
 INSTALL_DIR=$1
+
+if [ -d "$INSTALL_DIR" ] && [ -e "$INSTALL_DIR/install/bin/th" ]; then
+    echo "Using cached build at $INSTALL_DIR ..."
+    exit 0
+fi
+
+rm -rf $INSTALL_DIR
 mkdir -p $INSTALL_DIR
 
 # install Torch7


### PR DESCRIPTION
By removing the build time entirely, this brings the total TravisCI build+test time down from ~20 minutes to ~12 minutes when a cached build is present.