### PR TITLE
Remove cropping from validation phase in standard networks

### DIFF
--- a/digits/standard-networks/caffe/alexnet.prototxt
+++ b/digits/standard-networks/caffe/alexnet.prototxt
@@ -19,9 +19,6 @@ layer {
   type: "Data"
   top: "data"
   top: "label"
-  transform_param {
-    crop_size: 227
-  }
   data_param {
     batch_size: 32
   }

--- a/digits/standard-networks/caffe/googlenet.prototxt
+++ b/digits/standard-networks/caffe/googlenet.prototxt
@@ -19,10 +19,6 @@ layer {
   type: "Data"
   top: "data"
   top: "label"
-  transform_param {
-    mirror: false
-    crop_size: 224
-  }
   data_param {
     batch_size: 16
   }


### PR DESCRIPTION
Random cropping during validation phase makes it impossible to reproduce results on the validation set during testing.