### PR TITLE
Fix the table to fit in the container

### DIFF
--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -243,7 +243,7 @@
 
         <div class="row">
             <!-- Datasets -->
-            <div ng-show="tab.isSet(1)">
+            <div class="col-md-12" ng-show="tab.isSet(1)">
                 <div class="well">
                     <div ng-controller="datasets_controller">
                         <div class="row">
@@ -343,7 +343,7 @@
                 </div>
             </div>
             <!-- Models -->
-            <div ng-show="tab.isSet(2)">
+            <div class="col-md-12" ng-show="tab.isSet(2)">
                 <div class="well">
                     <div ng-controller="models_controller">
                         <div class="row">


### PR DESCRIPTION
The wells containing the Models and Datasets tables were not strictly in the container div so that as the window width was decreased, the wells could creep off screen before the divs were resized.