### PR TITLE
Addition of mean_path selection

### DIFF
--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -267,6 +267,7 @@ def create():
                         pretrained_model = pretrained_model,
                         crop_size = form.crop_size.data,
                         use_mean = form.use_mean.data,
+                        mean_path = form.mean_path.data,
                         network = network,
                         random_seed = form.random_seed.data,
                         solver_type = form.solver_type.data,

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -267,7 +267,7 @@ def create():
                         pretrained_model = pretrained_model,
                         crop_size = form.crop_size.data,
                         use_mean = form.use_mean.data,
-                        mean_path = form.mean_path.data,
+                        custom_mean_path = form.custom_mean_path.data,
                         network = network,
                         random_seed = form.random_seed.data,
                         solver_type = form.solver_type.data,

--- a/digits/model/images/forms.py
+++ b/digits/model/images/forms.py
@@ -36,7 +36,7 @@ class ImageModelForm(ModelForm):
 
     # The mean_path is the file path pointing to the a protoblob of the mean image which is to be used instead of the
     #  dataset's protoblob. If it is left empty, then the protoblob from the dataset will be used instead.
-    mean_path = utils.forms.StringField('Mean Image Protoblob file',
+    custom_mean_path = utils.forms.StringField('Custom Mean Image Protoblob File',
                                         validators = [
                                             validators.Optional()
                                             ],

--- a/digits/model/images/forms.py
+++ b/digits/model/images/forms.py
@@ -34,3 +34,12 @@ class ImageModelForm(ModelForm):
             tooltip = "Subtract the mean file or mean pixel for this dataset from each image."
             )
 
+    # The mean_path is the file path pointing to the a protoblob of the mean image which is to be used instead of the
+    #  dataset's protoblob. If it is left empty, then the protoblob from the dataset will be used instead.
+    mean_path = utils.forms.StringField('Mean Image Protoblob file',
+                                        validators = [
+                                            validators.Optional()
+                                            ],
+                                        tooltip = "The protoblob from which to get the data used for mean subtraction. If left unspecified, the protoblob of the dataset will be used."
+                                        )
+

--- a/digits/model/job.py
+++ b/digits/model/job.py
@@ -74,9 +74,12 @@ class ModelJob(Job):
         should be assumed that the mean image will be that of the dataset.
         returns: True if the custom_mean_path was successfully set, False otherwise
         """
-        if custom_mean_path != '' and path.isfile(custom_mean_path) is True:
-            self.custom_mean_path = custom_mean_path
-            return True
+        if custom_mean_path != '' and custom_mean_path is not None:
+            if path.isfile(custom_mean_path) is True:
+                self.custom_mean_path = custom_mean_path
+                return True
+            else:
+                return False
         else:
             return False
 
@@ -86,12 +89,14 @@ class ModelJob(Job):
         user specified path
         """
 
-        if self.dataset is None:
-            self.load_dataset()
-
-        if self.custom_mean_path is None:
-            # The user never set the mean path, so the dataset's mean path should be used
-            return self.dataset.path(self.dataset.get_mean_file())
-        else:
+        if self.custom_mean_path is not None:
             # The user has specified the file path to use
-            return self.dataset.path(self.custom_mean_path)
+            return self.custom_mean_path
+
+        if self.dataset is None:
+            # Cannot retrieve the mean path, as it isn't loaded anymore
+            return None
+        else:
+            # The user never set the mean path, so the dataset's mean path should be used
+            if self.custom_mean_path is None:
+                return self.dataset.path(self.dataset.get_mean_file())

--- a/digits/model/job.py
+++ b/digits/model/job.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+from os import path
+
 from . import tasks
 from digits.job import Job
 from digits.utils import override
@@ -20,6 +22,8 @@ class ModelJob(Job):
         """
         super(ModelJob, self).__init__(**kwargs)
         self.pickver_job_dataset = PICKLE_VERSION
+
+        self.custom_mean_path = None
 
         self.dataset_id = dataset_id
         self.load_dataset()
@@ -63,3 +67,28 @@ class ModelJob(Job):
         These files get added to an archive when this job is downloaded
         """
         return NotImplementedError()
+
+    def set_custom_mean_path(self, custom_mean_path):
+        """
+        Set the path to a custom mean image protoblob to be used by the model job. If the custom mean path is None, it
+        should be assumed that the mean image will be that of the dataset.
+        returns: True if the custom_mean_path was successfully set, False otherwise
+        """
+        if custom_mean_path != '' and path.isfile(custom_mean_path) is True:
+            self.custom_mean_path = custom_mean_path
+            return True
+        else:
+            return False
+
+    def get_mean_path(self):
+        """
+        returns the file path to the mean image protoblob\jpg\file, which is either the dataset's (default) or some
+        user specified path
+        """
+
+        if self.custom_mean_path is None:
+            # The user never set the mean path, so the dataset's mean path should be used
+            return self.dataset.path(self.dataset.get_mean_file())
+        else:
+            # The user has specified the file path to use
+            return self.dataset.path(self.custom_mean_path)

--- a/digits/model/job.py
+++ b/digits/model/job.py
@@ -86,6 +86,9 @@ class ModelJob(Job):
         user specified path
         """
 
+        if self.dataset is None:
+            self.load_dataset()
+
         if self.custom_mean_path is None:
             # The user never set the mean path, so the dataset's mean path should be used
             return self.dataset.path(self.dataset.get_mean_file())

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -223,16 +223,6 @@ class CaffeTrainTask(TrainTask):
 
         layer.transform_param.mean_file = mean_file
 
-    def get_mean_path(self):
-        # returns the file path to the mean image protoblob, which is either the dataset's (default) or some user
-        #  specified path
-        if self.mean_path is None:
-            # The user never set the mean path, so the dataset's mean path should be used
-            return self.dataset.get_mean_file()
-        else:
-            # The user has specified the file path to use
-            return self.mean_path
-
     # TODO merge these monolithic save_files functions
     def save_files_classification(self):
         """

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -223,6 +223,16 @@ class CaffeTrainTask(TrainTask):
 
         layer.transform_param.mean_file = mean_file
 
+    def get_mean_path(self):
+        # returns the file path to the mean image protoblob, which is either the dataset's (default) or some user
+        #  specified path
+        if self.mean_path is None:
+            # The user never set the mean path, so the dataset's mean path should be used
+            return self.dataset.get_mean_file()
+        else:
+            # The user has specified the file path to use
+            return self.mean_path
+
     # TODO merge these monolithic save_files functions
     def save_files_classification(self):
         """
@@ -334,15 +344,15 @@ class CaffeTrainTask(TrainTask):
 
         if self.use_mean == 'pixel':
             assert dataset_backend != 'hdf5', 'HDF5Data layer does not support mean subtraction'
-            mean_pixel = self.get_mean_pixel(self.dataset.path(self.dataset.get_mean_file()))
+            mean_pixel = self.get_mean_pixel(self.dataset.path(self.get_mean_path()))
             self.set_mean_value(train_data_layer, mean_pixel)
             if val_data_layer is not None and has_val_set:
                 self.set_mean_value(val_data_layer, mean_pixel)
 
         elif self.use_mean == 'image':
-            self.set_mean_file(train_data_layer, self.dataset.path(self.dataset.get_mean_file()))
+            self.set_mean_file(train_data_layer, self.dataset.path(self.get_mean_path()))
             if val_data_layer is not None and has_val_set:
-                self.set_mean_file(val_data_layer, self.dataset.path(self.dataset.get_mean_file()))
+                self.set_mean_file(val_data_layer, self.dataset.path(self.get_mean_path()))
 
         if self.batch_size:
             if dataset_backend == 'lmdb':
@@ -767,13 +777,13 @@ class CaffeTrainTask(TrainTask):
             layer.data_param.batch_size = self.batch_size
 
         # mean
-        if name == 'data' and self.dataset.get_mean_file():
+        if name == 'data' and self.get_mean_path():
             if self.use_mean == 'pixel':
-                mean_pixel = self.get_mean_pixel(self.dataset.path(self.dataset.get_mean_file()))
+                mean_pixel = self.get_mean_pixel(self.dataset.path(self.get_mean_path()))
                 ## remove any values that may already be in the network
                 self.set_mean_value(layer, mean_pixel)
             elif self.use_mean == 'image':
-                self.set_mean_file(layer, self.dataset.path(self.dataset.get_mean_file()))
+                self.set_mean_file(layer, self.dataset.path(self.get_mean_path()))
 
         # crop size
         if name == 'data' and self.crop_size:
@@ -1388,11 +1398,12 @@ class CaffeTrainTask(TrainTask):
             # XXX see issue #59
             channel_swap = (2,1,0)
 
-        if self.dataset.get_mean_file():
+        if self.get_mean_path() or self.mean_path is not None:
+
             if self.use_mean == 'pixel':
-                mean_pixel = self.get_mean_pixel(self.dataset.path(self.dataset.get_mean_file()))
+                mean_pixel = self.get_mean_pixel(self.dataset.path(self.get_mean_path()))
             elif self.use_mean == 'image':
-                mean_image = self.get_mean_image(self.dataset.path(self.dataset.get_mean_file()), True)
+                mean_image = self.get_mean_image(self.dataset.path(self.get_mean_path()), True)
 
         t = caffe.io.Transformer(
                 inputs = {'data': tuple(data_shape)}

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -334,15 +334,15 @@ class CaffeTrainTask(TrainTask):
 
         if self.use_mean == 'pixel':
             assert dataset_backend != 'hdf5', 'HDF5Data layer does not support mean subtraction'
-            mean_pixel = self.get_mean_pixel(self.dataset.path(self.get_mean_path()))
+            mean_pixel = self.get_mean_pixel(self.job.get_mean_path())
             self.set_mean_value(train_data_layer, mean_pixel)
             if val_data_layer is not None and has_val_set:
                 self.set_mean_value(val_data_layer, mean_pixel)
 
         elif self.use_mean == 'image':
-            self.set_mean_file(train_data_layer, self.dataset.path(self.get_mean_path()))
+            self.set_mean_file(train_data_layer, self.job.get_mean_path())
             if val_data_layer is not None and has_val_set:
-                self.set_mean_file(val_data_layer, self.dataset.path(self.get_mean_path()))
+                self.set_mean_file(val_data_layer, self.job.get_mean_path())
 
         if self.batch_size:
             if dataset_backend == 'lmdb':
@@ -769,11 +769,11 @@ class CaffeTrainTask(TrainTask):
         # mean
         if name == 'data' and self.get_mean_path():
             if self.use_mean == 'pixel':
-                mean_pixel = self.get_mean_pixel(self.dataset.path(self.get_mean_path()))
+                mean_pixel = self.get_mean_pixel(self.job.get_mean_path())
                 ## remove any values that may already be in the network
                 self.set_mean_value(layer, mean_pixel)
             elif self.use_mean == 'image':
-                self.set_mean_file(layer, self.dataset.path(self.get_mean_path()))
+                self.set_mean_file(layer, self.job.get_mean_path())
 
         # crop size
         if name == 'data' and self.crop_size:
@@ -1388,12 +1388,12 @@ class CaffeTrainTask(TrainTask):
             # XXX see issue #59
             channel_swap = (2,1,0)
 
-        if self.get_mean_path() or self.mean_path is not None:
+        if self.job.get_mean_path():
 
             if self.use_mean == 'pixel':
-                mean_pixel = self.get_mean_pixel(self.dataset.path(self.get_mean_path()))
+                mean_pixel = self.get_mean_pixel(self.job.get_mean_path())
             elif self.use_mean == 'image':
-                mean_image = self.get_mean_image(self.dataset.path(self.get_mean_path()), True)
+                mean_image = self.get_mean_image(self.job.get_mean_path(), True)
 
         t = caffe.io.Transformer(
                 inputs = {'data': tuple(data_shape)}

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -334,15 +334,15 @@ class CaffeTrainTask(TrainTask):
 
         if self.use_mean == 'pixel':
             assert dataset_backend != 'hdf5', 'HDF5Data layer does not support mean subtraction'
-            mean_pixel = self.get_mean_pixel(self.job.get_mean_path())
+            mean_pixel = self.get_mean_pixel(self.get_mean_path())
             self.set_mean_value(train_data_layer, mean_pixel)
             if val_data_layer is not None and has_val_set:
                 self.set_mean_value(val_data_layer, mean_pixel)
 
         elif self.use_mean == 'image':
-            self.set_mean_file(train_data_layer, self.job.get_mean_path())
+            self.set_mean_file(train_data_layer, self.get_mean_path())
             if val_data_layer is not None and has_val_set:
-                self.set_mean_file(val_data_layer, self.job.get_mean_path())
+                self.set_mean_file(val_data_layer, self.get_mean_path())
 
         if self.batch_size:
             if dataset_backend == 'lmdb':
@@ -767,7 +767,7 @@ class CaffeTrainTask(TrainTask):
             layer.data_param.batch_size = self.batch_size
 
         # mean
-        if name == 'data' and self.get_mean_path():
+        if name == 'data' and self.job.get_mean_path():
             if self.use_mean == 'pixel':
                 mean_pixel = self.get_mean_pixel(self.job.get_mean_path())
                 ## remove any values that may already be in the network

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -112,7 +112,7 @@ class TorchTrainTask(TrainTask):
         filename = os.path.join(self.job_dir, constants.MEAN_FILE_IMAGE)
         # don't recreate file if it already exists
         if not os.path.exists(filename):
-            mean_file = self.dataset.get_mean_file()
+            mean_file = self.get_mean_path()
             assert mean_file != None and mean_file.endswith('.binaryproto'), 'Mean subtraction required but dataset has no mean file in .binaryproto format'
             blob = caffe_pb2.BlobProto()
             with open(self.dataset.path(mean_file),'rb') as infile:
@@ -516,7 +516,7 @@ class TorchTrainTask(TrainTask):
 
         if self.use_mean != 'none':
             filename = self.create_mean_file()
-            args.append('--mean=%s' % os.path.join(self.job_dir, constants.MEAN_FILE_IMAGE))
+            args.append('--mean=%s' % filename)
 
         if self.use_mean == 'pixel':
             args.append('--subtractMean=pixel')
@@ -820,7 +820,7 @@ class TorchTrainTask(TrainTask):
 
             if self.use_mean != 'none':
                 filename = self.create_mean_file()
-                args.append('--mean=%s' % os.path.join(self.job_dir, constants.MEAN_FILE_IMAGE))
+                args.append('--mean=%s' % filename)
 
             if self.use_mean == 'pixel':
                 args.append('--subtractMean=pixel')

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -111,8 +111,8 @@ class TorchTrainTask(TrainTask):
     def create_mean_file(self):
         filename = os.path.join(self.job_dir, constants.MEAN_FILE_IMAGE)
         # don't recreate file if it already exists, unless user has specified a non-db mean path
-        if not os.path.exists(filename) or self.mean_path is not None:
-            mean_file = self.get_mean_path()
+        if not os.path.exists(filename):
+            mean_file = self.job.get_mean_path()
             assert mean_file != None and mean_file.endswith('.binaryproto'), 'Mean subtraction required but dataset has no mean file in .binaryproto format'
             blob = caffe_pb2.BlobProto()
             with open(self.dataset.path(mean_file),'rb') as infile:

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -110,8 +110,8 @@ class TorchTrainTask(TrainTask):
 
     def create_mean_file(self):
         filename = os.path.join(self.job_dir, constants.MEAN_FILE_IMAGE)
-        # don't recreate file if it already exists
-        if not os.path.exists(filename):
+        # don't recreate file if it already exists, unless user has specified a non-db mean path
+        if not os.path.exists(filename) or self.mean_path is not None:
             mean_file = self.get_mean_path()
             assert mean_file != None and mean_file.endswith('.binaryproto'), 'Mean subtraction required but dataset has no mean file in .binaryproto format'
             blob = caffe_pb2.BlobProto()

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -121,6 +121,16 @@ class TrainTask(Task):
         self.snapshots = []
         self.dataset = None
 
+    def get_mean_path(self):
+        # returns the file path to the mean image protoblob\jpg\file, which is either the dataset's (default) or some
+        # user specified path
+        if self.mean_path is None:
+            # The user never set the mean path, so the dataset's mean path should be used
+            return self.dataset.get_mean_file()
+        else:
+            # The user has specified the file path to use
+            return self.mean_path
+
     @override
     def offer_resources(self, resources):
         if 'gpus' not in resources:

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -58,6 +58,7 @@ class TrainTask(Task):
         self.shuffle = kwargs.pop('shuffle', None)
         self.network = kwargs.pop('network', None)
         self.framework_id = kwargs.pop('framework_id', None)
+        self.mean_path = kwargs.pop('mean_path', None)
 
         super(TrainTask, self).__init__(job_dir = job.dir(), **kwargs)
         self.pickver_task_train = PICKLE_VERSION

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -59,6 +59,8 @@ class TrainTask(Task):
         self.network = kwargs.pop('network', None)
         self.framework_id = kwargs.pop('framework_id', None)
         self.mean_path = kwargs.pop('mean_path', None)
+        if self.mean_path == '':
+            self.mean_path = None
 
         super(TrainTask, self).__init__(job_dir = job.dir(), **kwargs)
         self.pickver_task_train = PICKLE_VERSION

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -550,3 +550,15 @@ class TrainTask(Task):
         """
         raise NotImplementedError()
 
+    def get_mean_path(self):
+        """
+        return the path to the mean protoblob image to use. Defers to the model job, unless that returns false
+        (typically because the dataset for the job has been cleared) after which the Task dataset's mean path is used
+        """
+        mean_path = self.job.get_mean_path()
+
+        if mean_path is None:
+            return self.dataset.path(self.dataset.get_mean_file())
+        else:
+            return mean_path
+

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -58,14 +58,14 @@ class TrainTask(Task):
         self.shuffle = kwargs.pop('shuffle', None)
         self.network = kwargs.pop('network', None)
         self.framework_id = kwargs.pop('framework_id', None)
-        self.mean_path = kwargs.pop('mean_path', None)
-        if self.mean_path == '':
-            self.mean_path = None
+        temp_custom_mean_path = kwargs.pop('custom_mean_path', None)
 
         super(TrainTask, self).__init__(job_dir = job.dir(), **kwargs)
         self.pickver_task_train = PICKLE_VERSION
 
         self.job = job
+        self.job.set_custom_mean_path(temp_custom_mean_path)
+
         self.dataset = dataset
         self.train_epochs = train_epochs
         self.snapshot_interval = snapshot_interval
@@ -120,16 +120,6 @@ class TrainTask(Task):
 
         self.snapshots = []
         self.dataset = None
-
-    def get_mean_path(self):
-        # returns the file path to the mean image protoblob\jpg\file, which is either the dataset's (default) or some
-        # user specified path
-        if self.mean_path is None:
-            # The user never set the mean path, so the dataset's mean path should be used
-            return self.dataset.get_mean_file()
-        else:
-            # The user has specified the file path to use
-            return self.mean_path
 
     @override
     def offer_resources(self, resources):

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -366,10 +366,10 @@ showHideAdvancedLROptions();
                     {{form.use_mean.tooltip}}
                     {{form.use_mean(class='form-control')}}
                 </div>
-                <div class="form-group{{mark_errors([form.mean_path])}}">
-                    {{form.mean_path.label}}
-                    {{form.mean_path.tooltip}}
-                    {{form.mean_path(class='form-control autocomplete_path')}}
+                <div class="form-group{{mark_errors([form.custom_mean_path])}}">
+                    {{form.custom_mean_path.label}}
+                    {{form.custom_mean_path.tooltip}}
+                    {{form.custom_mean_path(class='form-control autocomplete_path')}}
                 </div>
             </div>
         </div>

--- a/digits/templates/models/images/classification/new.html
+++ b/digits/templates/models/images/classification/new.html
@@ -366,6 +366,11 @@ showHideAdvancedLROptions();
                     {{form.use_mean.tooltip}}
                     {{form.use_mean(class='form-control')}}
                 </div>
+                <div class="form-group{{mark_errors([form.mean_path])}}">
+                    {{form.mean_path.label}}
+                    {{form.mean_path.tooltip}}
+                    {{form.mean_path(class='form-control autocomplete_path')}}
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Currently, when applying mean subtraction during the training of a model, the user is only able to use the mean image or pixels from the dataset on which the model is being trained. This pull request adds the option of specifying a path to a protoblob file containing a different mean image. 

This feature is useful when doing transfer learning: An already trained model is adapted for use with a new target dataset, but it is desired to maintain interoperability with the original source dataset. If the mean of the target dataset is significantly different from the source dataset, the performance of the new model on the source dataset will be needlessly negatively impacted by this discrepancy. By specifying the mean_path to be used for mean subtraction as the protoblob of the source dataset, the new model will still be applicable to the original source dataset.