### PR TITLE
Test BVLC/caffe as well as NVIDIA/caffe on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ compiler: gcc
 env:
     global:
         - NUM_THREADS=4
+    matrix:
+        - CAFFE_FORK=BVLC CAFFE_BRANCH=master
+        - CAFFE_FORK=NVIDIA CAFFE_BRANCH=caffe-0.14
 
 cache:
     timeout: 604800  # 1 week

--- a/scripts/travis/install-apt.sh
+++ b/scripts/travis/install-apt.sh
@@ -12,6 +12,7 @@ sudo apt-get install -y --no-install-recommends \
     git \
     gfortran \
     graphviz \
+    libboost-filesystem-dev \
     libboost-python-dev \
     libboost-system-dev \
     libboost-thread-dev \

--- a/scripts/travis/install-caffe.sh
+++ b/scripts/travis/install-caffe.sh
@@ -11,9 +11,9 @@ then
 fi
 
 INSTALL_DIR=$1
-NUM_THREADS=${NUM_THREADS-4}
-CAFFE_URL=https://github.com/NVIDIA/caffe.git
-CAFFE_BRANCH=caffe-0.14
+NUM_THREADS=${NUM_THREADS:-4}
+CAFFE_FORK=${CAFFE_FORK:-"NVIDIA"}
+CAFFE_BRANCH=${CAFFE_BRANCH:-"caffe-0.14"}
 
 if [ -d "$INSTALL_DIR" ] && [ -e "$INSTALL_DIR/build/tools/caffe" ]; then
     echo "Using cached build at $INSTALL_DIR ..."
@@ -23,7 +23,7 @@ fi
 rm -rf $INSTALL_DIR
 
 # get source
-git clone --branch ${CAFFE_BRANCH} --depth 1 ${CAFFE_URL} ${INSTALL_DIR}
+git clone https://github.com/${CAFFE_FORK}/caffe.git ${INSTALL_DIR} --branch ${CAFFE_BRANCH} --depth 1
 
 # configure project
 mkdir -p ${INSTALL_DIR}/build


### PR DESCRIPTION
*Enabled by https://github.com/NVIDIA/DIGITS/pull/769*

It'll be nice to know when/if they break something that DIGITS expects from a Caffe build.

I believe TravisCI will store separate caches for each Caffe build.