### PR TITLE
Image processing workflow

### DIFF
--- a/digits/dataset/generic/test_views.py
+++ b/digits/dataset/generic/test_views.py
@@ -3,8 +3,11 @@ from __future__ import absolute_import
 
 import json
 import os
+import tempfile
 
 from bs4 import BeautifulSoup
+import numpy as np
+import PIL.Image
 
 import digits.test_views
 from digits import extensions
@@ -52,6 +55,10 @@ class BaseViewsTestWithDataset(BaseViewsTest):
     Provides some functions
     """
 
+    IMAGE_WIDTH = 32
+    IMAGE_HEIGHT = 32
+    CHANNELS = 1
+
     @classmethod
     def create_dataset(cls, **kwargs):
         """
@@ -77,7 +84,7 @@ class BaseViewsTestWithDataset(BaseViewsTest):
         if request_json:
             if rv.status_code != 200:
                 raise RuntimeError(
-                    'Model creation failed with %s' % rv.status_code)
+                    'Dataset creation failed with %s' % rv.status_code)
             return json.loads(rv.data)['id']
 
         # expect a redirect
@@ -103,6 +110,44 @@ class BaseViewsTestWithDataset(BaseViewsTest):
         rv = cls.app.get('/datasets/%s.json' % cls.dataset_id)
         assert rv.status_code == 200, 'page load failed with %s' % rv.status_code
         return json.loads(rv.data)
+
+    @classmethod
+    def get_entry_count(cls, stage):
+        json_data = cls.get_dataset_json()
+        for t in json_data['create_db_tasks']:
+            if t['stage'] == stage:
+                return t['entry_count']
+        return None
+
+    @classmethod
+    def get_feature_dims(cls):
+        json_data = cls.get_dataset_json()
+        return json_data['feature_dims']
+
+    @classmethod
+    def create_random_imageset(cls, **kwargs):
+        """
+        Create a folder of random grayscale images
+        """
+        num_images = kwargs.pop('num_images', 10)
+        image_width = kwargs.pop('image_width', 32)
+        image_height = kwargs.pop('image_height', 32)
+        if not hasattr(cls, 'imageset_folder'):
+            # create a temporary folder
+            cls.imageset_folder = tempfile.mkdtemp()
+            for i in xrange(num_images):
+                x = np.random.randint(
+                    low=0,
+                    high=256,
+                    size=(image_height, image_width))
+                x = x.astype('uint8')
+                pil_img = PIL.Image.fromarray(x)
+                filename = os.path.join(
+                    cls.imageset_folder,
+                    '%d.png' % i)
+                pil_img.save(filename)
+                if not hasattr(cls, 'test_image'):
+                    cls.test_image = filename
 
     @classmethod
     def setUpClass(cls, **kwargs):
@@ -248,6 +293,11 @@ class GenericCreatedTest(BaseViewsTestWithDataset):
         # just make sure this doesn't return an error
         assert rv.status_code == 200, 'page load failed with %s' % rv.status_code
 
+    def test_feature_dims(self):
+        dims = self.get_feature_dims()
+        assert dims == [self.IMAGE_HEIGHT, self.IMAGE_WIDTH, self.CHANNELS]
+
+
 ################################################################################
 # Test classes
 ################################################################################
@@ -268,7 +318,18 @@ class TestImageGradientCreation(GenericCreationTest):
 
     @classmethod
     def setUpClass(cls, **kwargs):
-        super(TestImageGradientCreation, cls).setUpClass(train_image_count=100)
+        super(TestImageGradientCreation, cls).setUpClass(
+            train_image_count=100,
+            val_image_count=20,
+            test_image_count=10,
+            image_width=cls.IMAGE_WIDTH,
+            image_height=cls.IMAGE_HEIGHT,
+            )
+
+    def test_entry_counts(self):
+        assert self.get_entry_count(constants.TRAIN_DB) == 100
+        assert self.get_entry_count(constants.VAL_DB) == 20
+        assert self.get_entry_count(constants.TEST_DB) == 10
 
 
 class TestImageGradientCreated(GenericCreatedTest):
@@ -276,7 +337,68 @@ class TestImageGradientCreated(GenericCreatedTest):
     Test that create datasets
     """
     EXTENSION_ID = "image-gradients"
+    IMAGE_WIDTH = 8
+    IMAGE_HEIGHT = 24
 
     @classmethod
     def setUpClass(cls, **kwargs):
-        super(TestImageGradientCreated, cls).setUpClass(train_image_count=100)
+        super(TestImageGradientCreated, cls).setUpClass(
+            image_width=cls.IMAGE_WIDTH,
+            image_height=cls.IMAGE_HEIGHT)
+
+
+class TestImageProcessingCreated(GenericCreatedTest):
+    """
+    Test Image processing extension
+    """
+    EXTENSION_ID = "image-processing"
+
+    NUM_IMAGES = 100
+    FOLDER_PCT_VAL = 10
+
+    @classmethod
+    def setUpClass(cls, **kwargs):
+        cls.create_random_imageset(
+            num_images=cls.NUM_IMAGES,
+            image_width=cls.IMAGE_WIDTH,
+            image_height=cls.IMAGE_HEIGHT)
+        super(TestImageProcessingCreated, cls).setUpClass(
+            feature_folder=cls.imageset_folder,
+            label_folder=cls.imageset_folder,
+            folder_pct_val=cls.FOLDER_PCT_VAL,
+            channel_conversion='L')
+
+    def test_entry_counts(self):
+        assert self.get_entry_count(constants.TRAIN_DB) == self.NUM_IMAGES * (1.-self.FOLDER_PCT_VAL/100.)
+        assert self.get_entry_count(constants.VAL_DB) == self.NUM_IMAGES * (self.FOLDER_PCT_VAL/100.)
+
+
+class TestImageProcessingCreatedWithSeparateValidationDirs(GenericCreatedTest):
+    """
+    Test Image processing extension, using separate fields for the train and validation folders
+    Use RGB channel conversion for this test
+    """
+    EXTENSION_ID = "image-processing"
+
+    NUM_IMAGES = 100
+    CHANNELS = 3
+    IMAGE_HEIGHT = 16
+    IMAGE_WIDTH = 64
+
+    @classmethod
+    def setUpClass(cls, **kwargs):
+        cls.create_random_imageset(
+            num_images=cls.NUM_IMAGES,
+            image_width=cls.IMAGE_WIDTH,
+            image_height=cls.IMAGE_HEIGHT)
+        super(TestImageProcessingCreatedWithSeparateValidationDirs, cls).setUpClass(
+            feature_folder=cls.imageset_folder,
+            label_folder=cls.imageset_folder,
+            has_val_folder='y',
+            validation_feature_folder=cls.imageset_folder,
+            validation_label_folder=cls.imageset_folder,
+            channel_conversion='RGB')
+
+    def test_entry_counts(self):
+        assert self.get_entry_count(constants.TRAIN_DB) == self.NUM_IMAGES
+        assert self.get_entry_count(constants.VAL_DB) == self.NUM_IMAGES

--- a/digits/extensions/data/__init__.py
+++ b/digits/extensions/data/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from . import imageGradients
+from . import imageProcessing
 from . import objectDetection
 
 data_extensions = [
@@ -9,6 +10,7 @@ data_extensions = [
     # on DIGITS home page. These defaults can be changed by
     # editing DIGITS config option 'data_extension_list'
     {'class': imageGradients.DataIngestion, 'show': False},
+    {'class': imageProcessing.DataIngestion, 'show': True},
     {'class': objectDetection.DataIngestion, 'show': True},
 ]
 

--- a/digits/extensions/data/imageProcessing/__init__.py
+++ b/digits/extensions/data/imageProcessing/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .data import DataIngestion

--- a/digits/extensions/data/imageProcessing/data.py
+++ b/digits/extensions/data/imageProcessing/data.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import math
+import os
+import random
+
+import numpy as np
+
+from digits.utils import image, subclass, override, constants
+from ..interface import DataIngestionInterface
+from .forms import DatasetForm
+
+TEMPLATE = "template.html"
+
+
+@subclass
+class DataIngestion(DataIngestionInterface):
+    """
+    A data ingestion extension for an image processing dataset
+    """
+
+    def __init__(self, **kwargs):
+        """
+        the parent __init__ method automatically populates this
+        instance with attributes from the form
+        """
+        super(DataIngestion, self).__init__(**kwargs)
+
+        self.random_indices = None
+
+        if not 'seed' in self.userdata:
+            # choose random seed and add to userdata so it gets persisted
+            self.userdata['seed'] = random.randint(0, 1000)
+
+        random.seed(self.userdata['seed'])
+
+    @override
+    def encode_entry(self, entry):
+        """
+        Return numpy.ndarray
+        """
+        feature_image_file = entry[0]
+        label_image_file = entry[1]
+
+        feature_image = self.encode_PIL_Image(
+            image.load_image(feature_image_file))
+        label_image = self.encode_PIL_Image(
+            image.load_image(label_image_file))
+
+        return feature_image, label_image
+
+    def encode_PIL_Image(self, image):
+        if self.channel_conversion != 'none':
+            if image.mode != self.channel_conversion:
+                # convert to different image mode if necessary
+                image = image.convert(self.channel_conversion)
+        # convert to numpy array
+        image = np.array(image)
+        # add channel axis if input is grayscale image
+        if image.ndim == 2:
+            image = image[..., np.newaxis]
+        elif image.ndim != 3:
+            raise ValueError("Unhandled number of channels: %d" % image.ndim)
+        # transpose to CHW
+        image = image.transpose(2, 0, 1)
+        return image
+
+    @staticmethod
+    @override
+    def get_category():
+        return "Images"
+
+    @staticmethod
+    @override
+    def get_id():
+        return "image-processing"
+
+    @staticmethod
+    @override
+    def get_dataset_form():
+        return DatasetForm()
+
+    @staticmethod
+    @override
+    def get_dataset_template(form):
+        """
+        parameters:
+        - form: form returned by get_dataset_form(). This may be populated
+        with values if the job was cloned
+        returns:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering dataset creation
+          options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        template = open(os.path.join(extension_dir, TEMPLATE), "r").read()
+        context = {'form': form}
+        return (template, context)
+
+    @staticmethod
+    @override
+    def get_title():
+        return "Processing"
+
+    @override
+    def itemize_entries(self, stage):
+        if stage == constants.TEST_DB:
+            # don't retun anything for the test stage
+            return []
+
+        if stage == constants.TRAIN_DB or (not self.has_val_folder):
+            feature_image_list = self.make_image_list(self.feature_folder)
+            label_image_list = self.make_image_list(self.label_folder)
+        else:
+            # separate validation images
+            feature_image_list = self.make_image_list(self.validation_feature_folder)
+            label_image_list = self.make_image_list(self.validation_label_folder)
+
+        # make sure filenames match
+        if len(feature_image_list) != len(label_image_list):
+            raise ValueError(
+                "Expect same number of images in feature and label folders (%d!=%d)"
+                % (len(feature_image_list), len(label_image_list)))
+
+        for idx in range(len(feature_image_list)):
+            feature_name = os.path.splitext(
+                os.path.split(feature_image_list[idx])[1])[0]
+            label_name = os.path.splitext(
+                os.path.split(label_image_list[idx])[1])[0]
+            if feature_name != label_name:
+                raise ValueError("No corresponding feature/label pair found for (%s,%s)"
+                                 % (feature_name, label_name) )
+
+        # split lists if there is no val folder
+        if not self.has_val_folder:
+                feature_image_list = self.split_image_list(feature_image_list, stage)
+                label_image_list = self.split_image_list(label_image_list, stage)
+
+        return zip(
+            feature_image_list,
+            label_image_list)
+
+    def make_image_list(self, folder):
+        image_files = []
+        for dirpath, dirnames, filenames in os.walk(folder, followlinks=True):
+            for filename in filenames:
+                if filename.lower().endswith(image.SUPPORTED_EXTENSIONS):
+                    image_files.append('%s' % os.path.join(folder, filename))
+        if len(image_files) == 0:
+            raise ValueError("Unable to find supported images in %s" % folder)
+        return sorted(image_files)
+
+    def split_image_list(self, filelist, stage):
+        if self.random_indices is None:
+            self.random_indices = range(len(filelist))
+            random.shuffle(self.random_indices)
+        elif len(filelist) != len(self.random_indices):
+            raise ValueError(
+                "Expect same number of images in folders (%d!=%d)"
+                % (len(filelist), len(self.random_indices)))
+        filelist = [filelist[idx] for idx in self.random_indices]
+        pct_val = int(self.folder_pct_val)
+        n_val_entries = int(math.floor(len(filelist) * pct_val / 100))
+        if stage == constants.VAL_DB:
+            return filelist[:n_val_entries]
+        elif stage == constants.TRAIN_DB:
+            return filelist[n_val_entries:]
+        else:
+            raise ValueError("Unknown stage: %s" % stage)

--- a/digits/extensions/data/imageProcessing/forms.py
+++ b/digits/extensions/data/imageProcessing/forms.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from digits import utils
+from digits.utils import subclass
+from digits.utils.forms import validate_required_iff
+from flask.ext.wtf import Form
+import os
+from wtforms import validators
+
+
+@subclass
+class DatasetForm(Form):
+    """
+    A form used to create an image processing dataset
+    """
+
+    def validate_folder_path(form, field):
+        if not field.data:
+            pass
+        else:
+            # make sure the filesystem path exists
+            if not os.path.exists(field.data) or not os.path.isdir(field.data):
+                raise validators.ValidationError(
+                    'Folder does not exist or is not reachable')
+            else:
+                return True
+
+    feature_folder = utils.forms.StringField(
+        u'Feature image folder',
+        validators=[
+            validators.DataRequired(),
+            validate_folder_path,
+            ],
+        tooltip="Indicate a folder full of images."
+        )
+
+    label_folder = utils.forms.StringField(
+        u'Label image folder',
+        validators=[
+            validators.DataRequired(),
+            validate_folder_path,
+            ],
+        tooltip="Indicate a folder full of images. For each image in the feature"
+                " image folder there must be one corresponding image in the label"
+                " image folder. The label image must have the same filename except"
+                " for the extension, which may differ."
+        )
+
+    folder_pct_val = utils.forms.IntegerField(
+        u'% for validation',
+        default=10,
+        validators=[
+            validators.NumberRange(min=0, max=100)
+            ],
+        tooltip="You can choose to set apart a certain percentage of images "
+                "from the training images for the validation set."
+        )
+
+    has_val_folder = utils.forms.BooleanField('Separate validation images',
+            default = False,
+            )
+
+    validation_feature_folder = utils.forms.StringField(
+        u'Validation feature image folder',
+        validators=[
+            validate_required_iff(has_val_folder=True),
+            validate_folder_path,
+            ],
+        tooltip="Indicate a folder full of images."
+        )
+
+    validation_label_folder = utils.forms.StringField(
+        u'Validation label image folder',
+        validators=[
+            validate_required_iff(has_val_folder=True),
+            validate_folder_path,
+            ],
+        tooltip="Indicate a folder full of images. For each image in the feature"
+                " image folder there must be one corresponding image in the label"
+                " image folder. The label image must have the same filename except"
+                " for the extension, which may differ."
+        )
+
+    channel_conversion = utils.forms.SelectField(
+        'Channel conversion',
+        choices=[
+            ('RGB', 'RGB'),
+            ('L', 'Grayscale'),
+            ('none', 'None'),
+            ],
+        default='none',
+        tooltip="Perform selected channel conversion."
+        )

--- a/digits/extensions/data/imageProcessing/forms.py
+++ b/digits/extensions/data/imageProcessing/forms.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+import os
+
+from flask.ext.wtf import Form
+from wtforms import validators
+
 from digits import utils
 from digits.utils import subclass
 from digits.utils.forms import validate_required_iff
-from flask.ext.wtf import Form
-import os
-from wtforms import validators
 
 
 @subclass

--- a/digits/extensions/data/imageProcessing/template.html
+++ b/digits/extensions/data/imageProcessing/template.html
@@ -1,0 +1,65 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+<div class="form-group{{mark_errors([form.feature_folder])}}">
+    {{ form.feature_folder.label }}
+    {{ form.feature_folder.tooltip }}
+    {{ form.feature_folder(class='form-control autocomplete_path', placeholder='folder or URL')}}
+</div>
+
+<div class="form-group{{mark_errors([form.label_folder])}}">
+    {{ form.label_folder.label }}
+    {{ form.label_folder.tooltip }}
+    {{ form.label_folder(class='form-control autocomplete_path', placeholder='folder or URL')}}
+</div>
+
+<div class="form-group{{mark_errors([form.folder_pct_val])}}">
+    {{ form.folder_pct_val.label }}
+    {{ form.folder_pct_val.tooltip }}
+    {{ form.folder_pct_val(class='form-control') }}
+</div>
+
+{{form.has_val_folder}}
+{{form.has_val_folder.label}}
+
+<div style="display:none;" class="form-group{{mark_errors([form.validation_feature_folder])}} cl-separate-val-folder">
+    {{ form.validation_feature_folder.label }}
+    {{ form.validation_feature_folder.tooltip }}
+    {{ form.validation_feature_folder(class='form-control autocomplete_path') }}
+</div>
+
+<div style="display:none;" class="form-group{{mark_errors([form.validation_label_folder])}} cl-separate-val-folder">
+    {{ form.validation_label_folder.label }}
+    {{ form.validation_label_folder.tooltip }}
+    {{ form.validation_label_folder(class='form-control autocomplete_path') }}
+</div>
+
+<script>
+function hasValFolderChanged() {
+    if ($("#has_val_folder").prop("checked"))
+    {
+        $("#validation_feature_folder").prop("disabled", false);
+        $("#validation_label_folder").prop("disabled", false);
+        $(".cl-separate-val-folder").show();
+        $("#folder_pct_val").prop("disabled", true);
+    }
+    else
+    {
+        $(".cl-separate-val-folder").hide();
+        $("#validation_feature_folder").prop("disabled", true);
+        $("#validation_label_folder").prop("disabled", true);
+        $("#folder_pct_val").prop("disabled", false);
+    }
+}
+$("#has_val_folder").click(hasValFolderChanged);
+hasValFolderChanged();
+</script>
+
+<div class="form-group{{mark_errors([form.channel_conversion])}}">
+    {{ form.channel_conversion.label }}
+    {{ form.channel_conversion.tooltip }}
+    {{ form.channel_conversion(class='form-control') }}
+</div>

--- a/digits/extensions/view/__init__.py
+++ b/digits/extensions/view/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from . import boundingBox
+from . import imageOutput
 from . import imageGradients
 from . import rawData
 
@@ -12,6 +13,7 @@ view_extensions = [
     # 'view_extension_list'
     {'class': boundingBox.Visualization, 'show': True},
     {'class': imageGradients.Visualization, 'show': False},
+    {'class': imageOutput.Visualization, 'show': True},
     {'class': rawData.Visualization, 'show': True},
 ]
 

--- a/digits/extensions/view/imageOutput/__init__.py
+++ b/digits/extensions/view/imageOutput/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .view import Visualization

--- a/digits/extensions/view/imageOutput/config_template.html
+++ b/digits/extensions/view/imageOutput/config_template.html
@@ -1,0 +1,19 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+<small>Display network output as an image.</small>
+
+<div class="form-group{{mark_errors([form.channel_order])}}">
+    {{ form.channel_order.label }}
+    {{ form.channel_order.tooltip }}
+    {{ form.channel_order(class='form-control') }}
+</div>
+
+<div class="form-group{{mark_errors([form.pixel_conversion])}}">
+    {{ form.pixel_conversion.label }}
+    {{ form.pixel_conversion.tooltip }}
+    {{ form.pixel_conversion(class='form-control') }}
+</div>

--- a/digits/extensions/view/imageOutput/forms.py
+++ b/digits/extensions/view/imageOutput/forms.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from flask.ext.wtf import Form
+
+from digits import utils
+from digits.utils import subclass
+
+
+@subclass
+class ConfigForm(Form):
+    """
+    A form used to display the network output as an image
+    """
+    channel_order = utils.forms.SelectField(
+        'Channel order',
+        choices=[
+            ('rgb', 'RGB'),
+            ('bgr', 'BGR'),
+            ],
+        default='rgb',
+        tooltip='Set channel order to BGR for Caffe networks (this field '
+                'is ignored in the case of a grayscale image)'
+        )
+
+    pixel_conversion = utils.forms.SelectField(
+        'Pixel conversion',
+        choices=[
+            ('normalize', 'Normalize'),
+            ('clip', 'Clip'),
+            ],
+        default='normalize',
+        tooltip='Select method to convert pixel values to the target bit '
+                'range'
+        )

--- a/digits/extensions/view/imageOutput/view.py
+++ b/digits/extensions/view/imageOutput/view.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import os
+
+import PIL.Image
+import PIL.ImageDraw
+
+import digits
+from digits.utils import subclass, override
+from .forms import ConfigForm
+from ..interface import VisualizationInterface
+
+CONFIG_TEMPLATE = "config_template.html"
+VIEW_TEMPLATE = "view_template.html"
+
+
+@subclass
+class Visualization(VisualizationInterface):
+    """
+    A visualization extension to display the network output as an image
+    """
+
+    def __init__(self, dataset, **kwargs):
+        # memorize view template for later use
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        self.view_template = open(
+            os.path.join(extension_dir, VIEW_TEMPLATE), "r").read()
+
+        # view options
+        self.channel_order = kwargs['channel_order'].upper()
+        self.normalize = (kwargs['pixel_conversion'] == 'normalize')
+
+    @staticmethod
+    def get_config_form():
+        return ConfigForm()
+
+    @staticmethod
+    def get_config_template(form):
+        """
+        parameters:
+        - form: form returned by get_config_form(). This may be populated
+        with values if the job was cloned
+        returns:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering config options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        template = open(
+            os.path.join(extension_dir, CONFIG_TEMPLATE), "r").read()
+        return (template, {'form': form})
+
+    @staticmethod
+    def get_id():
+        return 'image-image-output'
+
+    @staticmethod
+    def get_title():
+        return 'Image output'
+
+    @override
+    def get_view_template(self, data):
+        """
+        returns:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering config options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        return self.view_template, {'image': digits.utils.image.embed_image_html(data)}
+
+    @override
+    def process_data(self, input_id, input_data, output_data):
+        """
+        Process one inference and return data to visualize
+        """
+        # assume the only output is a CHW image
+        data = output_data[output_data.keys()[0]].astype('float32')
+        channels = data.shape[0]
+        if channels == 3 and self.channel_order == 'BGR':
+            data = data[[2, 1, 0], ...]  # BGR to RGB
+        # convert to HWC
+        data = data.transpose((1, 2, 0))
+        # assume 8-bit
+        if self.normalize:
+            data -= data.min()
+            if data.max() > 0:
+                data /= data.max()
+                data *= 255
+        else:
+            # clip
+            data = data.clip(0, 255)
+        # convert to uint8
+        data = data.astype('uint8')
+        # convert to PIL image
+        if channels == 1:
+            # drop channel axis
+            image = PIL.Image.fromarray(data[:, :, 0])
+        elif channels == 3:
+            image = PIL.Image.fromarray(data)
+        else:
+            raise ValueError("Unhandled number of channels: %d" % channels)
+
+        return image

--- a/digits/extensions/view/imageOutput/view_template.html
+++ b/digits/extensions/view/imageOutput/view_template.html
@@ -1,0 +1,3 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+<img src="{{image}}" style="max-width:100%;" />


### PR DESCRIPTION
This adds data and view extensions to train image processing networks in DIGITS. This may be used for de-noising, super-resolution, segmentation, etc.

The image processing data extension creates datasets for which both the input and the label are images.

The image view extension displays the network output as an image.

Only works with Caffe for now. Torch wrappers need to be updated to deal with image labels (currently only scalar or vector labels are supported).