### PR TITLE
Use default branches for TravisCI caffe builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     global:
         - NUM_THREADS=4
     matrix:
-        - CAFFE_FORK=BVLC CAFFE_BRANCH=master
-        - CAFFE_FORK=NVIDIA CAFFE_BRANCH=caffe-0.14
+        - CAFFE_FORK=NVIDIA
+        - CAFFE_FORK=BVLC
 
 cache:
     apt: true

--- a/scripts/travis/install-caffe.sh
+++ b/scripts/travis/install-caffe.sh
@@ -13,7 +13,9 @@ fi
 INSTALL_DIR=$1
 NUM_THREADS=${NUM_THREADS:-4}
 CAFFE_FORK=${CAFFE_FORK:-"NVIDIA"}
-CAFFE_BRANCH=${CAFFE_BRANCH:-"caffe-0.14"}
+if [ ! -z "$CAFFE_BRANCH" ]; then
+    CAFFE_BRANCH="--branch ${CAFFE_BRANCH}"
+fi
 
 if [ -d "$INSTALL_DIR" ] && [ -e "$INSTALL_DIR/build/tools/caffe" ]; then
     echo "Using cached build at $INSTALL_DIR ..."
@@ -23,7 +25,7 @@ fi
 rm -rf $INSTALL_DIR
 
 # get source
-git clone https://github.com/${CAFFE_FORK}/caffe.git ${INSTALL_DIR} --branch ${CAFFE_BRANCH} --depth 1
+git clone https://github.com/${CAFFE_FORK}/caffe.git ${INSTALL_DIR} ${CAFFE_BRANCH} --depth 1
 
 # configure project
 pushd .


### PR DESCRIPTION
The default branch for NVcaffe is now 0.15:
https://github.com/NVIDIA/caffe/branches