### PR TITLE
Avoid creation of CUDA context in master process operated by gunicorn

### DIFF
--- a/digits/device_query.py
+++ b/digits/device_query.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import argparse
 import ctypes
 import platform
+from multiprocessing import Process, Pipe
 
 class c_cudaDeviceProp(ctypes.Structure):
     """
@@ -160,18 +161,7 @@ def get_nvml():
 
 devices = None
 
-def get_devices(force_reload=False):
-    """
-    Returns a list of c_cudaDeviceProp's
-    Prints an error and returns None if something goes wrong
-
-    Keyword arguments:
-    force_reload -- if False, return the previously loaded list of devices
-    """
-    global devices
-    if not force_reload and devices is not None:
-        # Only query CUDA once
-        return devices
+def get_devices_process(force_reload, conn):
     devices = []
 
     cudart = get_cudart()
@@ -209,6 +199,33 @@ def get_devices(force_reload=False):
         else:
             print 'cudaGetDeviceProperties() failed with error #%s' % rc
         del properties
+    
+    conn.send(devices)
+    conn.close()
+    
+def get_devices(force_reload=False):
+    """
+    Returns a list of c_cudaDeviceProp's
+    Prints an error and returns None if something goes wrong
+
+    Keyword arguments:
+    force_reload -- if False, return the previously loaded list of devices
+    """
+    global devices
+    if not force_reload and devices is not None:
+        # Only query CUDA once
+        return devices
+
+	devices = []
+
+    parent_conn, child_conn = Pipe(duplex=False)
+    process = Process(target = get_devices_process, args = (force_reload, child_conn, ))
+    process.start()
+    devices = parent_conn.recv()
+    process.join()
+    parent_conn.close()
+    child_conn.close()
+
     return devices
 
 def get_device(device_id):


### PR DESCRIPTION
```
$ cat gunicorn/arbiter.py | grep "pid = os.fork()"
        pid = os.fork()
```

Otherwise, forked worker processes will receive invalid CUDA context and crash on image testing:

```
/usr/bin/gunicorn --config gunicorn_config.py digits.webapp:app
2016-07-30 21:26:50 [5394] [INFO] Starting gunicorn 17.5
2016-07-30 21:26:50 [5394] [DEBUG] Arbiter booted
2016-07-30 21:26:50 [5394] [INFO] Listening at: http://0.0.0.0:34448 (5394)
2016-07-30 21:26:50 [5394] [INFO] Using worker: socketio.sgunicorn.GeventSocketIOWorker
2016-07-30 21:26:50 [5456] [INFO] Booting worker with pid: 5456
WARNING: Logging before InitGoogleLogging() is written to STDERR
E0730 21:27:11.797976  5456 common.cpp:110] Cannot create Cublas handle. Cublas won't be available.
E0730 21:27:11.800433  5456 common.cpp:117] Cannot create Curand generator. Curand won't be available.
E0730 21:27:11.802403  5456 common.cpp:121] Cannot create cuDNN handle. cuDNN won't be available.
F0730 21:27:11.804111  5456 syncedmem.hpp:19] Check failed: error == cudaSuccess (3 vs. 0)  initialization error
```

This patch performs necessary device querying in forked process as well, keeping master of CUDA context creation.