### PR TITLE
Move bounding box drawing from the server to the client.

### DIFF
--- a/digits/extensions/view/boundingBox/app_begin_template.html
+++ b/digits/extensions/view/boundingBox/app_begin_template.html
@@ -1,0 +1,265 @@
+<!-- {# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #} -->
+
+<script>
+ // Create image filters
+ Filters = {};
+ Filters.get_canvas = function(width, height) {
+     var canvas = document.createElement('canvas');
+     canvas.width = width;
+     canvas.height = height;
+     return canvas;
+ };
+
+ Filters.get_pixels = function(image) {
+     var canvas = this.get_canvas(image.width, image.height);
+     var context = canvas.getContext('2d');
+     context.drawImage(image, 0, 0);
+     return context.getImageData(0, 0, canvas.width, canvas.height);
+ };
+
+ Filters.filter_image = function(filter, image, var_args) {
+     var args = [this.get_pixels(image)];
+     for (var i = 2; i < arguments.length; i++) {
+         args.push(arguments[i]);
+     }
+     return filter.apply(null, args);
+ };
+
+ Filters.desaturate = function(pixels, desaturation) {
+     var d = pixels.data;
+     for (var i = 0; i < d.length; i += 4) {
+         var r = d[i];
+         var g = d[i+1];
+         var b = d[i+2];
+         var v = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+         d[i]   = r + (v - r) * desaturation;
+         d[i+1] = g + (v - g) * desaturation;
+         d[i+2] = b + (v - b) * desaturation;
+     }
+     return pixels;
+ };
+
+ // Add a bounding box draw method to the canvas
+ CanvasRenderingContext2D.prototype.draw_bbox = function(bbox, color, opacity) {
+     this.globalAlpha = opacity;
+     this.fillStyle = color;
+     this.fillRect(bbox[0],
+                   bbox[1],
+                   bbox[2] - bbox[0],
+                   bbox[3] - bbox[1]);
+     this.globalAlpha = 1.0;
+     this.strokeStyle = color;
+     this.strokeRect(bbox[0],
+                     bbox[1],
+                     bbox[2] - bbox[0],
+                     bbox[3] - bbox[1]);
+ }
+
+ // Add a text to bounding box
+ CanvasRenderingContext2D.prototype.draw_text = function(bbox, color, scale, text) {
+     this.globalAlpha = 1.0;
+     this.fillStyle = color;
+     this.strokeStyle = color;
+     this.font = Math.round(11 * scale) + "px Arial";
+     // move text because of lineWidth and decenders
+     this.fillText(text,
+                   bbox[0] - this.lineWidth / 2,
+                   bbox[1] - this.lineWidth / 2 - scale * 4);
+ }
+
+ // Angularjs app, visualization_app
+ var app = angular.module('visualization_app', ['ngStorage']);
+
+ // Controller to handle global display attributes
+ app.controller('display_controller',
+                ['$scope', '$rootScope', '$localStorage',
+                 function($scope, $rootScope, $localStorage) {
+                     $rootScope.storage = $localStorage.$default({
+                         line_width: 2,
+                         desaturation: 0,
+                         opacity: 30,
+                     });
+                     // Broadcast to child scopes that the line width has changed.
+                     $scope.$watch(function(){
+                         return $localStorage.line_width;
+                     }, function(new_line_width, old_line_width){
+                         $rootScope.$broadcast('draw_settings_changed');
+                     });
+                     // Broadcast to child scopes that the desaturation has changed.
+                     $scope.$watch(function(){
+                         return $localStorage.desaturation;
+                     }, function(new_desaturation, old_desaturation){
+                         $rootScope.$broadcast('draw_settings_changed');
+                     });
+                     // Broadcast to child scopes that the opacity has changed.
+                     $scope.$watch(function(){
+                         return $localStorage.opacity;
+                     }, function(new_opacity, old_opacity){
+                         $rootScope.$broadcast('draw_settings_changed');
+                     });
+                 }]);
+
+ // Controller to draw bounding boxes on an image.
+ // The line_width is adjusted by the display_controller and the canvas width.
+ app.controller('bbox_controller', ['$scope','$rootScope', function($scope, $rootScope) {
+     $scope.canvas_width = 0;
+
+     // The display_controller has broadcast that the draw settings change have changed
+     $scope.$on('draw_settings_changed', function(event) {
+         $scope.draw_bboxes_and_image();
+     });
+     
+     // may need to rewrite
+     function hsv(h, s, v) {
+         var hp = h * 6;
+         var c = v * s
+         var x = c * (1 - Math.abs(hp % 2 - 1));
+         var rgb = [0, 0, 0];
+         switch (Math.floor(hp % 6)) {
+             case 0: rgb = [c, x, 0]; break;
+             case 1: rgb = [x, c, 0]; break;
+             case 2: rgb = [0, c, x]; break;
+             case 3: rgb = [0, x, c]; break;
+             case 4: rgb = [x, 0, c]; break;
+             case 5: rgb = [c, 0, x]; break;
+         }
+         var m = v - c;
+         r = Math.round((rgb[0] + m) * 255);
+         g = Math.round((rgb[1] + m) * 255);
+         b = Math.round((rgb[2] + m) * 255);
+         return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+     }
+
+     $scope.get_color = function(i) {
+         if (i == 0) {
+             var h = 0.0;
+         } else {
+             // Divide the hsv into n parts depending on the input. First cut
+             // in half, then quarters, then eighths, ...
+             var d = Math.pow( 2, Math.floor( Math.log(i) / Math.log(2) ) + 1);
+             // Then iterate though the odd sections 1/8, 3/8, 5/8, ...
+             var n = 2 * i - d + 1;
+             var h = n / d;
+         }
+         return hsv(h, 1, 1);
+     };
+
+
+     // Draw the image and the bounding boxes with line_width and desaturated by desaturation.
+     $scope.draw_bboxes = function(image, bboxes) {
+         var canvas = document.getElementById($scope.canvas_id);
+         var context = canvas.getContext('2d'); 
+         
+         // first set the size of the canvas
+         canvas.width = image.width;
+         canvas.height = image.height;
+
+         // draw the image
+         if (false) {
+             context.drawImage(image, 0, 0);
+         } else {
+             var desaturation = $rootScope.storage.desaturation / 100.0;
+             var image_data = Filters.filter_image(Filters.desaturate, image, desaturation);
+             context.putImageData(image_data, 0, 0);
+         }
+         
+         // scale the line width
+         $scope.canvas_width = $('#' + $scope.canvas_id).width();
+         var scale = image.width / $scope.canvas_width;
+         context.lineWidth = $rootScope.storage.line_width * scale;
+
+         // rectangle fill opacity
+         var opacity = $rootScope.storage.opacity / 100.0;
+
+         // draw the bounding boxes
+         var keys = Object.keys(bboxes);
+         keys.sort();
+         for (var k = 0; k < keys.length; k++) {
+             var color = $scope.get_color(k);
+             for (var i = 0; i < bboxes[keys[k]].length; i++) {
+                 context.draw_bbox(bboxes[keys[k]][i], color, opacity);
+             }
+         }
+     }
+
+     // Draw after the image data is loaded
+     $scope.draw_bboxes_and_image = function() {
+         var image = new Image;
+         image.onload = function() {
+             $scope.draw_bboxes(image, $scope.bboxes);
+         }
+         image.src = $scope.image;
+     }
+
+     // Redraw if the canvas width has changed because the line_width is
+     // adjusted by the inverse of the canvas_width to keep apparent
+     // width constant.
+     $scope.resize_canvas = function() {
+         if ($scope.canvas_width != $('#' + $scope.canvas_id).width()) {
+             $scope.draw_bboxes_and_image();
+         }
+     }
+ }]);
+
+ // A directive to notify the bbox_controllers that the window has resized.
+ app.directive('resize', function ($window) {
+     return function (scope, element, attr) {
+         
+         var w = angular.element($window);
+         scope.$watch(function () {
+             return {
+                 'w': w.width()
+             };
+         }, function (newValue, oldValue) {
+             scope.resize_canvas();
+         }, true);
+
+         w.bind('resize', function () {
+             scope.$apply();
+         });
+     }
+ }); 
+
+ // Because jinja uses {{ and }}, tell angular to use {[ and ]}
+ app.config(['$interpolateProvider', function($interpolateProvider) {
+     $interpolateProvider.startSymbol('{[');
+     $interpolateProvider.endSymbol(']}');
+ }]);
+</script>
+
+<div ng-app="visualization_app">
+    <div ng-controller="display_controller as dispaly">
+        <!-- The ngCloak directive is used to prevent the Angular html
+        template from being briefly displayed by the browser in its raw
+        (uncompiled) form while your application is loading. Use this
+        directive to avoid the undesirable flicker effect caused by
+        the html template display. -->
+        <!-- Display Options -->
+        <div class="pull-right">
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="button-group pull-right">
+                        <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
+                            <span class="glyphicon glyphicon-cog"></span>
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu"
+                            style="padding:10px"
+                            ng-click="$event.stopPropagation()">
+                            <li>
+                                <small>Line Width {[storage.line_width]}</small>
+                                <input type="range" min="1" max="4" ng-model="storage.line_width">
+                            </li>
+                            <li>
+                                <small>Desaturation {[storage.desaturation]}%</small>
+                                <input type="range" min="0" max="100" step="10" ng-model="storage.desaturation">
+                            </li>
+                            <li>
+                                <small>Opacity {[storage.opacity]}%</small>
+                                <input type="range" min="0" max="100" step="5" ng-model="storage.opacity">
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>

--- a/digits/extensions/view/boundingBox/app_end_template.html
+++ b/digits/extensions/view/boundingBox/app_end_template.html
@@ -1,0 +1,4 @@
+<!-- {# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #} -->
+
+    </div>
+</div>

--- a/digits/extensions/view/boundingBox/config_template.html
+++ b/digits/extensions/view/boundingBox/config_template.html
@@ -4,19 +4,4 @@
 {% from "helper.html" import print_errors %}
 {% from "helper.html" import mark_errors %}
 
-<small>Draw a bounding box around a detected object. This expected network output is a nested list of list of box coordinates</small>
-
-<div class="form-group{{mark_errors([form.box_color])}}">
-    {{ form.box_color.label }}
-    {{ form.box_color.tooltip }}
-    {{ form.box_color(class='form-control') }}
-</div>
-
-<div class="form-group{{mark_errors([form.line_width])}}">
-    {{ form.line_width.label }}
-    {{ form.line_width.tooltip }}
-    {{ form.line_width(class='form-control') }}
-</div>
-
-
-
+<small>Draw a bounding box around a detected object. The expected network output is a dictionary, keyed by class, where the values are lists of bounding boxes for that image. e.g. {'class1': [[l, t, r, b, confidence], ...], ...}</small>

--- a/digits/extensions/view/boundingBox/forms.py
+++ b/digits/extensions/view/boundingBox/forms.py
@@ -1,34 +1,10 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-from digits import utils
 from digits.utils import subclass
 from flask.ext.wtf import Form
-import wtforms
-from wtforms import validators
 
 
 @subclass
 class ConfigForm(Form):
-    """
-    A form used to configure the drawing of bounding boxes
-    """
-
-    box_color = wtforms.SelectField(
-        'Box color',
-        choices=[
-            ('red', 'Red'),
-            ('green', 'Green'),
-            ('blue', 'Blue'),
-            ],
-        default='red',
-        )
-
-    line_width = utils.forms.IntegerField(
-        'Line width',
-        validators=[
-            validators.DataRequired(),
-            validators.NumberRange(min=1),
-            ],
-        default=2,
-        )
+    pass

--- a/digits/extensions/view/boundingBox/header_template.html
+++ b/digits/extensions/view/boundingBox/header_template.html
@@ -1,3 +1,3 @@
 {# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
 
-Found {{ bbox_count }} bounding box(es) in {{ image_count }} image(s).
+Found {{ bbox_count }} bounding box{% if bbox_count != 1 %}es{% endif %}{% if image_count != 1 %} in {{ image_count }} images{% endif %}.

--- a/digits/extensions/view/boundingBox/view_template.html
+++ b/digits/extensions/view/boundingBox/view_template.html
@@ -1,3 +1,25 @@
 {# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+<script>
+ // For each image, setup one angularjs controller derived from bbox_controller
+ app.controller('bbox_controller_{{index}}', function($scope, $controller) {
+     $controller('bbox_controller', {$scope: $scope});
+     $scope.canvas_id = 'image-canvas-{{index}}';
+     $scope.bboxes = {{bboxes}};
+     $scope.image = "{{image}}";
+     $scope.draw_bboxes_and_image();
+ });
+</script>
 
-<img src="{{image}}" style="max-width:100%;" />
+<div ng-controller="bbox_controller_{{index}}">
+    <canvas id="image-canvas-{{index}}"
+            style="max-width:100%;"
+            resize></canvas>
+    <p align="center">
+        <span ng-repeat="(key, boxes) in bboxes">
+            <span ng-if="boxes.length > 0" style="display:inline-block;">
+                <span style="display:inline-block; width:10px;height:10px;border:1px solid #000; background-color: {[get_color($index)]}"></span>
+                <span style="display:inline-block; padding-right:10px">{[key]}</span>
+            </span>
+        </span>
+    </p>
+</div>

--- a/digits/extensions/view/interface.py
+++ b/digits/extensions/view/interface.py
@@ -49,6 +49,32 @@ class VisualizationInterface(object):
         """
         return None, None
 
+    def get_ng_templates(self):
+        """
+        This returns the angularjs content defining the app and maybe a
+        large scope controller. By default this method returns None,
+        an indication that there is no angular header. This method
+        may be overridden in sub-classes to implement the app and controller.
+
+        This header html protion will likely be of the form:
+        <script>
+        ...
+        </script>
+        <div ng-app="my_app">
+            <div ng-controller="my_controller">
+
+        and the footer needs to close any open divs:
+            </div>
+        </div>
+        Returns:
+        - (header, footer) tuple
+          - header is the html text defining the angular app and adding the ng-app div,
+          or None if there is no angular app defined
+          - footer is the html text closing any open divs from the header
+          or None if there is no angular app defined
+        """
+        return None, None
+
     @staticmethod
     def get_id():
         """

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -368,7 +368,7 @@ def infer_one():
 
     if inputs is not None and len(inputs['data']) == 1:
         image = utils.image.embed_image_html(inputs['data'][0])
-        visualizations, header_html = get_inference_visualizations(
+        visualizations, header_html, app_begin_html, app_end_html = get_inference_visualizations(
             model_job.dataset,
             inputs,
             outputs)
@@ -377,6 +377,8 @@ def infer_one():
         image = None
         inference_view_html = None
         header_html = None
+        app_begin_html = None
+        app_end_html = None
 
     if request_wants_json():
         return flask.jsonify({'outputs': dict((name, blob.tolist())
@@ -389,6 +391,8 @@ def infer_one():
             image_src=image,
             inference_view_html=inference_view_html,
             header_html=header_html,
+            app_begin_html=app_begin_html,
+            app_end_html=app_end_html,
             visualizations=model_visualization,
             total_parameters=sum(v['param_count'] for v in model_visualization
                                  if v['vis_type'] == 'Weights'),
@@ -452,7 +456,7 @@ def infer_db():
 
     if inputs is not None:
         keys = [str(idx) for idx in inputs['ids']]
-        inference_views_html, header_html = get_inference_visualizations(
+        inference_views_html, header_html, app_begin_html, app_end_html = get_inference_visualizations(
             model_job.dataset,
             inputs,
             outputs)
@@ -460,6 +464,8 @@ def infer_db():
         inference_views_html = None
         header_html = None
         keys = None
+        app_begin_html = None
+        app_end_html = None
 
     if request_wants_json():
         result = {}
@@ -474,6 +480,8 @@ def infer_db():
             keys=keys,
             inference_views_html=inference_views_html,
             header_html=header_html,
+            app_begin_html=app_begin_html,
+            app_end_html=app_end_html,
             ), status_code
 
 
@@ -564,13 +572,15 @@ def infer_many():
 
     if inputs is not None:
         paths = [paths[idx] for idx in inputs['ids']]
-        inference_views_html, header_html = get_inference_visualizations(
+        inference_views_html, header_html, app_begin_html, app_end_html = get_inference_visualizations(
             model_job.dataset,
             inputs,
             outputs)
     else:
         inference_views_html = None
         header_html = None
+        app_begin_html = None
+        app_end_html = None
 
     if request_wants_json():
         result = {}
@@ -585,6 +595,8 @@ def infer_many():
             paths=paths,
             inference_views_html=inference_views_html,
             header_html=header_html,
+            app_begin_html=app_begin_html,
+            app_end_html=app_end_html,
             ), status_code
 
 
@@ -639,7 +651,8 @@ def get_inference_visualizations(dataset, inputs, outputs):
     # get header
     template, context = extension.get_header_template()
     header = flask.render_template_string(template, **context) if template else None
-    return visualizations, header
+    app_begin, app_end = extension.get_ng_templates()
+    return visualizations, header, app_begin, app_end
 
 
 def get_previous_networks():

--- a/digits/templates/models/images/generic/infer_db.html
+++ b/digits/templates/models/images/generic/infer_db.html
@@ -1,6 +1,11 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 {% extends "job.html" %}
 
+{% block head %}
+<script type="text/javascript" src="{{ url_for('static', filename='js/angular.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/ngStorage.min.js') }}"></script>
+{% endblock %}
+
 {% block nav %}
 <li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
 <li class="active"><a>Test Many</a></li>
@@ -34,6 +39,10 @@
 </div>
 {% endif %}
 
+{% if app_begin_html %}
+{{app_begin_html|safe}}
+{% endif %}
+
 {% if inference_views_html %}
 <div class="row">
     <h3>Visualizations</h3>
@@ -55,6 +64,10 @@
         {% endfor %}
     </table>
 </div>
+{% endif %}
+
+{% if app_end_html %}
+{{app_end_html|safe}}
 {% endif %}
 
 {% endblock %}

--- a/digits/templates/models/images/generic/infer_many.html
+++ b/digits/templates/models/images/generic/infer_many.html
@@ -1,13 +1,17 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 {% extends "job.html" %}
 
+{% block head %}
+<script type="text/javascript" src="{{ url_for('static', filename='js/angular.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/ngStorage.min.js') }}"></script>
+{% endblock %}
+
 {% block nav %}
 <li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
 <li class="active"><a>Test Many</a></li>
 {% endblock %}
 
 {% block job_content %}
-
 <div class="page-header">
     <h1>
         {{model_job.name()}}
@@ -34,6 +38,10 @@
 </div>
 {% endif %}
 
+{% if app_begin_html %}
+{{app_begin_html|safe}}
+{% endif %}
+
 {% if paths %}
 <div class="row">
     <h3>Visualizations</h3>
@@ -53,6 +61,10 @@
         {% endfor %}
     </table>
 </div>
+{% endif %}
+
+{% if app_end_html %}
+{{app_end_html|safe}}
 {% endif %}
 
 {% endblock %}

--- a/digits/templates/models/images/generic/infer_one.html
+++ b/digits/templates/models/images/generic/infer_one.html
@@ -1,6 +1,11 @@
 {# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
 {% extends "job.html" %}
 
+{% block head %}
+<script type="text/javascript" src="{{ url_for('static', filename='js/angular.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/ngStorage.min.js') }}"></script>
+{% endblock %}
+
 {% block nav %}
 <li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
 <li class="active"><a>Test One</a></li>
@@ -25,6 +30,10 @@
 </div>
 {% endif %}
 
+{% if app_begin_html %}
+{{app_begin_html|safe}}
+{% endif %}
+
 {% if image_src %}
 <div class="row">
     <h3>Source image</h3>
@@ -40,6 +49,10 @@
         <p>Inference failed, see job log</p>
     </div>
 </div>
+{% endif %}
+
+{% if app_end_html %}
+{{app_end_html|safe}}
 {% endif %}
 
 {% endblock %}

--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -309,42 +309,6 @@ def embed_image_html(image):
     data = string_buf.getvalue().encode('base64').replace('\n', '')
     return 'data:image/%s;base64,%s' % (fmt, data)
 
-def add_bboxes_to_image(image, bboxes, color='red', width=1):
-    """
-    Draw rectangles on the image for the bounding boxes
-    Returns a PIL.Image
-
-    Arguments:
-    image -- input image
-    bboxes -- bounding boxes in the [((l, t), (r, b)), ...] format
-
-    Keyword arguments:
-    color -- color to draw the rectangles
-    width -- line width of the rectangles
-
-    Example:
-    image = Image.open(filename)
-    add_bboxes_to_image(image, bboxes[filename], width=2, color='#FF7700')
-    image.show()
-    """
-    def expanded_bbox(bbox, n):
-        """
-        Grow the bounding box by n pixels
-        """
-        l = min(bbox[0][0], bbox[1][0])
-        r = max(bbox[0][0], bbox[1][0])
-        t = min(bbox[0][1], bbox[1][1])
-        b = max(bbox[0][1], bbox[1][1])
-        return ((l - n, t - n), (r + n, b + n))
-
-    from PIL import Image, ImageDraw
-    draw = ImageDraw.Draw(image)
-    for bbox in bboxes:
-        for n in xrange(width):
-            draw.rectangle(expanded_bbox(bbox, n), outline = color)
-
-    return image
-
 def get_layer_vis_square(data,
         allow_heatmap = True,
         normalize = True,

--- a/digits/utils/test_image.py
+++ b/digits/utils/test_image.py
@@ -187,14 +187,3 @@ class TestResizeImage():
         resize_mode=%s
         image_type=%s
         shape=%s""" % args
-
-
-class TestBBoxes():
-
-    def test_add_bboxes(self):
-        np_color = np.random.randint(0, 100, (10,10,3)).astype('uint8')
-        pil_color = PIL.Image.fromarray(np_color)
-        pil_color = image_utils.add_bboxes_to_image(pil_color, [((4, 4), (7, 7))], color='red')
-        pixelMap = pil_color.load()
-        assert pixelMap[4, 4] == (255, 0, 0)
-        assert pixelMap[7, 7] == (255, 0, 0)


### PR DESCRIPTION
In preparation for the multi-class object detection display, I have moved the drawing of the bounding boxes from the server to the client. This will allow quicker interactions with the display. Users will be able to toggle displays of bounding boxes by class, adjust the image desaturation if there are color conflicts between the image a class's bounding box color, and change the line width.

![screen shot 2016-06-24 at 1 49 43 pm](https://cloud.githubusercontent.com/assets/13259615/16350247/8cbc9060-3a12-11e6-8e09-b85c7a719f19.png)

So that the lines are drawn with a fixed width regardless of scale, the images are redrawn when the window is resized such that the image display is resized.

The header text "Found 7 box(es) in 3 image(s)" has been changed to drop the "in `n` images" if the number of images is one and to pluralize "box" as needed.

The line width and desaturation settings are saved per browser.