### PR TITLE
[DONT MERGE] Plug-in examples

### DIFF
--- a/digits/extensions/data/__init__.py
+++ b/digits/extensions/data/__init__.py
@@ -1,15 +1,22 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+import copy
+from pkg_resources import iter_entry_points
+
 from . import imageGradients
 from . import objectDetection
 
-data_extensions = [
-    # Set show=True if extension should be shown by default
-    # on DIGITS home page. These defaults can be changed by
-    # editing DIGITS config option 'data_extension_list'
-    {'class': imageGradients.DataIngestion, 'show': False},
-    {'class': objectDetection.DataIngestion, 'show': True},
+
+# Entry point group (this is the key we use to register and
+# find installed plug-ins)
+GROUP = "digits.plugins.data"
+
+
+# built-in extensions
+builtin_data_extensions = [
+    imageGradients.DataIngestion,
+    objectDetection.DataIngestion,
 ]
 
 
@@ -17,17 +24,21 @@ def get_extensions(show_all=False):
     """
     return set of data data extensions
     """
-    return [extension['class']
-            for extension in data_extensions
-            if show_all or extension['show']]
+    extensions = copy.copy(builtin_data_extensions)
+    # find installed extension plug-ins
+    for entry_point in iter_entry_points(group=GROUP, name=None):
+        extensions.append(entry_point.load())
+
+    return [extension
+            for extension in extensions
+            if show_all or extension.get_default_visibility()]
 
 
 def get_extension(extension_id):
     """
     return extension associated with specified extension_id
     """
-    for extension in data_extensions:
-        extension_class = extension['class']
-        if extension_class.get_id() == extension_id:
-            return extension_class
+    for extension in get_extensions(show_all=True):
+        if extension.get_id() == extension_id:
+            return extension
     return None

--- a/digits/extensions/data/imageGradients/data.py
+++ b/digits/extensions/data/imageGradients/data.py
@@ -46,6 +46,14 @@ class DataIngestion(DataIngestionInterface):
         return "Images"
 
     @staticmethod
+    def get_default_visibility():
+        """
+        Return whether to show extension in GUI (can be overwridden through
+        DIGITS configuration options)
+        """
+        return False
+
+    @staticmethod
     @override
     def get_id():
         return "image-gradients"

--- a/digits/extensions/data/interface.py
+++ b/digits/extensions/data/interface.py
@@ -37,6 +37,14 @@ class DataIngestionInterface(object):
         raise NotImplementedError
 
     @staticmethod
+    def get_default_visibility():
+        """
+        Return whether to show extension in GUI (can be overridden through
+        DIGITS configuration options)
+        """
+        return True
+
+    @staticmethod
     def get_dataset_template(form):
         """
         Parameters:

--- a/digits/extensions/view/__init__.py
+++ b/digits/extensions/view/__init__.py
@@ -1,18 +1,24 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
+import copy
+from pkg_resources import iter_entry_points
+
 from . import boundingBox
 from . import imageGradients
 from . import rawData
 
-view_extensions = [
-    # Set show=True if extension should be shown by default
-    # in the 'Select Visualization Method' dialog. These defaults
-    # can be changed by editing DIGITS config option
-    # 'view_extension_list'
-    {'class': boundingBox.Visualization, 'show': True},
-    {'class': imageGradients.Visualization, 'show': False},
-    {'class': rawData.Visualization, 'show': True},
+
+# Entry point group (this is the key we use to register and
+# find installed plug-ins)
+GROUP = "digits.plugins.view"
+
+
+# built-in extensions
+builtin_view_extensions = [
+    boundingBox.Visualization,
+    imageGradients.Visualization,
+    rawData.Visualization,
 ]
 
 
@@ -27,17 +33,21 @@ def get_extensions(show_all=False):
     """
     return set of data data extensions
     """
-    return [extension['class']
-            for extension in view_extensions
-            if show_all or extension['show']]
+    extensions = copy.copy(builtin_view_extensions)
+    # find installed extension plug-ins
+    for entry_point in iter_entry_points(group=GROUP, name=None):
+        extensions.append(entry_point.load())
+
+    return [extension
+            for extension in extensions
+            if show_all or extension.get_default_visibility()]
 
 
 def get_extension(extension_id):
     """
     return extension associated with specified extension_id
     """
-    for extension in view_extensions:
-        extension_class = extension['class']
-        if extension_class.get_id() == extension_id:
-            return extension_class
+    for extension in get_extensions(show_all=True):
+        if extension.get_id() == extension_id:
+            return extension
     return None

--- a/digits/extensions/view/imageGradients/view.py
+++ b/digits/extensions/view/imageGradients/view.py
@@ -70,6 +70,14 @@ class Visualization(VisualizationInterface):
         return (template, context)
 
     @staticmethod
+    def get_default_visibility():
+        """
+        Return whether to show extension in GUI (can be overwridden through
+        DIGITS configuration options)
+        """
+        return False
+
+    @staticmethod
     def get_id():
         return digits.extensions.data.imageGradients.data.DataIngestion.get_id()
 

--- a/digits/extensions/view/interface.py
+++ b/digits/extensions/view/interface.py
@@ -32,6 +32,14 @@ class VisualizationInterface(object):
         """
         raise NotImplementedError
 
+    @staticmethod
+    def get_default_visibility():
+        """
+        Return whether to show extension in GUI (can be overridden through
+        DIGITS configuration options)
+        """
+        return True
+
     def get_header_template(self):
         """
         This returns the content to be rendered at the top of the result

--- a/plugins/data/dummyData/MANIFEST.in
+++ b/plugins/data/dummyData/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include dummyData *.html

--- a/plugins/data/dummyData/README
+++ b/plugins/data/dummyData/README
@@ -1,0 +1,1 @@
+This is a simple example to show how to create a data plug-in in DIGITS.

--- a/plugins/data/dummyData/dummyData/__init__.py
+++ b/plugins/data/dummyData/dummyData/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .data import DataIngestion

--- a/plugins/data/dummyData/dummyData/data.py
+++ b/plugins/data/dummyData/dummyData/data.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from digits.utils import subclass, override, constants
+from digits.extensions.data.interface import DataIngestionInterface
+from .forms import DatasetForm
+
+import numpy as np
+import os
+
+TEMPLATE = "templates/template.html"
+
+
+@subclass
+class DataIngestion(DataIngestionInterface):
+    """
+    A data ingestion extension for an image gradient dataset
+    """
+
+    def __init__(self, **kwargs):
+        super(DataIngestion, self).__init__(**kwargs)
+
+        # Used to calculate the gradients later
+        self.yy, self.xx = np.mgrid[:self.image_height,
+                                    :self.image_width].astype('float')
+
+    @override
+    def encode_entry(self, entry):
+        xslope, yslope = np.random.random_sample(2) - 0.5
+        label = np.array([xslope, yslope])
+        a = xslope * 255 / self.image_width
+        b = yslope * 255 / self.image_height
+        image = a * (self.xx - self.image_width/2) + b * (self.yy - self.image_height/2) + 127.5
+
+        image = image.astype('uint8')
+
+        # convert to 3D tensors
+        image = image[np.newaxis, ...]
+        label = label[np.newaxis, np.newaxis, ...]
+
+        return image, label
+
+    @staticmethod
+    @override
+    def get_category():
+        return "Images"
+
+    @staticmethod
+    @override
+    def get_id():
+        return "dummy-image-gradients"
+
+    @staticmethod
+    @override
+    def get_dataset_form():
+        return DatasetForm()
+
+    @staticmethod
+    @override
+    def get_dataset_template(form):
+        """
+        parameters:
+        - form: form returned by get_dataset_form(). This may be populated
+           with values if the job was cloned
+        return:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering dataset creation
+          options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        template = open(os.path.join(extension_dir, TEMPLATE), "r").read()
+        context = {'form': form}
+        return (template, context)
+
+    @staticmethod
+    @override
+    def get_title():
+        return "Dummy Image Gradients"
+
+    @override
+    def itemize_entries(self, stage):
+        if stage == constants.TRAIN_DB:
+            count = self.train_image_count
+        elif stage == constants.VAL_DB:
+            count = self.val_image_count
+        elif stage == constants.TEST_DB:
+            count = self.test_image_count
+        else:
+            raise ValueError('Unknown stage %s' % stage)
+        return xrange(count) if count > 0 else []

--- a/plugins/data/dummyData/dummyData/forms.py
+++ b/plugins/data/dummyData/dummyData/forms.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from digits import utils
+from digits.utils import subclass
+from flask.ext.wtf import Form
+import wtforms
+from wtforms import validators
+
+
+@subclass
+class DatasetForm(Form):
+    """
+    A form used to create an image gradient dataset
+    """
+
+    train_image_count = utils.forms.IntegerField(
+        'Train Image count',
+        validators=[
+            validators.DataRequired(),
+            validators.NumberRange(min=1),
+            ],
+        default=1000,
+        tooltip="Number of images to create in training set"
+        )
+
+    val_image_count = utils.forms.IntegerField(
+        'Validation Image count',
+        validators=[
+            validators.Optional(),
+            validators.NumberRange(min=0),
+            ],
+        default=250,
+        tooltip="Number of images to create in validation set"
+        )
+
+    test_image_count = utils.forms.IntegerField(
+        'Test Image count',
+        validators=[
+            validators.Optional(),
+            validators.NumberRange(min=0),
+            ],
+        default=0,
+        tooltip="Number of images to create in validation set"
+        )
+
+    image_width = wtforms.IntegerField(
+        u'Image Width',
+        default=32,
+        validators=[validators.DataRequired()]
+        )
+
+    image_height = wtforms.IntegerField(
+        u'Image Height',
+        default=32,
+        validators=[validators.DataRequired()]
+        )

--- a/plugins/data/dummyData/dummyData/templates/template.html
+++ b/plugins/data/dummyData/dummyData/templates/template.html
@@ -1,0 +1,41 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+<h1>Dummy Image Gradients</h1>
+
+<div class="form-group{{mark_errors([form.train_image_count])}}">
+    {{ form.train_image_count.label }}
+    {{ form.train_image_count.tooltip }}
+    {{ form.train_image_count(class='form-control') }}
+</div>
+
+<div class="form-group{{mark_errors([form.val_image_count])}}">
+    {{ form.val_image_count.label }}
+    {{ form.val_image_count.tooltip }}
+    {{ form.val_image_count(class='form-control') }}
+</div>
+
+<div class="form-group{{mark_errors([form.test_image_count])}}">
+    {{ form.test_image_count.label }}
+    {{ form.test_image_count.tooltip }}
+    {{ form.test_image_count(class='form-control') }}
+</div>
+
+<div class="form-group{{mark_errors([form.image_width, form.image_height])}}">
+    <label>Image size (Width x Height)</label>
+    <span name="size_dims_explanation"
+          class="explanation-tooltip glyphicon glyphicon-question-sign"
+          data-container="body"
+          title="Input images will be resized to fit."
+          ></span>
+    <div class="input-group">
+        {{ form.image_width(size=4, placeholder='width', class='form-control') }}
+        <span class="input-group-addon">x</span>
+        {{ form.image_height(size=4, placeholder='height', class='form-control') }}
+    </div>
+</div>
+
+

--- a/plugins/data/dummyData/setup.py
+++ b/plugins/data/dummyData/setup.py
@@ -1,0 +1,24 @@
+import os
+from setuptools import setup, find_packages
+
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from digits.extensions.data import GROUP as DIGITS_PLUGIN_GROUP
+
+# Utility function to read the README file.
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+setup(
+    name="digits_dummy_data_plugin",
+    version="0.0.1",
+    author="Greg Heinrich",
+    description=("A dummy data ingestion plugin"),
+    long_description=read('README'),
+    license="Apache",
+    packages=find_packages(),
+    entry_points={
+        DIGITS_PLUGIN_GROUP: [
+        'visualization=dummyData:DataIngestion',
+        ]},
+    include_package_data=True,
+)

--- a/plugins/view/dummyView/MANIFEST.in
+++ b/plugins/view/dummyView/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include dummyView *.html

--- a/plugins/view/dummyView/README
+++ b/plugins/view/dummyView/README
@@ -1,0 +1,1 @@
+This is a simple example to show how to create a view plug-in in DIGITS.

--- a/plugins/view/dummyView/dummyView/__init__.py
+++ b/plugins/view/dummyView/dummyView/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from .view import Visualization

--- a/plugins/view/dummyView/dummyView/forms.py
+++ b/plugins/view/dummyView/dummyView/forms.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from digits.utils import subclass
+from flask.ext.wtf import Form
+
+
+@subclass
+class ConfigForm(Form):
+    pass

--- a/plugins/view/dummyView/dummyView/templates/config_template.html
+++ b/plugins/view/dummyView/dummyView/templates/config_template.html
@@ -1,0 +1,7 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+<small>This dummy visualization has no configuration options</small>

--- a/plugins/view/dummyView/dummyView/templates/view_template.html
+++ b/plugins/view/dummyView/dummyView/templates/view_template.html
@@ -1,0 +1,10 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+{% for key, val in data.iteritems() %}
+	<td>{{key}}</td>
+	<td>{{data[key]}}</td>
+{% endfor %}

--- a/plugins/view/dummyView/dummyView/view.py
+++ b/plugins/view/dummyView/dummyView/view.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+import os
+
+from digits.utils import subclass, override
+from .forms import ConfigForm
+from digits.extensions.view.interface import VisualizationInterface
+
+CONFIG_TEMPLATE = "templates/config_template.html"
+VIEW_TEMPLATE = "templates/view_template.html"
+
+
+@subclass
+class Visualization(VisualizationInterface):
+    """
+    A visualization extension to display raw data
+    """
+
+    def __init__(self, dataset, **kwargs):
+        # memorize view template for later use
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        self.view_template = open(
+            os.path.join(extension_dir, VIEW_TEMPLATE), "r").read()
+
+    @staticmethod
+    def get_config_form():
+        return ConfigForm()
+
+    @staticmethod
+    def get_config_template(form):
+        """
+        parameters:
+        - form: form returned by get_config_form(). This may be populated
+        with values if the job was cloned
+        return:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering config options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        template = open(
+            os.path.join(extension_dir, CONFIG_TEMPLATE), "r").read()
+        return (template, {})
+
+    @staticmethod
+    def get_id():
+        return 'all-dummy-raw-data'
+
+    @staticmethod
+    def get_title():
+        return 'Dummy view'
+
+    @override
+    def get_view_template(self, data):
+        """
+        return:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering config options
+          - context is a dictionary of context variables to use for rendering
+          the form
+        """
+        return self.view_template, {'data': data}
+
+    @override
+    def process_data(
+            self,
+            dataset,
+            input_data,
+            inference_data,
+            ground_truth=None):
+        """
+        Process one inference output
+        Parameters:
+        - dataset: dataset used during training
+        - input_data: input to the network
+        - inference_data: network output
+        - ground_truth: Ground truth. Format is application specific.
+          None if absent.
+        Returns:
+        - an object reprensenting the processed data
+        """
+        # just return the same data and ignore ground truth
+        return inference_data

--- a/plugins/view/dummyView/setup.py
+++ b/plugins/view/dummyView/setup.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+import os
+from setuptools import setup, find_packages
+
+from digits.extensions.view import GROUP as DIGITS_PLUGIN_GROUP
+
+# Utility function to read the README file.
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+setup(
+    name="digits_dummy_view_plugin",
+    version="0.0.1",
+    author="Greg Heinrich",
+    description=("A dummy vizualisation plugin"),
+    long_description=read('README'),
+    license="Apache",
+    packages=find_packages(),
+    entry_points={
+        DIGITS_PLUGIN_GROUP: [
+        'visualization=dummyView:Visualization',
+        ]},
+    include_package_data=True,
+    #data_files=[('dummyView/config_template.html','dummyView/config_template.html')],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup, find_packages
+
+import digits
+
+setup(
+    name = "digits",
+    packages = find_packages(),
+    version = digits.__version__
+)


### PR DESCRIPTION
Simple example to show how to create a plug-in. The plug-in registers an entry point that any Python module can retrieve through the `digits.view` key (see how this is done in `digits/extensions/view/__init__.py`).

To install the plug-in:
```
pip install $DIGITS_HOME/plugins/dummyView
```

Since the plug-in requires DIGITS modules and use them through absolute imports, DIGITS must also be installed (once):
```
pip install $DIGITS_HOME
```