### PR TITLE
 	Allow segmentation color map to be specified explicitly

### DIFF
--- a/digits/extensions/data/imageSegmentation/forms.py
+++ b/digits/extensions/data/imageSegmentation/forms.py
@@ -58,7 +58,9 @@ class DatasetForm(Form):
                 " image folder there must be one corresponding image in the label"
                 " image folder. The label image must have the same filename except"
                 " for the extension, which may differ. Label images are expected"
-                " to be single-channel images (paletted or grayscale)."
+                " to be single-channel images (paletted or grayscale), or RGB"
+                " images, in which case the color/class mappings need to be"
+                " specified through a separate text file."
         )
 
     folder_pct_val = utils.forms.IntegerField(
@@ -94,7 +96,9 @@ class DatasetForm(Form):
                 " image folder there must be one corresponding image in the label"
                 " image folder. The label image must have the same filename except"
                 " for the extension, which may differ. Label images are expected"
-                " to be single-channel images (paletted or grayscale)."
+                " to be single-channel images (paletted or grayscale), or RGB"
+                " images, in which case the color/class mappings need to be"
+                " specified through a separate text file."
         )
 
     channel_conversion = utils.forms.SelectField(
@@ -115,7 +119,34 @@ class DatasetForm(Form):
             validate_file_path,
             ],
         tooltip="The 'i'th line of the file should give the string label "
-                "associated with the '(i-1)'th numberic label. (E.g. the "
+                "associated with the '(i-1)'th numeric label. (E.g. the "
                 "string label for the numeric label 0 is supposed to be "
                 "on line 1.)"
+        )
+
+    colormap_method = utils.forms.SelectField(
+        'Color map specification',
+        choices=[
+            ('label', 'From label image'),
+            ('textfile', 'From text file'),
+            ],
+        default='label',
+        tooltip="Specify how to map class IDs to colors. Select 'From label "
+                "image' to use palette or grayscale from label images. For "
+                "RGB image labels, select 'From text file' and provide "
+                "color map in separate text file."
+        )
+
+    colormap_text_file = utils.forms.StringField(
+        'Color map file',
+        validators=[
+            validate_required_iff(colormap_method="textfile"),
+            validate_file_path,
+            ],
+        tooltip="Specify color/class mappings through a text file. "
+                "Each line in the file should contain three space-separated "
+                "integer values, one for each of the Red, Green, Blue "
+                "channels. The 'i'th line of the file should give the color "
+                "associated with the '(i-1)'th class. (E.g. the "
+                "color for class #0 is supposed to be on line 1.)"
         )

--- a/digits/extensions/data/imageSegmentation/template.html
+++ b/digits/extensions/data/imageSegmentation/template.html
@@ -7,13 +7,13 @@
 <div class="form-group{{mark_errors([form.feature_folder])}}">
     {{ form.feature_folder.label }}
     {{ form.feature_folder.tooltip }}
-    {{ form.feature_folder(class='form-control autocomplete_path', placeholder='folder or URL')}}
+    {{ form.feature_folder(class='form-control autocomplete_path', placeholder='folder')}}
 </div>
 
 <div class="form-group{{mark_errors([form.label_folder])}}">
     {{ form.label_folder.label }}
     {{ form.label_folder.tooltip }}
-    {{ form.label_folder(class='form-control autocomplete_path', placeholder='folder or URL')}}
+    {{ form.label_folder(class='form-control autocomplete_path', placeholder='folder')}}
 </div>
 
 <div class="form-group{{mark_errors([form.folder_pct_val])}}">
@@ -28,13 +28,37 @@
 <div style="display:none;" class="form-group{{mark_errors([form.validation_feature_folder])}} cl-separate-val-folder">
     {{ form.validation_feature_folder.label }}
     {{ form.validation_feature_folder.tooltip }}
-    {{ form.validation_feature_folder(class='form-control autocomplete_path') }}
+    {{ form.validation_feature_folder(class='form-control autocomplete_path', placeholder='folder') }}
 </div>
 
 <div style="display:none;" class="form-group{{mark_errors([form.validation_label_folder])}} cl-separate-val-folder">
     {{ form.validation_label_folder.label }}
     {{ form.validation_label_folder.tooltip }}
-    {{ form.validation_label_folder(class='form-control autocomplete_path') }}
+    {{ form.validation_label_folder(class='form-control autocomplete_path', placeholder='folder') }}
+</div>
+
+<div class="form-group{{mark_errors([form.class_labels_file])}}">
+    {{ form.class_labels_file.label }}
+    {{ form.class_labels_file.tooltip }}
+    {{ form.class_labels_file(class='form-control autocomplete_path', placeholder='file')}}
+</div>
+
+<div class="form-group{{mark_errors([form.colormap_method])}}">
+    {{ form.colormap_method.label }}
+    {{ form.colormap_method.tooltip }}
+    {{ form.colormap_method(class='form-control') }}
+</div>
+
+<div class="form-group{{mark_errors([form.colormap_text_file])}} cl-colormap-text-file">
+    {{ form.colormap_text_file.label }}
+    {{ form.colormap_text_file.tooltip }}
+    {{ form.colormap_text_file(class='form-control autocomplete_path', placeholder='file')}}
+</div>
+
+<div class="form-group{{mark_errors([form.channel_conversion])}}">
+    {{ form.channel_conversion.label }}
+    {{ form.channel_conversion.tooltip }}
+    {{ form.channel_conversion(class='form-control') }}
 </div>
 
 <script>
@@ -56,16 +80,17 @@ function hasValFolderChanged() {
 }
 $("#has_val_folder").click(hasValFolderChanged);
 hasValFolderChanged();
+
+function hasColorMapMethodChanged() {
+    if ($("#colormap_method").val() == "textfile")
+    {
+        $("#colormap_text_file").prop("disabled", false);
+    }
+    else
+    {
+        $("#colormap_text_file").prop("disabled", true);
+    }
+}
+$("#colormap_method").click(hasColorMapMethodChanged);
+hasColorMapMethodChanged();
 </script>
-
-<div class="form-group{{mark_errors([form.class_labels_file])}}">
-    {{ form.class_labels_file.label }}
-    {{ form.class_labels_file.tooltip }}
-    {{ form.class_labels_file(class='form-control autocomplete_path', placeholder='folder or URL')}}
-</div>
-
-<div class="form-group{{mark_errors([form.channel_conversion])}}">
-    {{ form.channel_conversion.label }}
-    {{ form.channel_conversion.tooltip }}
-    {{ form.channel_conversion(class='form-control') }}
-</div>


### PR DESCRIPTION
Add form fields to allow users to provide separate text file with color/class mappings.
This is useful when working with datasets that have label images in RGB.

Depends on #961 