### PR TITLE
Remove unused resize_mode in Torch path

### DIFF
--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -807,7 +807,6 @@ class TorchTrainTask(TrainTask):
                     '--testMany=yes',
                     '--allPredictions=yes',   #all predictions are grabbed and formatted as required by DIGITS
                     '--image=%s' % str(temp_imglist_path),
-                    '--resizeMode=%s' % str(self.dataset.resize_mode),   # Here, we are using original images, so they will be resized in Torch code. This logic needs to be changed to eliminate the rework of resizing. Need to find a way to send python images array to Lua script efficiently
                     '--network=%s' % self.model_file.split(".")[0],
                     '--networkDirectory=%s' % self.job_dir,
                     '--snapshot=%s' % file_to_load,

--- a/tools/torch/test.lua
+++ b/tools/torch/test.lua
@@ -22,7 +22,6 @@ require 'Optimizer'
 --print 'processing options'
 
 opt = lapp[[
--m,--resizeMode (default squash) Resize mode (squash/crop/fill/half_crop) for the input test image, if it's dimensions differs from those of Train DB images.
 -t,--threads (default 8) number of threads
 -p,--type (default cuda) float or cuda
 -d,--devid (default 1) device ID (if using CUDA)


### PR DESCRIPTION
The resize mode is no longer used by the Torch wrapper in `test.lua`.
Besides, this field isn't part of the common dataset interface.
Using it is causing problems during multiple image inference in Torch when using generic datasets.
This should have been changed in #723