### PR TITLE
Double sort with blanks fix

### DIFF
--- a/digits/static/js/home_app.js
+++ b/digits/static/js/home_app.js
@@ -317,12 +317,6 @@
             active2: 'submitted',
             descending2: true,
         }
-        $scope.predicate1 = function(rows) {
-            return rows[$scope.sort.active1];
-        }
-        $scope.predicate2 = function(rows) {
-            return rows[$scope.sort.active2];
-        }
         $scope.jobs = [];
 
         $scope.set_jobs = function(jobs) {
@@ -545,16 +539,29 @@
             return match ? match[0] : ''
         }
     });
-    app.filter("empty_to_end", function () {
+    app.filter("sort_with_empty_at_end", function () {
         return function (array, scope) {
+            console.log(scope.sort.active1, scope.sort.active2);
             if (!angular.isArray(array)) return;
-            var present = array.filter(function (item) {
-                return item[scope.sort.active2];
-            });
-            var empty = array.filter(function (item) {
-                return !item[scope.sort.active2]
-            });
-            return present.concat(empty);
+            array.sort(
+                function(x, y)
+                {
+                    let x1 = x[scope.sort.active1];
+                    let y1 = y[scope.sort.active1];
+                    let x2 = x[scope.sort.active2];
+                    let y2 = y[scope.sort.active2];
+
+                    if (x1 == y1) {
+                        if (x2 === undefined) return true;
+                        if (y2 === undefined) return false;
+                        return (scope.sort.descending2 == x2 < y2);
+                    }
+                    if (x1 === undefined) return true;
+                    if (y1 === undefined) return false;
+                    return (scope.sort.descending1 == x1 < y1);
+                }
+            );
+            return array;
         };
     });
 

--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -49,7 +49,7 @@
     <section ng-controller="tab_controller as tab">
         <div ng-controller="running_controller">
             <div ng-if="jc.running_jobs.length">
-                {[jobs = (jc.running_jobs | filter:search_text | orderBy:predicate2:sort.descending2 | orderBy:predicate1:sort.descending1 | empty_to_end:this);'']}
+                {[jobs = (jc.running_jobs | filter:search_text | sort_with_empty_at_end:this);'']}
                 {[set_jobs(jobs)]}
                 <h4>
                     Running Jobs
@@ -287,7 +287,7 @@
                                     </th>
                                 </tr>
                             </thead>
-                            {[jobs = (jc.dataset_jobs | filter:search_text | orderBy:predicate2:sort.descending2 | orderBy:predicate1:sort.descending1 | empty_to_end:this);'']}
+                            {[jobs = (jc.dataset_jobs | filter:search_text | sort_with_empty_at_end:this);'']}
                             {[set_jobs(jobs)]}
                             <tbody ng-if="jobs.length">
                                 <!-- Table -->
@@ -422,7 +422,7 @@
                                     </th>
                                 </tr>
                             </thead>
-                            {[jobs = (jc.model_jobs | filter:search_text | orderBy:predicate2:sort.descending2 | orderBy:predicate1:sort.descending1 | empty_to_end:this);'']}
+                            {[jobs = (jc.model_jobs | filter:search_text | sort_with_empty_at_end:this);'']}
                             {[set_jobs(jobs)]}
                             <tbody ng-if="jobs.length">
                                 <tr ng-attr-id="{[ job.id ]}"


### PR DESCRIPTION
When sorting with two columns (click on a column header and shift-click a second) the blank entries in the second column could be at the top or the bottom of that column depending on the ascending / descending state.

I've replaced the predicte functions and empty_to_the_end filter with a custom sort filter.