### PR TITLE
Stop setting cache timeout in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
         - CAFFE_FORK=NVIDIA CAFFE_BRANCH=caffe-0.14
 
 cache:
-    timeout: 604800  # 1 week
     apt: true
     directories:
         - ~/caffe


### PR DESCRIPTION
It refers to the caching command timeout (https://github.com/travis-ci/travis-ci/issues/6317#issuecomment-233065994), not how long before the caches expire as I had thought.