### PR TITLE
Make padding optional in object detection data extension

### DIFF
--- a/digits/extensions/data/objectDetection/README.md
+++ b/digits/extensions/data/objectDetection/README.md
@@ -1,0 +1,31 @@
+# Object Detection Data Extension
+
+This data extension creates DIGITS datasets for Object Detection networks such as [DetectNet](https://github.com/NVIDIA/caffe/tree/caffe-0.15/examples/kitti).
+
+Labels are expected in KITTI format.
+Refer to the Object Detection track on KITTI web site for more information.
+
+Custom class mappings may be used by specifiying a comma-separated list of lower-case class names in the Object Detection dataset creation form.
+Class ID #0 is intended to be reserved for `DontCare` objects.
+Labels whose class is not listed in the class mappings are implicitly mapped to the `DontCare` class.
+Class IDs are used by DetectNet (see `DetectNetTransformation.detectnet_groundtruth_param.object_class` fields) to recognize which objects should be included and mapped to the specified index in the coverage map.
+
+The following table shows the default class-ID mappings in DIGITS:
+
+Class name | ID
+---------- | ---
+dontcare | 0
+car | 1
+van | 2
+truck | 3
+bus | 4
+pickup | 5
+vehicle-with-trailer | 6
+special-vehicle | 7
+person | 8
+person-fa | 9
+person? | 10
+people | 11
+cyclist | 12
+tram | 13
+person_sitting | 14

--- a/digits/extensions/data/objectDetection/data.py
+++ b/digits/extensions/data/objectDetection/data.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import numpy as np
+import csv
 import operator
 import os
-import PIL.Image
 import random
+import StringIO
+
+import numpy as np
+import PIL.Image
 
 import digits
 from digits.utils import subclass, override, constants
@@ -28,6 +31,15 @@ class DataIngestion(DataIngestionInterface):
 
         # this instance is automatically populated with form field
         # attributes by superclass constructor
+
+        if self.custom_classes != '':
+            s = StringIO.StringIO(self.custom_classes)
+            reader = csv.reader(s)
+            self.class_mappings = {}
+            for idx, name in enumerate(reader.next()):
+                self.class_mappings[name.strip()] = idx
+        else:
+            self.class_mappings = None
 
         if ((self.val_image_folder == '') ^ (self.val_label_folder == '')):
             raise ValueError("You must specify either both val_image_folder and val_label_folder or none")
@@ -194,7 +206,10 @@ class DataIngestion(DataIngestionInterface):
         """
         load ground truth from specified folder
         """
-        datasrc = GroundTruth(folder, min_box_size=min_box_size)
+        datasrc = GroundTruth(
+            folder,
+            min_box_size=min_box_size,
+            class_mappings=self.class_mappings)
         datasrc.load_gt_obj()
         self.datasrc_annotation_dict = datasrc.objects_all
 

--- a/digits/extensions/data/objectDetection/forms.py
+++ b/digits/extensions/data/objectDetection/forms.py
@@ -7,7 +7,7 @@ from wtforms import validators
 
 from digits import utils
 from digits.utils import subclass
-
+from digits.utils.forms import validate_required_if_set
 
 @subclass
 class DatasetForm(Form):
@@ -46,7 +46,7 @@ class DatasetForm(Form):
     val_image_folder = utils.forms.StringField(
         u'Validation image folder',
         validators=[
-            validators.Optional(),
+            validate_required_if_set('val_label_folder'),
             validate_folder_path,
             ],
         tooltip="Indicate a folder of images to use for training"
@@ -55,7 +55,7 @@ class DatasetForm(Form):
     val_label_folder = utils.forms.StringField(
         u'Validation label folder',
         validators=[
-            validators.Optional(),
+            validate_required_if_set('val_image_folder'),
             validate_folder_path,
             ],
         tooltip="Indicate a folder of validation labels"
@@ -64,7 +64,7 @@ class DatasetForm(Form):
     resize_image_width = utils.forms.IntegerField(
         u'Resize Image Width',
         validators=[
-            validators.Optional(),
+            validate_required_if_set('resize_image_height'),
             validators.NumberRange(min=1),
             ],
         tooltip="If specified, images will be resized to that dimension after padding"
@@ -73,7 +73,7 @@ class DatasetForm(Form):
     resize_image_height = utils.forms.IntegerField(
         u'Resize Image Height',
         validators=[
-            validators.Optional(),
+            validate_required_if_set('resize_image_width'),
             validators.NumberRange(min=1),
             ],
         tooltip="If specified, images will be resized to that dimension after padding"
@@ -83,20 +83,20 @@ class DatasetForm(Form):
         u'Padding Image Width',
         default=1248,
         validators=[
-            validators.DataRequired(),
+            validate_required_if_set('padding_image_height'),
             validators.NumberRange(min=1),
             ],
-        tooltip="Images will be padded to that dimension"
+        tooltip="If specified, images will be padded to that dimension"
         )
 
     padding_image_height = utils.forms.IntegerField(
         u'Padding Image Height',
         default=384,
         validators=[
-            validators.DataRequired(),
+            validate_required_if_set('padding_image_width'),
             validators.NumberRange(min=1),
             ],
-        tooltip="Images will be padded to that dimension"
+        tooltip="If specified, images will be padded to that dimension"
         )
 
     channel_conversion = utils.forms.SelectField(

--- a/digits/extensions/data/objectDetection/forms.py
+++ b/digits/extensions/data/objectDetection/forms.py
@@ -121,3 +121,15 @@ class DatasetForm(Form):
                 "value in both dimensions. This only affects objects in "
                 "the validation set. Enter 0 to disable this threshold."
         )
+
+    custom_classes = utils.forms.StringField(
+        u'Custom classes',
+        validators=[
+            validators.Optional(),
+            ],
+        tooltip="Enter a comma-separated list of lower-case class names. "
+                "Class IDs are assigned sequentially, starting from 0. "
+                "Leave this field blank to use default class mappings. "
+                "See object detection extension documentation for more "
+                "information."
+        )

--- a/digits/extensions/data/objectDetection/template.html
+++ b/digits/extensions/data/objectDetection/template.html
@@ -74,3 +74,9 @@
     {{ form.val_min_box_size.tooltip }}
     {{ form.val_min_box_size(class='form-control')}}
 </div>
+
+<div class="form-group{{mark_errors([form.custom_classes])}}">
+    {{ form.custom_classes.label }}
+    {{ form.custom_classes.tooltip }}
+    {{ form.custom_classes(class='form-control')}}
+</div>

--- a/digits/extensions/data/objectDetection/template.html
+++ b/digits/extensions/data/objectDetection/template.html
@@ -39,28 +39,32 @@
     {{ form.val_label_folder(class='form-control autocomplete_path', placeholder='folder')}}
 </div>
 
-<div class="form-group{{mark_errors([form.padding_image_width])}}">
-    {{ form.padding_image_width.label }}
-    {{ form.padding_image_width.tooltip }}
-    {{ form.padding_image_width(class='form-control')}}
+<div class="form-group{{mark_errors([form.padding_image_width, form.padding_image_height])}}">
+    <label>Pad image (Width x Height)</label>
+    <span name="pad_dims_explanation"
+          class="explanation-tooltip glyphicon glyphicon-question-sign"
+          data-container="body"
+          title="If specified, input images will be padded to that dimension. Pad dimensions should be greater than those of input images."
+          ></span>
+    <div class="input-group">
+        {{ form.padding_image_width(size=4, placeholder='width', class='form-control') }}
+        <span class="input-group-addon">x</span>
+        {{ form.padding_image_height(size=4, placeholder='height', class='form-control') }}
+    </div>
 </div>
 
-<div class="form-group{{mark_errors([form.padding_image_height])}}">
-    {{ form.padding_image_height.label }}
-    {{ form.padding_image_height.tooltip }}
-    {{ form.padding_image_height(class='form-control')}}
-</div>
-
-<div class="form-group{{mark_errors([form.resize_image_width])}}">
-    {{ form.resize_image_width.label }}
-    {{ form.resize_image_width.tooltip }}
-    {{ form.resize_image_width(class='form-control')}}
-</div>
-
-<div class="form-group{{mark_errors([form.resize_image_height])}}">
-    {{ form.resize_image_height.label }}
-    {{ form.resize_image_height.tooltip }}
-    {{ form.resize_image_height(class='form-control')}}
+<div class="form-group{{mark_errors([form.resize_image_width, form.resize_image_height])}}">
+    <label>Resize image (Width x Height)</label>
+    <span name="resize_dims_explanation"
+          class="explanation-tooltip glyphicon glyphicon-question-sign"
+          data-container="body"
+          title="If specified, input images will be squashed to that dimension after padding."
+          ></span>
+    <div class="input-group">
+        {{ form.resize_image_width(size=4, placeholder='width', class='form-control') }}
+        <span class="input-group-addon">x</span>
+        {{ form.resize_image_height(size=4, placeholder='height', class='form-control') }}
+    </div>
 </div>
 
 <div class="form-group{{mark_errors([form.channel_conversion])}}">

--- a/digits/extensions/data/objectDetection/utils.py
+++ b/digits/extensions/data/objectDetection/utils.py
@@ -39,9 +39,7 @@ class GroundTruthObj:
 
         #Values    Name      Description
         ----------------------------------------------------------------------------
-        1    type         Describes the type of object: 'Car', 'Van', 'Truck',
-                          'Pedestrian', 'Person_sitting', 'Cyclist', 'Tram',
-                          'Misc' or 'DontCare'
+        1    type         Class ID
         1    truncated    Float from 0 (non-truncated) to 1 (truncated), where
                           truncated refers to the object leaving image boundaries.
                           -1 corresponds to a don't care region.
@@ -61,6 +59,24 @@ class GroundTruthObj:
         for example because they have been too far away from the laser scanner.
     """
 
+    # default class mappings
+    OBJECT_TYPES = {
+        'bus': ObjectType.Bus,
+        'car': ObjectType.Car,
+        'cyclist': ObjectType.Cyclist,
+        'pedestrian': ObjectType.Person,
+        'people': ObjectType.People,
+        'person': ObjectType.Person,
+        'person_sitting': ObjectType.Person_Sitting,
+        'person-fa': ObjectType.Person_fa,
+        'person?': ObjectType.Person_unsure,
+        'pickup': ObjectType.Pickup,
+        'misc': ObjectType.Misc,
+        'special-vehicle': ObjectType.SpecialVehicle,
+        'tram': ObjectType.Tram,
+        'truck': ObjectType.Truck,
+        'van': ObjectType.Van,
+        'vehicle-with-trailer': ObjectType.VehicleWithTrailer}
 
     def __init__(self):
         self.stype = ''
@@ -119,38 +135,28 @@ class GroundTruthObj:
         return result
 
     def set_type(self):
-        object_types = {
-            'bus': ObjectType.Bus,
-            'car': ObjectType.Car,
-            'cyclist': ObjectType.Cyclist,
-            'pedestrian': ObjectType.Person,
-            'people': ObjectType.People,
-            'person': ObjectType.Person,
-            'person_sitting': ObjectType.Person_Sitting,
-            'person-fa': ObjectType.Person_fa,
-            'person?': ObjectType.Person_unsure,
-            'pickup': ObjectType.Pickup,
-            'misc': ObjectType.Misc,
-            'special-vehicle': ObjectType.SpecialVehicle,
-            'tram': ObjectType.Tram,
-            'truck': ObjectType.Truck,
-            'van': ObjectType.Van,
-            'vehicle-with-trailer': ObjectType.VehicleWithTrailer
-        }
-        self.object = object_types.get(self.stype, ObjectType.Dontcare)
+        self.object = self.OBJECT_TYPES.get(self.stype, ObjectType.Dontcare)
 
 
 class GroundTruth:
-
-    """ this class load the ground truth
+    """
+    this class loads the ground truth
     """
 
-    def __init__(self, label_dir, label_ext='.txt', label_delimiter=' ', min_box_size=None):
+    def __init__(self,
+                 label_dir,
+                 label_ext='.txt',
+                 label_delimiter=' ',
+                 min_box_size=None,
+                 class_mappings=None):
         self.label_dir = label_dir
         self.label_ext = label_ext  # extension of label files
         self.label_delimiter = label_delimiter  # space is used as delimiter in label files
         self._objects_all = dict()  # positive bboxes across images
         self.min_box_size = min_box_size
+
+        if class_mappings is not None:
+            GroundTruthObj.OBJECT_TYPES = class_mappings
 
     def update_objects_all(self, _key, _bboxes):
         if _bboxes:

--- a/digits/extensions/data/objectDetection/utils.py
+++ b/digits/extensions/data/objectDetection/utils.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 
 import csv
-import numpy as np
 import os
+
+import numpy as np
+import PIL.Image
 
 class ObjectType:
 
@@ -267,6 +269,29 @@ def bbox_overlap(abox, bbox):
     overlap_pix = xoverlap * yoverlap
 
     return overlap_pix, overlap_box
+
+
+def pad_image(img, padding_image_height, padding_image_width):
+    """
+    pad a single image to the specified dimensions
+    """
+    src_width = img.size[0]
+    src_height = img.size[1]
+
+    if padding_image_width < src_width:
+        raise ValueError("Source image width %d is greater than padding width %d" % (src_width, padding_image_width))
+
+    if padding_image_height < src_height:
+        raise ValueError("Source image height %d is greater than padding height %d" % (src_height, padding_image_height))
+
+    padded_img = PIL.Image.new(
+        img.mode,
+        (padding_image_width, padding_image_height),
+        "black")
+    padded_img.paste(img, (0, 0))  # copy to top-left corner
+
+    return padded_img
+
 
 def resize_bbox_list(bboxlist, rescale_x=1, rescale_y=1):
         # this is expecting x1,y1,w,h:

--- a/digits/utils/forms.py
+++ b/digits/utils/forms.py
@@ -38,6 +38,31 @@ def validate_required_iff(**kwargs):
 
     return _validator
 
+def validate_required_if_set(other_field, **kwargs):
+    """
+    Used as a validator within a wtforms.Form
+
+    This implements a conditional DataRequired
+    `other_field` is a field name; if set, the other field makes it mandatory
+    to set the field being tested
+    """
+    def _validator(form, field):
+        other_field_value = getattr(form, other_field).data
+        if other_field_value is not None and other_field_value is not "":
+            # Verify that data exists
+            if field.data is None \
+                    or (isinstance(field.data, (str, unicode))
+                            and not field.data.strip()) \
+                    or (isinstance(field.data, FileStorage)
+                            and not field.data.filename.strip()):
+                raise validators.ValidationError('This field is required if %s is set.' % other_field)
+        else:
+            # This field is not required, ignore other errors
+            field.errors[:] = []
+            raise validators.StopValidation()
+
+    return _validator
+
 def validate_greater_than(fieldname):
     """
     Compares the value of two fields the value of self is to be greater than the supplied field.


### PR DESCRIPTION
This change makes it optional to pad images when creating an object detection dataset.

A form validator is added to verify that either both or none of width/height are specified when validating the form.
Doing this in the form validator instead of (like formerly) the extension instantiation helps drop a more user-friendly error.

Template updated to show width/height on same row.