### PR TITLE
Fixed the sorting function.

### DIFF
--- a/digits/static/js/home_app.js
+++ b/digits/static/js/home_app.js
@@ -313,9 +313,9 @@
         $scope.search_text = '';     // set the default search/filter term
         $scope.sort = {
             active1: 'submitted',
-            descending1: true,
+            descending1: 1,
             active2: 'submitted',
-            descending2: true,
+            descending2: 1,
         }
         $scope.jobs = [];
 
@@ -323,20 +323,29 @@
             $scope.jobs = jobs;
         }
 
+        $scope.default_descending = function(active) {
+            for (var i = 0; i < $scope.jobs.length; i++) {
+                if (typeof($scope.jobs[i][active]) == 'string') {
+                    return -1;
+                }
+            }
+            return 1;
+        };
+
         $scope.change_sorting = function(parameter, event) {
             var sort = $scope.sort;
             if (!event.shiftKey || sort.active1 == parameter) {
                 if (sort.active1 == parameter) {
-                    sort.descending1 = sort.descending2 = !sort.descending1;
+                    sort.descending1 = sort.descending2 = -sort.descending1;
                 } else {
-                    sort.descending1 = sort.descending2 = false;
+                    sort.descending1 = sort.descending2 = $scope.default_descending(parameter);
                 }
                 sort.active1 = sort.active2 = parameter;
             } else {
                 if (sort.active2 == parameter) {
-                    sort.descending2 = !sort.descending2;
+                    sort.descending2 = -sort.descending2;
                 } else {
-                    sort.descending2 = false;
+                    sort.descending2 = $scope.default_descending(parameter);
                 }
                 sort.active2 = parameter;
             }
@@ -346,12 +355,12 @@
             var sort = $scope.sort;
 
             if (sort.active1 == parameter) {
-                return sort.descending1
+                return sort.descending1 == 1
                     ? 'glyphicon-chevron-up'
                     : 'glyphicon-chevron-down';
             }
             if (sort.active2 == parameter) {
-                return sort.descending2
+                return sort.descending2 == 1
                     ? 'glyphicon-chevron-up'
                     : 'glyphicon-chevron-down';
             }
@@ -539,25 +548,28 @@
             return match ? match[0] : ''
         }
     });
+
     app.filter("sort_with_empty_at_end", function () {
         return function (array, scope) {
             if (!angular.isArray(array)) return;
             array.sort(
                 function(x, y)
                 {
-                    let x1 = x[scope.sort.active1];
-                    let y1 = y[scope.sort.active1];
-                    let x2 = x[scope.sort.active2];
-                    let y2 = y[scope.sort.active2];
+                    var x1 = x[scope.sort.active1];
+                    var y1 = y[scope.sort.active1];
+                    var x2 = x[scope.sort.active2];
+                    var y2 = y[scope.sort.active2];
+                    var d1 = scope.sort.descending1;
+                    var d2 = scope.sort.descending2;
 
                     if (x1 == y1) {
-                        if (x2 === undefined) return true;
-                        if (y2 === undefined) return false;
-                        return (scope.sort.descending2 == x2 < y2);
+                        if (x2 === undefined) return 1;
+                        if (y2 === undefined) return -1;
+                        return ((x2 < y2) ? d2 : (x2 > y2) ? -d2 : 0);
                     }
-                    if (x1 === undefined) return true;
-                    if (y1 === undefined) return false;
-                    return (scope.sort.descending1 == x1 < y1);
+                    if (x1 === undefined) return 1;
+                    if (y1 === undefined) return -1;
+                    return ((x1 < y1) ? d1 : (x1 > y1) ? -d1 : 0);
                 }
             );
             return array;


### PR DESCRIPTION
*Close #853*

The sorting function is fixed. It needed to return -1, 0, -1, but had been returning true, false. The Boolean return appeared to work in FireFox, but that may have been a coincidence.

Also changed the default descending choice when a column is first selected based on whether the columns data type is a string on not. This has strings sort a->z and numbers and dates (large -> small). This is similar to OSX file browser. This gives the "logical" choice and feels natural. 