### PR TITLE
Rework Torch multi-GPU training

### DIFF
--- a/digits/standard-networks/torch/ImageNet-Training/alexnet.lua
+++ b/digits/standard-networks/torch/ImageNet-Training/alexnet.lua
@@ -82,6 +82,7 @@ return function(params)
     end
     return {
         model = createModel(params.ngpus, channels, nclasses),
+        disableAutoDataParallelism = true,
         croplen = 224,
         trainBatchSize = 128,
         validationBatchSize = 32,

--- a/digits/standard-networks/torch/lenet.lua
+++ b/digits/standard-networks/torch/lenet.lua
@@ -44,27 +44,8 @@ return function(params)
     lenet:add(nn.Linear(500, nclasses))  -- 500 -> nclasses
     lenet:add(nn.LogSoftMax())
 
-    local model
-    if params.ngpus > 1 then
-      local gpus = torch.range(1, params.ngpus):totable()
-      local fastest, benchmark
-      local use_cudnn = cudnn ~= nil
-      if use_cudnn then
-        fastest, benchmark = cudnn.fastest, cudnn.benchmark
-      end
-      model = nn.DataParallelTable(1, true, true):add(lenet,gpus):threads(function()
-            if use_cudnn then
-              local cudnn = require 'cudnn'
-              cudnn.fastest, cudnn.benchmark = fastest, benchmark
-            end
-      end)
-      model.gradInput = nil
-    else
-      model = lenet
-    end
-
     return {
-        model = model,
+        model = lenet,
         loss = nn.ClassNLLCriterion(),
         trainBatchSize = 64,
         validationBatchSize = 32,

--- a/docs/GettingStartedTorch.md
+++ b/docs/GettingStartedTorch.md
@@ -106,6 +106,7 @@ labelHook             | function     | No        | A function(input,dblabel) tha
 trainBatchSize        | number       | No        | If specified, sets train batch size. May be overridden by user in DIGITS UI.
 validationBatchSize   | number       | No        | If specified, sets validation batch size. May be overridden by user in DIGITS UI.
 fineTuneHook          | function     | No        | A function(net) that returns the model to be used for fine-tuning. The untuned model is passed as a function parameter.
+disableAutoDataParallelism | boolean | No        | By default models are encapsulated in a nn.DataParallelTable container to enable multi-GPU training when more than 1 GPUs are selected. Setting this flag to `true` disables this mechanism.
 
 ### Tensors
 

--- a/tools/torch/main.lua
+++ b/tools/torch/main.lua
@@ -280,6 +280,12 @@ local parameters = {
 network = network_func(parameters)
 local model = network.model
 
+-- embed model in parallel table unless explicitly disallowed in user-defined description
+if nGpus > 1 and not network.disableAutoDataParallelism then
+    local gpus = torch.range(1, nGpus):totable()
+    model = nn.DataParallelTable(1, true, true):add(model, gpus)
+end
+
 -- if the loss criterion was not defined in the network
 -- use nn.ClassNLLCriterion() by default
 local loss = network.loss or nn.ClassNLLCriterion()


### PR DESCRIPTION
This change enables automatic encapsulation in an `nn.DataParallelTable` container for multi-GPU training. This comes from @thatguymike's realization that this would simplify the programming model. A `disableAutoDataParallelism` flag is added to the internal parameters to disable this mechanism. This flag is intended to be used by users who wish to retain control over what exactly gets parallelized. As an example, the standard Alexnet model enables this flag to parallelize only the feature part of the network.

Note: this changes does not enable threading in `nn.DataParallelTable` when doing the automatic encapsulation. Some of the numbers below are showing training time with/without threading.

For the record, some training time numbers:

LeNet:
1 GPU => 1m3s
2 GPUs, all parallel, single-thread => 1m33s;1m34s
2 GPUs, all parallel, multi-thread => 3m41s

Alexnet:
1 GPU => 11m6s
2 GPUs, feature parallel, single-thread => 10m29s
2 GPUs, feature parallel, multi-thread => 9m34s;10m6s
2 GPUs, all parallel, threaded => 13m47s

GoogLeNet:
1 GPU => 16m28s
2 GPUs, all parallel, single-thread => 12m28s
2 GPUs, all parallel, multi-thread => 11m6s;11m7s

Text classification (1D convolutions followed by FC layers):
1 GPU => 32m35s;32m14s
2 GPUs, all parallel, single-thread => 19m41s
2 GPUs, all parallel, multi-thread => 18m46s

Very Simple segmentation FCN (only 2 conv layers followed by a deconv):
1 GPU => 7m12s;7m11s
2 GPUs, all parallel, single-thread => 19m48s
2 GPUs, all parallel, multi-thread => 21m41s

GPUs are Titan X.