### PR TITLE
Update documentation to add python-opencv package

### DIFF
--- a/docs/BuildCaffe.md
+++ b/docs/BuildCaffe.md
@@ -14,7 +14,7 @@ For best performance, you'll want:
 
 Install some dependencies with Deb packages:
 ```sh
-sudo apt-get install --no-install-recommends build-essential cmake git gfortran libatlas-base-dev libboost-all-dev libgflags-dev libgoogle-glog-dev libhdf5-serial-dev libleveldb-dev liblmdb-dev libopencv-dev libprotobuf-dev libsnappy-dev protobuf-compiler python-all-dev python-dev python-h5py python-matplotlib python-numpy python-pil python-pip python-protobuf python-scipy python-skimage python-sklearn
+sudo apt-get install --no-install-recommends build-essential cmake git gfortran libatlas-base-dev libboost-all-dev libgflags-dev libgoogle-glog-dev libhdf5-serial-dev libleveldb-dev liblmdb-dev libopencv-dev libprotobuf-dev libsnappy-dev protobuf-compiler python-all-dev python-dev python-h5py python-matplotlib python-numpy python-opencv python-pil python-pip python-protobuf python-scipy python-skimage python-sklearn
 ```
 
 ## Download source


### PR DESCRIPTION
NVcaffe added a dependency on the Python bindings for OpenCV with https://github.com/NVIDIA/caffe/pull/144. Unfortunately, there doesn't seem to be a PyPI package for OpenCV, so we can't fix this just by updating `$CAFFE_HOME/python/requirements.txt`.