### PR TITLE
Make "./digits-test tools/" work again

### DIFF
--- a/tools/test_analyze_db.py
+++ b/tools/test_analyze_db.py
@@ -4,13 +4,13 @@ import os.path
 import shutil
 import tempfile
 
-import caffe.io
 import lmdb
 import numpy as np
 
 from . import analyze_db
 
 # Must import after importing digits.config
+import caffe.io
 import caffe_pb2
 
 class BaseTestWithDB(object):


### PR DESCRIPTION
Fixes this issue:
```
$ ./digits-test tools/
E............................................................................................................................
======================================================================
ERROR: Failure: ImportError (No module named caffe.io)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/lyeager/digits/tools/test_analyze_db.py", line 7, in <module>
    import caffe.io
ImportError: No module named caffe.io

----------------------------------------------------------------------
Ran 125 tests in 10.397s

FAILED (errors=1)
```