### PR TITLE
Fix path to kitti devkit in data preparation script

### DIFF
--- a/examples/object-detection/prepare_kitti_data.py
+++ b/examples/object-detection/prepare_kitti_data.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
     )
     print 'Calculating image to video mapping ...'
     mapping = get_image_to_video_mapping(
-        os.path.join(args.output_dir, 'raw', 'devkit'),
+        os.path.join(args.output_dir, 'raw'),
     )
     print 'Splitting images by video ...'
     split_by_video(


### PR DESCRIPTION
The script seems to assume that files from `devkit_object.zip` will be uncompressed into a folder `devkit` however that is not the case when using the archive from KITTI (?).