### PR TITLE
Simplify input scaling on LeNet network

### DIFF
--- a/digits/standard-networks/caffe/lenet.prototxt
+++ b/digits/standard-networks/caffe/lenet.prototxt
@@ -3,12 +3,8 @@ name: "LeNet"
 layer {
   name: "train-data"
   type: "Data"
-  top: "scaled"
+  top: "data"
   top: "label"
-  transform_param {
-    # 1/(standard deviation)
-    scale: 0.0125
-  }
   data_param {
     batch_size: 64
   }
@@ -17,28 +13,23 @@ layer {
 layer {
   name: "val-data"
   type: "Data"
-  top: "scaled"
+  top: "data"
   top: "label"
-  transform_param {
-    # 1/(standard deviation)
-    scale: 0.0125
-  }
   data_param {
     batch_size: 32
   }
   include { stage: "val" }
 }
 layer {
-  # Use Power layer in deploy phase for input scaling
+  # Use Power layer for input scaling
   name: "scale"
   bottom: "data"
   top: "scaled"
   type: "Power"
   power_param {
-    # 1/(standard deviation)
+    # 1/(standard deviation on MNIST dataset)
     scale: 0.0125
   }
-  include { stage: "deploy" }
 }
 layer {
   name: "conv1"

--- a/digits/standard-networks/torch/lenet.lua
+++ b/digits/standard-networks/torch/lenet.lua
@@ -33,7 +33,7 @@ return function(params)
     -- -- This is a LeNet model. For more information: http://yann.lecun.com/exdb/lenet/
 
     local lenet = nn.Sequential()
-    lenet:add(nn.MulConstant(0.00390625))
+    lenet:add(nn.MulConstant(0.0125)) -- 1/(standard deviation on MNIST dataset)
     lenet:add(backend.SpatialConvolution(channels,20,5,5,1,1,0)) -- channels*28*28 -> 20*24*24
     lenet:add(backend.SpatialMaxPooling(2, 2, 2, 2)) -- 20*24*24 -> 20*12*12
     lenet:add(backend.SpatialConvolution(20,50,5,5,1,1,0)) -- 20*12*12 -> 50*8*8


### PR DESCRIPTION
Removed scaling from data layers and kept single unified power layer. Previous definition was faster due to multi-threaded data loader, but potentially less straightforward to new users.

The scaling factor 0.0125 corresponds to 1/(standard deviation on MNIST dataset), which is ~80 per pixel (from a range of [0-255] per pixel). Scaling factor comment updated to reflect this.