### PR TITLE
Fix Flask requirement to 0.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ protobuf>=2.5.0
 six>=1.5.2
 requests>=2.2.1
 gevent>=1.0,<=1.0.2
-Flask>=0.10.1
+Flask==0.10.1
 Flask-WTF>=0.11
 wtforms>=2.0.0
 Flask-SocketIO==0.6.0


### PR DESCRIPTION
Otherwise, you get a cryptic error:
```
    exc_class = default_exceptions[exc_class_or_code]
KeyError: 300
```