### PR TITLE
[digits-4.0] Explicitly use Lua LMDB wrapper version 0.9.18.1-1

### DIFF
--- a/docs/BuildTorch.md
+++ b/docs/BuildTorch.md
@@ -39,7 +39,7 @@ DIGITS requires you to install a few extra dependencies.
 sudo apt-get install --no-install-recommends libhdf5-serial-dev liblmdb-dev
 luarocks install tds
 luarocks install "https://raw.github.com/deepmind/torch-hdf5/master/hdf5-0-0.rockspec"
-luarocks install lightningmdb LMDB_INCDIR=/usr/include LMDB_LIBDIR=/usr/lib/x86_64-linux-gnu
+luarocks install lightningmdb 0.9.18.1-1 LMDB_INCDIR=/usr/include LMDB_LIBDIR=/usr/lib/x86_64-linux-gnu
 luarocks install "https://raw.github.com/Sravan2j/lua-pb/master/lua-pb-scm-0.rockspec"
 # If you have installed NCCL
 luarocks install "https://raw.githubusercontent.com/ngimel/nccl.torch/master/nccl-scm-1.rockspec"

--- a/scripts/travis/install-torch.sh
+++ b/scripts/travis/install-torch.sh
@@ -30,5 +30,4 @@ cd $INSTALL_DIR
 ${INSTALL_DIR}/install/bin/luarocks install tds
 ${INSTALL_DIR}/install/bin/luarocks install "https://raw.github.com/deepmind/torch-hdf5/master/hdf5-0-0.rockspec"
 ${INSTALL_DIR}/install/bin/luarocks install "https://raw.github.com/Sravan2j/lua-pb/master/lua-pb-scm-0.rockspec"
-${INSTALL_DIR}/install/bin/luarocks install lightningmdb LMDB_INCDIR=/usr/include LMDB_LIBDIR=/usr/lib/x86_64-linux-gnu
-
+${INSTALL_DIR}/install/bin/luarocks install lightningmdb 0.9.18.1-1 LMDB_INCDIR=/usr/include LMDB_LIBDIR=/usr/lib/x86_64-linux-gnu


### PR DESCRIPTION
*Close #974*

Cherry-pick of https://github.com/NVIDIA/DIGITS/pull/928 into `digits-4.0` branch.