### PR TITLE
Remove unnecessary print messages for LMDB mapsize

### DIFF
--- a/digits/dataset/images/generic/test_lmdb_creator.py
+++ b/digits/dataset/images/generic/test_lmdb_creator.py
@@ -144,7 +144,6 @@ def _write_to_lmdb(db, key, value):
             # double the map_size
             curr_limit = db.info()['map_size']
             new_limit = curr_limit*2
-            print '>>> Doubling LMDB map size to %sMB ...' % (new_limit>>20,)
             db.set_mapsize(new_limit) # double it
 
 def _save_mean(mean, filename):

--- a/examples/siamese/create_db.py
+++ b/examples/siamese/create_db.py
@@ -187,7 +187,6 @@ def _write_batch_to_lmdb(db, batch):
         # double the map_size
         curr_limit = db.info()['map_size']
         new_limit = curr_limit*2
-        print('Doubling LMDB map size to %sMB ...' % (new_limit>>20,))
         try:
             db.set_mapsize(new_limit) # double it
         except AttributeError as e:

--- a/examples/text-classification/create_dataset.py
+++ b/examples/text-classification/create_dataset.py
@@ -131,7 +131,6 @@ def _write_batch_to_lmdb(db, batch):
         # double the map_size
         curr_limit = db.info()['map_size']
         new_limit = curr_limit*2
-        print('Doubling LMDB map size to %sMB ...' % (new_limit>>20,))
         try:
             db.set_mapsize(new_limit) # double it
         except AttributeError as e:

--- a/tools/create_db.py
+++ b/tools/create_db.py
@@ -653,7 +653,6 @@ def _write_batch_lmdb(db, batch, image_count):
         # double the map_size
         curr_limit = db.info()['map_size']
         new_limit = curr_limit*2
-        logger.debug('Doubling LMDB map size to %sMB ...' % (new_limit>>20,))
         try:
             db.set_mapsize(new_limit) # double it
         except AttributeError as e:

--- a/tools/create_generic_db.py
+++ b/tools/create_generic_db.py
@@ -200,8 +200,6 @@ class LmdbWriter(DbWriter):
             # double the map_size
             curr_limit = db.info()['map_size']
             new_limit = curr_limit*2
-            logger.info(
-                'Doubling LMDB map size to %sMB ...' % (new_limit >> 20,))
             try:
                 db.set_mapsize(new_limit)  # double it
             except AttributeError as e:


### PR DESCRIPTION
There's really no need for these