### PR TITLE
[Reopen Pull Request #823] Added Delete Snapshot Button

### DIFF
--- a/digits/model/views.py
+++ b/digits/model/views.py
@@ -7,6 +7,7 @@ import json
 import math
 import tarfile
 import zipfile
+import os
 
 import flask
 import werkzeug.exceptions
@@ -30,8 +31,14 @@ def show(job_id):
         {id, name, directory, status, snapshots: [epoch,epoch,...]}
     """
     job = scheduler.get_job(job_id)
+
     if job is None:
         raise werkzeug.exceptions.NotFound('Job not found')
+
+    task = job.train_task()
+
+    # Update the snapshots
+    task.detect_snapshots()
 
     related_jobs = scheduler.get_related_jobs(job)
 
@@ -224,6 +231,51 @@ def download(job_id, extension):
     response = flask.make_response(b.getvalue())
     response.headers['Content-Disposition'] = 'attachment; filename=%s_epoch_%s.%s' % (job.id(), epoch, extension)
     return response
+
+@blueprint.route('/<job_id>/delete_snapshot',
+        methods=['post'])
+def delete_snapshot(job_id):
+    """
+    Delete a specific snapshot epoch from server
+    """
+    job = scheduler.get_job(job_id)
+    if job is None:
+        raise werkzeug.exceptions.NotFound('Job not found')
+
+    epoch = -1
+    # POST ?snapshot_epoch=n (from form)
+    if 'snapshot_epoch' in flask.request.form:
+        epoch = float(flask.request.form['snapshot_epoch'])
+    else:
+        raise werkzeug.exceptions.BadRequest('Invalid epoch')
+
+    task = job.train_task()
+
+    snapshot_filename = None
+    if len(task.snapshots) == 1:
+        # if there is only 1 model left, do not allow deleting
+        raise werkzeug.exceptions.BadRequest('Cannot delete last model')
+
+    else:
+        for f, e in task.snapshots:
+            if e == epoch:
+                snapshot_filename = f
+                break
+    if not snapshot_filename:
+        raise werkzeug.exceptions.BadRequest('Invalid epoch')
+
+    # Get the name of last snapshot
+    last_snapshot, e = task.snapshots[-1]
+
+    # Deleting last snapshot is not allowed
+    if last_snapshot == snapshot_filename:
+        raise werkzeug.exceptions.BadRequest('Cannot delete last model')
+
+    # Delete the snaspshot
+    os.remove(snapshot_filename)
+
+    # redirect to the /models/<job_id> page
+    return flask.redirect('/models/{0}'.format(job_id))
 
 class JobBasicInfo(object):
     def __init__(self, name, ID, status, time, framework_id):

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -149,6 +149,16 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             Download Model
                         </button>
                     </div>
+                    <div class="col-sm-4">
+                        <button
+                            id="delete-snapshot"
+                            class="btn btn-danger"
+                            formaction="{{url_for('digits.model.views.delete_snapshot', job_id=job.id())}}"
+                            formenctype="multipart/form-data"
+                            formmethod="post">
+                            Delete Snapshot
+                        </button>
+                    </div>
                 </div>
                 {% if task.get_framework_id() in framework_ids %}
                 <div class="row">
@@ -248,4 +258,3 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
 </div>
 
 {% endblock %}
-

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -143,6 +143,16 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             Download Model
                         </button>
                     </div>
+                    <div class="col-sm-4">
+                        <button
+                            id="delete-snapshot"
+                            class="btn btn-danger"
+                            formaction="{{url_for('digits.model.views.delete_snapshot', job_id=job.id())}}"
+                            formenctype="multipart/form-data"
+                            formmethod="post">
+                            Delete Snapshot
+                        </button>
+                    </div>
                 </div>
                 <div class="row">
                     <div class="col-sm-6">
@@ -274,4 +284,3 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
 </div>
 
 {% endblock %}
-


### PR DESCRIPTION
I closed the pull request #823 before, since it could not pass the test. I reopen it by changing some parts according to comments of @gheinrich, @lukeyeager.

I added deleting a specific snapshot of a model on the model page, since my harddisk sometimes runs out of space when so many model are saved. So, I put a Delete Snapshot button under Download Model Button.
The deletion process does not allow: 

- deleting all snapshots (in that case, it becomes deletion of all model)
- deleting the last snapshot 

Now, the model page seems like:

![screenshot from 2016-06-14 17 21 37](https://cloud.githubusercontent.com/assets/7191084/16051826/154ec2c8-326a-11e6-982d-aa810c8588ab.png)
