### PR TITLE
Better error-checking in psutil code

### DIFF
--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -191,21 +191,22 @@ class TrainTask(Task):
         while True:
             # CPU (Non-GPU) Info
             data_cpu = {}
-            data_cpu['pid'] = self.p.pid
-            try:
-                ps = psutil.Process(self.p.pid) # 'self.p' is the system call object
-                if ps.is_running():
-                    if psutil.version_info[0] >= 2:
-                        data_cpu['cpu_pct'] = ps.cpu_percent(interval=1)
-                        data_cpu['mem_pct'] = ps.memory_percent()
-                        data_cpu['mem_used'] = ps.memory_info().rss
-                    else:
-                        data_cpu['cpu_pct'] = ps.get_cpu_percent(interval=1)
-                        data_cpu['mem_pct'] = ps.get_memory_percent()
-                        data_cpu['mem_used'] = ps.get_memory_info().rss
-            except psutil.NoSuchProcess:
-                # In rare case of instant process crash or PID went zombie (report nothing)
-                pass
+            if hasattr(self, 'p') and self.p is not None:
+                data_cpu['pid'] = self.p.pid
+                try:
+                    ps = psutil.Process(self.p.pid) # 'self.p' is the system call object
+                    if ps.is_running():
+                        if psutil.version_info[0] >= 2:
+                            data_cpu['cpu_pct'] = ps.cpu_percent(interval=1)
+                            data_cpu['mem_pct'] = ps.memory_percent()
+                            data_cpu['mem_used'] = ps.memory_info().rss
+                        else:
+                            data_cpu['cpu_pct'] = ps.get_cpu_percent(interval=1)
+                            data_cpu['mem_pct'] = ps.get_memory_percent()
+                            data_cpu['mem_used'] = ps.get_memory_info().rss
+                except psutil.NoSuchProcess:
+                    # In rare case of instant process crash or PID went zombie (report nothing)
+                    pass
 
             data_gpu = []
             for index, device in devices:


### PR DESCRIPTION
Bug from https://github.com/NVIDIA/DIGITS/pull/800.

Sometimes when a job fails there may not be a `self.p.pid`:
```
Traceback (most recent call last):
  File "/home/lyeager/digits/venv1/local/lib/python2.7/site-packages/gevent/greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "/home/lyeager/digits/digits/model/tasks/train.py", line 194, in hw_socketio_updater
    data_cpu['pid'] = self.p.pid
AttributeError: 'NoneType' object has no attribute 'pid'
<Greenlet at 0x7f492632f550: <bound method CaffeTrainTask.hw_socketio_updater of <digits.model.tasks.caffe_train.CaffeTrainTask object at 0x7f4926316190>>(['0'])> failed with AttributeError
```
I think this error is actually harmless as the thread would get killed anyway. But it's no fun seeing messages like that in the log.