### PR TITLE
Fix handling of long multi-field documents

### DIFF
--- a/examples/text-classification/create_dataset.py
+++ b/examples/text-classification/create_dataset.py
@@ -64,6 +64,8 @@ def create_dataset(folder, input_file_name, db_batch_size=None, create_images=Fa
             sample = np.ones(FEATURE_LEN) # one by default (i.e. 'other' character)
             count = 0
             for field in row['fields']:
+                if count > FEATURE_LEN-1:
+                    break
                 for char in field.lower():
                     if char in cdict:
                         sample[count] = cdict[char]


### PR DESCRIPTION
This fixes cases when a document has multiple, long fields, and reaches the FEATURE_LEN limit before the last field. This causes it to break out of the inner loop, but not the outer loop and raises an IndexError.
