### PR TITLE
Add a hash to cached assets (.js and .css files)

### DIFF
--- a/digits/templates/error.html
+++ b/digits/templates/error.html
@@ -3,8 +3,8 @@
 <html>
 <head>
 <link rel="icon" href="{{url_for('static', filename='images/nvidia.ico')}}" />
-<link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-theme.min.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css', ver=dir_hash) }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-theme.min.css', ver=dir_hash) }}">
 </head>
 
 <body>

--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -5,12 +5,12 @@
 {% extends "layout.html" %}
 
 {% block head %}
-<script type="text/javascript" src="{{ url_for('static', filename='js/jquery.time_filters.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/angular.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/ngStorage.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/jquery.sparkline.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/home_app.js') }}"></script>
-<link rel="stylesheet" href="{{ url_for('static', filename='css/table_selection.css') }}">
+<script type="text/javascript" src="{{ url_for('static', filename='js/jquery.time_filters.js', ver=dir_hash) }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/angular.min.js', ver=dir_hash) }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/ngStorage.min.js', ver=dir_hash) }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/jquery.sparkline.min.js', ver=dir_hash) }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/home_app.js', ver=dir_hash) }}"></script>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/table_selection.css', ver=dir_hash) }}">
 
 {% with namespace = "/jobs" %}
     {% set room = "job_management" %}

--- a/digits/templates/layout.html
+++ b/digits/templates/layout.html
@@ -3,25 +3,25 @@
 <!doctype html>
 <head>
     <link rel="icon" href="{{url_for('static', filename='images/nvidia.ico')}}" />
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-theme.min.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/c3.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css', ver=dir_hash) }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-theme.min.css', ver=dir_hash) }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css', ver=dir_hash) }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/c3.min.css', ver=dir_hash) }}">
     <title>{% block title %}DIGITS{% endblock %}</title>
 
-    <script src="{{ url_for('static', filename='js/jquery-1.11.1.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/bootbox.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/digits.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/d3.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/c3.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/jquery.autocomplete.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/file_field.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery-1.11.1.min.js', ver=dir_hash) }}"></script>
+    <script src="{{ url_for('static', filename='js/bootstrap.min.js', ver=dir_hash) }}"></script>
+    <script src="{{ url_for('static', filename='js/bootbox.min.js', ver=dir_hash) }}"></script>
+    <script src="{{ url_for('static', filename='js/digits.js', ver=dir_hash) }}"></script>
+    <script src="{{ url_for('static', filename='js/d3.min.js', ver=dir_hash) }}"></script>
+    <script src="{{ url_for('static', filename='js/c3.min.js', ver=dir_hash) }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery.autocomplete.min.js', ver=dir_hash) }}"></script>
+    <script src="{{ url_for('static', filename='js/file_field.js', ver=dir_hash) }}"></script>
 
-    <script src="{{ url_for('static', filename='js/ace/ace.js') }}" type="text/javascript" charset="utf-8"></script>
-    <script src="{{ url_for('static', filename='js/ace/mode-python.js') }}" type="text/javascript" charset="utf-8"></script>
-    <script src="{{ url_for('static', filename='js/ace/mode-lua.js') }}" type="text/javascript" charset="utf-8"></script>
-    <script src="{{ url_for('static', filename='js/ace/theme-chrome.js') }}" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ url_for('static', filename='js/ace/ace.js', ver=dir_hash) }}" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ url_for('static', filename='js/ace/mode-python.js', ver=dir_hash) }}" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ url_for('static', filename='js/ace/mode-lua.js', ver=dir_hash) }}" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ url_for('static', filename='js/ace/theme-chrome.js', ver=dir_hash) }}" type="text/javascript" charset="utf-8"></script>
     {% block head %}
     {% endblock %}
 </head>

--- a/digits/templates/models/images/classification/classify_one.html
+++ b/digits/templates/models/images/classification/classify_one.html
@@ -8,7 +8,7 @@
 
 {% block job_content %}
 
-<script src="{{ url_for('static', filename='js/jquery.elevateZoom.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/jquery.elevateZoom.min.js', ver=dir_hash) }}"></script>
 
 <div class="page-header">
     <h1>

--- a/digits/templates/models/images/classification/large_graph.html
+++ b/digits/templates/models/images/classification/large_graph.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block head %}
-<script src="{{ url_for('static', filename='js/model-graphs.js') }}"></script>
+<script src="{{ url_for('static', filename='js/model-graphs.js', ver=dir_hash) }}"></script>
 {% endblock %}
 
 {% block nav %}

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -5,7 +5,7 @@
 
 {% block job_content %}
 
-<script src="{{ url_for('static', filename='js/model-graphs.js') }}"></script>
+<script src="{{ url_for('static', filename='js/model-graphs.js', ver=dir_hash) }}"></script>
 
 {% set task = job.train_task() %}
 

--- a/digits/templates/models/images/generic/infer_one.html
+++ b/digits/templates/models/images/generic/infer_one.html
@@ -8,7 +8,7 @@
 
 {% block job_content %}
 
-<script src="{{ url_for('static', filename='js/jquery.elevateZoom.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/jquery.elevateZoom.min.js', ver=dir_hash) }}"></script>
 
 <div class="page-header">
     <h1>

--- a/digits/templates/models/images/generic/large_graph.html
+++ b/digits/templates/models/images/generic/large_graph.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block head %}
-<script src="{{ url_for('static', filename='js/model-graphs.js') }}"></script>
+<script src="{{ url_for('static', filename='js/model-graphs.js', ver=dir_hash) }}"></script>
 {% endblock %}
 
 {% block nav %}

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -5,7 +5,7 @@
 
 {% block job_content %}
 
-<script src="{{ url_for('static', filename='js/model-graphs.js') }}"></script>
+<script src="{{ url_for('static', filename='js/model-graphs.js', ver=dir_hash) }}"></script>
 
 {% set task = job.train_task() %}
 

--- a/digits/webapp.py
+++ b/digits/webapp.py
@@ -7,6 +7,7 @@ from gevent import monkey; monkey.patch_all()
 
 from .config import config_value
 from digits import utils
+from digits.utils import filesystem as fs
 import digits.scheduler
 
 ### Create Flask, Scheduler and SocketIO objects
@@ -27,6 +28,7 @@ app.jinja_env.globals['server_name'] = config_value('server_name')
 app.jinja_env.globals['server_version'] = digits.__version__
 app.jinja_env.globals['caffe_version'] = config_value('caffe_root')['ver_str']
 app.jinja_env.globals['caffe_flavor'] = config_value('caffe_root')['flavor']
+app.jinja_env.globals['dir_hash'] = fs.dir_hash('digits/static')
 app.jinja_env.filters['print_time'] = utils.time_filters.print_time
 app.jinja_env.filters['print_time_diff'] = utils.time_filters.print_time_diff
 app.jinja_env.filters['print_time_since'] = utils.time_filters.print_time_since


### PR DESCRIPTION
When moving between versions of DIGITS changes in javascript content can cause render issues.

git checkout 74afccb
reload the DIGITS home page, click on a job name to navigate to a job page,
git checkout d0b407a
Use the DIGITS link in the upper left corner to navigate back to the home page.

The content of the app javascript file has changed, however the file is cached in session by the name, and the name has not changed. To flush the cache a hash for the static directory is being added to the url for the .js and .css files.