### PR TITLE
fix cudart load on osx

### DIFF
--- a/digits/device_query.py
+++ b/digits/device_query.py
@@ -133,6 +133,13 @@ def get_cudart():
             cudart = get_library('cudart%s_%d.dll' % (arch[:2], ver))
             if cudart is not None:
                 return cudart
+    elif platform.system() == 'Darwin':
+        for major in xrange(9,5,-1):
+            for minor in (5,0):
+                cudart = get_library('libcudart.%d.%d.dylib' % (major, minor))
+                if cudart is not None:
+                    return cudart
+        return get_library('libcudart.dylib')
     else:
         for major in xrange(9,5,-1):
             for minor in (5,0):


### PR DESCRIPTION
`device_query.py` wasn't able to detect a CUDA device on my macbook.

# Before
```shell
$ python digits/device_query.py
No devices found.
```

# After
```shell
python digits/device_query.py
Device #0:
>>> CUDA attributes:
  name                         GeForce GT 750M
  totalGlobalMem               2147024896
  clockRate                    925500
  major                        3
  minor                        0
```

It seems that this is originally addressed in https://github.com/NVIDIA/DIGITS/commit/56af4ec9ae5a5e5b3616d41096520b89b169eee4, but lost in https://github.com/NVIDIA/DIGITS/commit/e69019d5ac8ae5bbd14c227240db4735e124c70c.