### PR TITLE
cleaned up layerVis and gradientAscent to just include job updates

### DIFF
--- a/digits/framework_helpers/__init__.py
+++ b/digits/framework_helpers/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+from __future__ import absolute_import
+
+from . import caffe_helpers

--- a/digits/framework_helpers/caffe_helpers.py
+++ b/digits/framework_helpers/caffe_helpers.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+import caffe_pb2
+from google.protobuf import text_format
+
+# Constants
+CAFFE_SOLVER_FILE = 'solver.prototxt'
+CAFFE_ORIGINAL_FILE = 'original.prototxt'
+CAFFE_TRAIN_VAL_FILE = 'train_val.prototxt'
+CAFFE_SNAPSHOT_PREFIX = 'snapshot'
+CAFFE_DEPLOY_FILE = 'deploy.prototxt'
+CAFFE_WEIGHTS_FILE = 'model.caffemodel'
+
+class Error(Exception):
+    pass
+
+class CaffeSanityCheckError(Error):
+    """A sanity check failed"""
+    pass
+
+def filterLayersByState(network):
+    """
+    Splits up a network into data, train_val and deploy layers
+    """
+    # The net has a NetState when in use
+    train_state = caffe_pb2.NetState()
+    text_format.Merge('phase: TRAIN stage: "train"', train_state)
+    val_state = caffe_pb2.NetState()
+    text_format.Merge('phase: TEST stage: "val"', val_state)
+    deploy_state = caffe_pb2.NetState()
+    text_format.Merge('phase: TEST stage: "deploy"', deploy_state)
+
+    # Each layer can have several NetStateRules
+    train_rule = caffe_pb2.NetStateRule()
+    text_format.Merge('phase: TRAIN', train_rule)
+    val_rule = caffe_pb2.NetStateRule()
+    text_format.Merge('phase: TEST', val_rule)
+
+    # Return three NetParameters
+    data_layers = caffe_pb2.NetParameter()
+    train_val_layers = caffe_pb2.NetParameter()
+    deploy_layers = caffe_pb2.NetParameter()
+
+    for layer in network.layer:
+        included_train = _layerIncludedInState(layer, train_state)
+        included_val = _layerIncludedInState(layer, val_state)
+        included_deploy = _layerIncludedInState(layer, deploy_state)
+
+        # Treat data layers differently (more processing done later)
+        if 'Data' in layer.type:
+            data_layers.layer.add().CopyFrom(layer)
+            rule = None
+            if not included_train:
+                # Exclude from train
+                rule = val_rule
+            elif not included_val:
+                # Exclude from val
+                rule = train_rule
+            _setLayerRule(data_layers.layer[-1], rule)
+
+        # Non-data layers
+        else:
+            if included_train or included_val:
+                # Add to train_val
+                train_val_layers.layer.add().CopyFrom(layer)
+                rule = None
+                if not included_train:
+                    # Exclude from train
+                    rule = val_rule
+                elif not included_val:
+                    # Exclude from val
+                    rule = train_rule
+                _setLayerRule(train_val_layers.layer[-1], rule)
+
+            if included_deploy:
+                # Add to deploy
+                deploy_layers.layer.add().CopyFrom(layer)
+                _setLayerRule(deploy_layers.layer[-1], None)
+
+    return (data_layers, train_val_layers, deploy_layers)
+
+def cleanedUpClassificationNetwork(original_network, num_categories):
+    """
+    Perform a few cleanup routines on a classification network
+    Returns a new NetParameter
+    """
+    network = caffe_pb2.NetParameter()
+    network.CopyFrom(original_network)
+
+    for i, layer in enumerate(network.layer):
+        if 'Data' in layer.type:
+            assert layer.type in ['Data', 'HDF5Data'], \
+                'Unsupported data layer type %s' % layer.type
+
+        elif layer.type == 'Input':
+            # DIGITS handles the deploy file for you
+            del network.layer[i]
+
+        elif layer.type == 'Accuracy':
+            # Check to see if top_k > num_categories
+            if ( layer.accuracy_param.HasField('top_k') and
+                    layer.accuracy_param.top_k > num_categories ):
+                del network.layer[i]
+
+        elif layer.type == 'InnerProduct':
+            # Check to see if num_output is unset
+            if not layer.inner_product_param.HasField('num_output'):
+                layer.inner_product_param.num_output = num_categories
+
+    return network
+
+def cleanedUpGenericNetwork(original_network):
+    """
+    Perform a few cleanup routines on a generic network
+    Returns a new NetParameter
+    """
+    network = caffe_pb2.NetParameter()
+    network.CopyFrom(original_network)
+
+    for i, layer in enumerate(network.layer):
+        if 'Data' in layer.type:
+            assert layer.type in ['Data'], \
+                'Unsupported data layer type %s' % layer.type
+
+        elif layer.type == 'Input':
+            # DIGITS handles the deploy file for you
+            del network.layer[i]
+
+        elif layer.type == 'InnerProduct':
+            # Check to see if num_output is unset
+            assert layer.inner_product_param.HasField('num_output'), \
+                "Don't leave inner_product_param.num_output unset for generic networks (layer %s)" % layer.name
+
+    return network
+
+def _layerIncludedInState(layer, state):
+    """
+    Returns True if this layer will be included in the given state
+    Logic copied from Caffe's Net::FilterNet()
+    """
+    # If no include rules are specified, the layer is included by default and
+    # only excluded if it meets one of the exclude rules.
+    layer_included = len(layer.include) == 0
+
+    for exclude_rule in layer.exclude:
+        if _stateMeetsRule(state, exclude_rule):
+            layer_included = False
+            break
+
+    for include_rule in layer.include:
+        if _stateMeetsRule(state, include_rule):
+            layer_included = True
+            break
+
+    return layer_included
+
+def _stateMeetsRule(state, rule):
+    """
+    Returns True if the given state meets the given rule
+    Logic copied from Caffe's Net::StateMeetsRule()
+    """
+    if rule.HasField('phase'):
+        if rule.phase != state.phase:
+            return False
+
+    if rule.HasField('min_level'):
+        if state.level < rule.min_level:
+            return False
+
+    if rule.HasField('max_level'):
+        if state.level > rule.max_level:
+            return False
+
+    # The state must contain ALL of the rule's stages
+    for stage in rule.stage:
+        if stage not in state.stage:
+            return False
+
+    # The state must contain NONE of the rule's not_stages
+    for stage in rule.not_stage:
+        if stage in state.stage:
+            return False
+
+    return True
+
+def _setLayerRule(layer, rule=None):
+    """
+    Set a new include rule for this layer
+    If rule is None, the layer will always be included
+    """
+    layer.ClearField('include')
+    layer.ClearField('exclude')
+    if rule is not None:
+        layer.include.add().CopyFrom(rule)
+
+def save_deploy_file_classification(network,path,num_categories, crop_size=None, feature_dims=None,logger=None):
+    """
+    Save deploy_file to disk
+    """
+    network = cleanedUpClassificationNetwork(network, num_categories)
+    _, _, deploy_layers = filterLayersByState(network)
+
+    deploy_network = caffe_pb2.NetParameter()
+    deploy_file = CAFFE_DEPLOY_FILE
+
+    # Input
+    deploy_network.input.append('data')
+    shape = deploy_network.input_shape.add()
+    shape.dim.append(1)
+    shape.dim.append(feature_dims[2])
+
+    # TODO - Implement crop_size
+    shape.dim.append(feature_dims[0])
+    shape.dim.append(feature_dims[1])
+
+    # Layers
+    deploy_network.MergeFrom(deploy_layers)
+
+    # Write to file
+    with open(path+"/"+deploy_file, 'w') as outfile:
+        text_format.PrintMessage(deploy_network, outfile)
+
+    # network sanity checks
+    if logger:
+        logger.debug("Network sanity check - deploy")
+
+    net_sanity_check(deploy_network, caffe_pb2.TEST)
+    found_softmax = False
+    for layer in deploy_network.layer:
+        if layer.type == 'Softmax':
+            found_softmax = True
+            break
+    assert found_softmax, 'Your deploy network is missing a Softmax layer! Read the documentation for custom networks and/or look at the standard networks for examples.'
+
+
+def net_sanity_check(net, phase):
+    """
+    Perform various sanity checks on the network, including:
+    - check that all layer bottoms are included at the specified stage
+    """
+    assert phase == caffe_pb2.TRAIN or phase == caffe_pb2.TEST, "Unknown phase: %s" % repr(phase)
+    # work out which layers and tops are included at the specified phase
+    layers = []
+    tops = []
+    for layer in net.layer:
+        if len(layer.include)>0:
+            mask = 0 # include none by default
+            for rule in layer.include:
+                mask = mask | (1<<rule.phase)
+        elif len(layer.exclude)>0:
+            # include and exclude rules are mutually exclusive as per Caffe spec
+            mask = (1<<caffe_pb2.TRAIN) | (1<<caffe_pb2.TEST) # include all by default
+            for rule in layer.exclude:
+                mask = mask & ~(1<<rule.phase)
+        else:
+            mask = (1<<caffe_pb2.TRAIN) | (1<<caffe_pb2.TEST)
+        if mask & (1<<phase):
+            # layer will be included at this stage
+            layers.append(layer)
+            tops.extend(layer.top)
+    # add inputs
+    tops.extend(net.input)
+    # now make sure all bottoms are present at this stage
+    for layer in layers:
+        for bottom in layer.bottom:
+            if bottom not in tops:
+                raise CaffeSanityCheckError("Layer '%s' references bottom '%s' at the %s stage however " \
+                                                 "this blob is not included at that stage. Please consider " \
+                                                 "using an include directive to limit the scope of this layer." % (
+                                                   layer.name, bottom, "TRAIN" if phase == caffe_pb2.TRAIN else "TEST"))

--- a/digits/job.py
+++ b/digits/job.py
@@ -17,11 +17,13 @@ from digits.utils import sizeof_fmt, filesystem as fs
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 2
 
+
 class Job(StatusCls):
     """
     Base class
     """
     SAVE_FILE = 'status.pickle'
+    NON_PERSISTENT_JOB_DELETE_TIMEOUT_SECONDS = 3600
 
     @classmethod
     def load(cls, job_id):
@@ -342,6 +344,12 @@ class Job(StatusCls):
         # assume it has completed already (done, errored or interrupted)
         if hasattr(self, 'event'):
             self.event.wait()
+
+    def delete_timeout(self):
+        """
+        Returns how long a non-persistent job should exist for
+        """
+        return self.NON_PERSISTENT_JOB_DELETE_TIMEOUT_SECONDS
 
     def is_persistent(self):
         """

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -23,6 +23,7 @@ from digits.config import config_value
 from digits.status import Status
 from digits.utils import subclass, override, constants
 from digits.utils.filesystem import tail
+from digits.framework_helpers import caffe_helpers
 
 # Must import after importing digit.config
 import caffe
@@ -30,13 +31,6 @@ import caffe_pb2
 
 # NOTE: Increment this everytime the pickled object changes
 PICKLE_VERSION = 5
-
-# Constants
-CAFFE_SOLVER_FILE = 'solver.prototxt'
-CAFFE_ORIGINAL_FILE = 'original.prototxt'
-CAFFE_TRAIN_VAL_FILE = 'train_val.prototxt'
-CAFFE_SNAPSHOT_PREFIX = 'snapshot'
-CAFFE_DEPLOY_FILE = 'deploy.prototxt'
 
 @subclass
 class DigitsTransformer(caffe.io.Transformer):
@@ -127,11 +121,11 @@ class CaffeTrainTask(TrainTask):
         self.image_mean = None
         self.solver = None
 
-        self.solver_file = CAFFE_SOLVER_FILE
-        self.model_file = CAFFE_ORIGINAL_FILE
-        self.train_val_file = CAFFE_TRAIN_VAL_FILE
-        self.snapshot_prefix = CAFFE_SNAPSHOT_PREFIX
-        self.deploy_file = CAFFE_DEPLOY_FILE
+        self.solver_file = caffe_helpers.CAFFE_SOLVER_FILE
+        self.model_file = caffe_helpers.CAFFE_ORIGINAL_FILE
+        self.train_val_file = caffe_helpers.CAFFE_TRAIN_VAL_FILE
+        self.snapshot_prefix = caffe_helpers.CAFFE_SNAPSHOT_PREFIX
+        self.deploy_file = caffe_helpers.CAFFE_DEPLOY_FILE
         self.log_file = self.CAFFE_LOG
 
         self.digits_version = digits.__version__
@@ -185,11 +179,12 @@ class CaffeTrainTask(TrainTask):
                 pass
 
         if state['pickver_task_caffe_train'] <= 4:
+            self.model_file = caffe_helpers.CAFFE_ORIGINAL_FILE
+            with open(self.path(self.model_file), 'w') as outfile:
+                text_format.PrintMessage(self.network, outfile)
+
             if hasattr(self,"original_file"):
-                self.model_file = self.original_file
                 del self.original_file
-            else:
-                self.model_file = None
 
         self.pickver_task_caffe_train = PICKLE_VERSION
 
@@ -306,12 +301,12 @@ class CaffeTrainTask(TrainTask):
         """
         Save solver, train_val and deploy files to disk
         """
-        # Save the origin network to file:
+        # Save the original network to file:
         with open(self.path(self.model_file), 'w') as outfile:
             text_format.PrintMessage(self.network, outfile)
 
-        network = cleanedUpClassificationNetwork(self.network, len(self.get_labels()))
-        data_layers, train_val_layers, deploy_layers = filterLayersByState(network)
+        network = caffe_helpers.cleanedUpClassificationNetwork(self.network, len(self.get_labels()))
+        data_layers, train_val_layers, deploy_layers = caffe_helpers.filterLayersByState(network)
 
         ### Write train_val file
 
@@ -615,8 +610,8 @@ class CaffeTrainTask(TrainTask):
 
         ### Split up train_val and deploy layers
 
-        network = cleanedUpGenericNetwork(self.network)
-        data_layers, train_val_layers, deploy_layers = filterLayersByState(network)
+        network = caffe_helpers.cleanedUpGenericNetwork(self.network)
+        data_layers, train_val_layers, deploy_layers = caffe_helpers.filterLayersByState(network)
 
         ### Write train_val file
 
@@ -1128,18 +1123,26 @@ class CaffeTrainTask(TrainTask):
 
         loc, mean_file = os.path.split(self.dataset.get_mean_file())
 
+        image_dimensions = list(self.dataset.get_feature_dims())
+
+        # TODO: Store both original, and cropped image dimensions
+        if self.crop_size is not None:
+            image_dimensions[0] = self.crop_size
+            image_dimensions[1] = self.crop_size
+
         stats = {
-            "image dimensions": self.dataset.get_feature_dims(),
+            "image dimensions": tuple(image_dimensions),
             "mean file": mean_file,
             "snapshot file": self.get_snapshot_filename(epoch),
             "solver file": self.solver_file,
             "train_val file": self.train_val_file,
             "deploy file": self.deploy_file,
-            "framework": "caffe"
+            "framework": "caffe",
+            "model file": self.model_file
         }
 
         # These attributes only available in more recent jobs:
-        if hasattr(self,"model_file"):
+        if hasattr(self,"caffe_flavor"):
             if self.model_file is not None:
                 stats.update({
                     "caffe flavor": self.caffe_flavor,
@@ -1615,183 +1618,3 @@ class CaffeTrainTask(TrainTask):
                                                      "this blob is not included at that stage. Please consider " \
                                                      "using an include directive to limit the scope of this layer." % (
                                                        layer.name, bottom, "TRAIN" if phase == caffe_pb2.TRAIN else "TEST"))
-
-
-def cleanedUpClassificationNetwork(original_network, num_categories):
-    """
-    Perform a few cleanup routines on a classification network
-    Returns a new NetParameter
-    """
-    network = caffe_pb2.NetParameter()
-    network.CopyFrom(original_network)
-
-    for i, layer in enumerate(network.layer):
-        if 'Data' in layer.type:
-            assert layer.type in ['Data', 'HDF5Data'], \
-                'Unsupported data layer type %s' % layer.type
-
-        elif layer.type == 'Input':
-            # DIGITS handles the deploy file for you
-            del network.layer[i]
-
-        elif layer.type == 'Accuracy':
-            # Check to see if top_k > num_categories
-            if ( layer.accuracy_param.HasField('top_k') and
-                    layer.accuracy_param.top_k > num_categories ):
-                del network.layer[i]
-
-        elif layer.type == 'InnerProduct':
-            # Check to see if num_output is unset
-            if not layer.inner_product_param.HasField('num_output'):
-                layer.inner_product_param.num_output = num_categories
-
-    return network
-
-
-def cleanedUpGenericNetwork(original_network):
-    """
-    Perform a few cleanup routines on a generic network
-    Returns a new NetParameter
-    """
-    network = caffe_pb2.NetParameter()
-    network.CopyFrom(original_network)
-
-    for i, layer in enumerate(network.layer):
-        if 'Data' in layer.type:
-            assert layer.type in ['Data'], \
-                'Unsupported data layer type %s' % layer.type
-
-        elif layer.type == 'Input':
-            # DIGITS handles the deploy file for you
-            del network.layer[i]
-
-        elif layer.type == 'InnerProduct':
-            # Check to see if num_output is unset
-            assert layer.inner_product_param.HasField('num_output'), \
-                "Don't leave inner_product_param.num_output unset for generic networks (layer %s)" % layer.name
-
-    return network
-
-
-def filterLayersByState(network):
-    """
-    Splits up a network into data, train_val and deploy layers
-    """
-    # The net has a NetState when in use
-    train_state = caffe_pb2.NetState()
-    text_format.Merge('phase: TRAIN stage: "train"', train_state)
-    val_state = caffe_pb2.NetState()
-    text_format.Merge('phase: TEST stage: "val"', val_state)
-    deploy_state = caffe_pb2.NetState()
-    text_format.Merge('phase: TEST stage: "deploy"', deploy_state)
-
-    # Each layer can have several NetStateRules
-    train_rule = caffe_pb2.NetStateRule()
-    text_format.Merge('phase: TRAIN', train_rule)
-    val_rule = caffe_pb2.NetStateRule()
-    text_format.Merge('phase: TEST', val_rule)
-
-    # Return three NetParameters
-    data_layers = caffe_pb2.NetParameter()
-    train_val_layers = caffe_pb2.NetParameter()
-    deploy_layers = caffe_pb2.NetParameter()
-
-    for layer in network.layer:
-        included_train = _layerIncludedInState(layer, train_state)
-        included_val = _layerIncludedInState(layer, val_state)
-        included_deploy = _layerIncludedInState(layer, deploy_state)
-
-        # Treat data layers differently (more processing done later)
-        if 'Data' in layer.type:
-            data_layers.layer.add().CopyFrom(layer)
-            rule = None
-            if not included_train:
-                # Exclude from train
-                rule = val_rule
-            elif not included_val:
-                # Exclude from val
-                rule = train_rule
-            _setLayerRule(data_layers.layer[-1], rule)
-
-        # Non-data layers
-        else:
-            if included_train or included_val:
-                # Add to train_val
-                train_val_layers.layer.add().CopyFrom(layer)
-                rule = None
-                if not included_train:
-                    # Exclude from train
-                    rule = val_rule
-                elif not included_val:
-                    # Exclude from val
-                    rule = train_rule
-                _setLayerRule(train_val_layers.layer[-1], rule)
-
-            if included_deploy:
-                # Add to deploy
-                deploy_layers.layer.add().CopyFrom(layer)
-                _setLayerRule(deploy_layers.layer[-1], None)
-
-    return (data_layers, train_val_layers, deploy_layers)
-
-
-def _layerIncludedInState(layer, state):
-    """
-    Returns True if this layer will be included in the given state
-    Logic copied from Caffe's Net::FilterNet()
-    """
-    # If no include rules are specified, the layer is included by default and
-    # only excluded if it meets one of the exclude rules.
-    layer_included = len(layer.include) == 0
-
-    for exclude_rule in layer.exclude:
-        if _stateMeetsRule(state, exclude_rule):
-            layer_included = False
-            break
-
-    for include_rule in layer.include:
-        if _stateMeetsRule(state, include_rule):
-            layer_included = True
-            break
-
-    return layer_included
-
-
-def _stateMeetsRule(state, rule):
-    """
-    Returns True if the given state meets the given rule
-    Logic copied from Caffe's Net::StateMeetsRule()
-    """
-    if rule.HasField('phase'):
-        if rule.phase != state.phase:
-            return False
-
-    if rule.HasField('min_level'):
-        if state.level < rule.min_level:
-            return False
-
-    if rule.HasField('max_level'):
-        if state.level > rule.max_level:
-            return False
-
-    # The state must contain ALL of the rule's stages
-    for stage in rule.stage:
-        if stage not in state.stage:
-            return False
-
-    # The state must contain NONE of the rule's not_stages
-    for stage in rule.not_stage:
-        if stage in state.stage:
-            return False
-
-    return True
-
-def _setLayerRule(layer, rule=None):
-    """
-    Set a new include rule for this layer
-    If rule is None, the layer will always be included
-    """
-    layer.ClearField('include')
-    layer.ClearField('exclude')
-    if rule is not None:
-        layer.include.add().CopyFrom(rule)

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -651,7 +651,7 @@ class TorchTrainTask(TrainTask):
             #    |  |- weights
             #    |- 2
             for layer_id,layer in vis_db['layers'].items():
-                layer_desc = layer['name'][...].tostring()
+                layer_desc  = layer['name'][...].tostring()
                 if 'Sequential' in layer_desc or 'Parallel' in layer_desc:
                     # ignore containers
                     continue

--- a/digits/pretrained_model/job.py
+++ b/digits/pretrained_model/job.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
+import os
 
 from . import tasks
 import digits.frameworks
@@ -7,23 +8,26 @@ from digits.job import Job
 from digits.utils import subclass, override
 from digits.pretrained_model.tasks import CaffeUploadTask, TorchUploadTask
 
+# NOTE: Increment this everytime the pickled object changes
+PICKLE_VERSION = 1
+
 @subclass
 class PretrainedModelJob(Job):
     """
     A Job that uploads a pretrained model
     """
+    def __init__(self, weights_path, model_def_path, labels_path=None, mean_path=None, framework="caffe",
+                image_type="3",resize_mode="Squash", height=224, width=224, **kwargs):
 
-    def __init__(self, weights_path, model_def_path, labels_path=None,framework="caffe",
-                image_type="3",resize_mode="Squash", width=224, height=224, **kwargs):
         super(PretrainedModelJob, self).__init__(persistent = False, **kwargs)
+        self.pickver_pretrained_job = PICKLE_VERSION
 
-        self.has_labels = labels_path is not None
         self.framework  = framework
         self.image_info = {
             "image_type": image_type,
             "resize_mode": resize_mode,
-            "width": width,
-            "height": height
+            "height": height,
+            "width": width
         }
 
         self.tasks = []
@@ -33,6 +37,7 @@ class PretrainedModelJob(Job):
             "model_def_path": model_def_path,
             "image_info": self.image_info,
             "labels_path": labels_path,
+            "mean_path": mean_path,
             "job_dir": self.dir()
         }
 
@@ -47,6 +52,33 @@ class PretrainedModelJob(Job):
     def get_model_def_path(self):
         return self.tasks[0].get_model_def_path()
 
+    def get_deploy_path(self):
+        return self.tasks[0].get_deploy_path()
+
+    def get_mean_path(self):
+        return self.tasks[0].get_mean_path()
+
+    def get_model_def(self,as_json=False):
+        with open(self.get_model_def_path(as_json), 'r') as myfile:
+            data=myfile.read()
+        return data
+
+    def has_weights(self):
+        return os.path.isfile(self.get_filters_path()) and os.path.isfile(self.get_model_def_path())
+
+    def has_deploy(self):
+        return os.path.isfile(self.get_deploy_path())
+
+    def has_labels_file(self):
+        return os.path.isfile(self.tasks[0].get_labels_path())
+
+    def has_mean_file(self):
+        return os.path.isfile(self.tasks[0].get_mean_path())
+
+    @override
+    def is_persistent(self):
+        return True
+
     @override
     def is_persistent(self):
         return True
@@ -57,8 +89,9 @@ class PretrainedModelJob(Job):
 
     @override
     def __getstate__(self):
-        fields_to_save = ['_id', '_name', 'username', 'tasks', 'status_history', 'has_labels', 'framework', 'image_info']
+        fields_to_save = ['_id', '_name', 'username', 'tasks', 'status_history','framework', 'image_info', 'pickver_pretrained_job']
         full_state = super(PretrainedModelJob, self).__getstate__()
+
         state_to_save = {}
         for field in fields_to_save:
             state_to_save[field] = full_state[field]
@@ -66,4 +99,8 @@ class PretrainedModelJob(Job):
 
     @override
     def __setstate__(self, state):
+        if "pickver_pretrained_job" not in state:
+            state['pickver_pretrained_job'] = 0
+
+        state['pickver_pretrained_job'] = PICKLE_VERSION
         super(PretrainedModelJob, self).__setstate__(state)

--- a/digits/pretrained_model/tasks/caffe_upload.py
+++ b/digits/pretrained_model/tasks/caffe_upload.py
@@ -2,14 +2,25 @@
 from __future__ import absolute_import
 import os
 import digits
+from digits import frameworks
 from digits.utils import subclass, override
 from digits.status import Status
 from digits.pretrained_model.tasks import UploadPretrainedModelTask
+from digits.framework_helpers import caffe_helpers
+
+# NOTE: Increment this everytime the pickled object changes
+PICKLE_VERSION = 1
+
 
 @subclass
 class CaffeUploadTask(UploadPretrainedModelTask):
     def __init__(self, **kwargs):
         super(CaffeUploadTask, self).__init__(**kwargs)
+        self.pickver_task_caffe_upload = PICKLE_VERSION
+
+        self.model_file = caffe_helpers.CAFFE_ORIGINAL_FILE
+        self.deploy_file = caffe_helpers.CAFFE_DEPLOY_FILE
+        self.weights_file = caffe_helpers.CAFFE_WEIGHTS_FILE
 
     @override
     def name(self):
@@ -20,18 +31,42 @@ class CaffeUploadTask(UploadPretrainedModelTask):
         """
         Get path to model definition
         """
-        return self.job_dir+"/original.prototxt"
+        return os.path.join(self.job_dir,self.model_file)
 
     @override
     def get_weights_path(self):
         """
         Get path to model weights
         """
-        return self.job_dir+"/model.caffemodel"
+        return os.path.join(self.job_dir,self.weights_file)
 
+    @override
+    def get_deploy_path(self):
+        """
+        Get path to file containing model def for deploy/visualization
+        """
+        return os.path.join(self.job_dir,self.deploy_file)
+
+    @override
+    def write_deploy(self):
+        # get handle to framework object
+        fw = frameworks.get_framework_by_id("caffe")
+        model_def_path  = self.get_model_def_path()
+        network = fw.get_network_from_path(model_def_path)
+
+        image_dim = [int(self.image_info["height"]), int(self.image_info["width"]),int(self.image_info["image_type"]) ]
+
+        caffe_helpers.save_deploy_file_classification(network,self.job_dir,len(self.get_labels()),None,image_dim,None)
 
     @override
     def __setstate__(self, state):
+        if 'pickver_task_caffe_upload' not in state:
+            state['model_file']   = caffe_helpers.CAFFE_ORIGINAL_FILE
+            state['deploy_file']  = caffe_helpers.CAFFE_DEPLOY_FILE
+            state['weights_file'] = caffe_helpers.CAFFE_WEIGHTS_FILE
+
+        state['pickver_task_caffe_upload'] = PICKLE_VERSION
+
         super(CaffeUploadTask, self).__setstate__(state)
 
     @override
@@ -43,4 +78,8 @@ class CaffeUploadTask(UploadPretrainedModelTask):
         if self.labels_path is not None:
             self.move_file(self.labels_path, "labels.txt")
 
+        if self.mean_path is not None:
+            self.move_file(self.mean_path, "mean.binaryproto")
+
+        self.write_deploy()
         self.status = Status.DONE

--- a/digits/pretrained_model/tasks/torch_upload.py
+++ b/digits/pretrained_model/tasks/torch_upload.py
@@ -1,15 +1,24 @@
 # Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 import os
+import subprocess
 import digits
 from digits.utils import subclass, override
 from digits.status import Status
 from digits.pretrained_model.tasks import UploadPretrainedModelTask
+from digits.config import config_value
+
+# NOTE: Increment this everytime the pickled object changes
+PICKLE_VERSION = 1
+
+from digits.config import config_value
+from digits import frameworks
 
 @subclass
 class TorchUploadTask(UploadPretrainedModelTask):
     def __init__(self, **kwargs):
         super(TorchUploadTask, self).__init__(**kwargs)
+        self.pickver_task_torch_upload = PICKLE_VERSION
 
     @override
     def name(self):
@@ -20,14 +29,21 @@ class TorchUploadTask(UploadPretrainedModelTask):
         """
         Get path to model definition
         """
-        return self.job_dir+"/original.lua"
+        return self.get_deploy_path()
 
     @override
     def get_weights_path(self):
         """
         Get path to model weights
         """
-        return self.job_dir+"/_Model.t7"
+        return os.path.join(self.job_dir,"_Model.t7")
+
+    @override
+    def get_deploy_path(self):
+        """
+        Get path to file containing model def for deploy/visualization
+        """
+        return os.path.join(self.job_dir,"original.lua")
 
     @override
     def __setstate__(self, state):
@@ -41,5 +57,9 @@ class TorchUploadTask(UploadPretrainedModelTask):
 
         if self.labels_path is not None:
             self.move_file(self.labels_path, "labels.txt")
+
+        if self.mean_path is not None:
+            self.move_file(self.mean_path, "mean.binaryproto")
+
 
         self.status = Status.DONE

--- a/digits/scheduler.py
+++ b/digits/scheduler.py
@@ -28,7 +28,7 @@ from digits.utils import errors
 This constant configures how long to wait before automatically
 deleting completed non-persistent jobs
 """
-NON_PERSISTENT_JOB_DELETE_TIMEOUT_SECONDS = 3600
+
 
 class Resource(object):
     """
@@ -425,7 +425,7 @@ class Scheduler:
                         if job.status.is_running():
                             if job.is_persistent():
                                 job.save()
-                        elif (not job.is_persistent()) and (time.time() - job.status_history[-1][1] > NON_PERSISTENT_JOB_DELETE_TIMEOUT_SECONDS):
+                        elif (not job.is_persistent()) and (time.time() - job.status_history[-1][1] > job.delete_timeout()):
                             # job has been unclaimed for far too long => proceed to garbage collection
                             self.delete_job(job)
                     last_saved = time.time()

--- a/digits/static/css/buttons.bootstrap.min.css
+++ b/digits/static/css/buttons.bootstrap.min.css
@@ -1,1 +1,11 @@
 div.dt-button-info{position:fixed;top:50%;left:50%;width:400px;margin-top:-100px;margin-left:-200px;background-color:white;border:2px solid #111;box-shadow:3px 3px 8px rgba(0,0,0,0.3);border-radius:3px;text-align:center;z-index:21}div.dt-button-info h2{padding:0.5em;margin:0;font-weight:normal;border-bottom:1px solid #ddd;background-color:#f3f3f3}div.dt-button-info>div{padding:1em}ul.dt-button-collection.dropdown-menu{display:block;z-index:2002;-webkit-column-gap:8px;-moz-column-gap:8px;-ms-column-gap:8px;-o-column-gap:8px;column-gap:8px}ul.dt-button-collection.dropdown-menu.fixed{position:fixed;top:50%;left:50%;margin-left:-75px}ul.dt-button-collection.dropdown-menu.fixed.two-column{margin-left:-150px}ul.dt-button-collection.dropdown-menu.fixed.three-column{margin-left:-225px}ul.dt-button-collection.dropdown-menu.fixed.four-column{margin-left:-300px}ul.dt-button-collection.dropdown-menu>*{-webkit-column-break-inside:avoid;break-inside:avoid}ul.dt-button-collection.dropdown-menu.two-column{width:300px;padding-bottom:1px;-webkit-column-count:2;-moz-column-count:2;-ms-column-count:2;-o-column-count:2;column-count:2}ul.dt-button-collection.dropdown-menu.three-column{width:450px;padding-bottom:1px;-webkit-column-count:3;-moz-column-count:3;-ms-column-count:3;-o-column-count:3;column-count:3}ul.dt-button-collection.dropdown-menu.four-column{width:600px;padding-bottom:1px;-webkit-column-count:4;-moz-column-count:4;-ms-column-count:4;-o-column-count:4;column-count:4}div.dt-button-background{position:fixed;top:0;left:0;width:100%;height:100%;z-index:2001}
+
+.ui-button .ui-button-default{
+  background: transparent none !important;
+  color: #333333 !important;
+  font-weight: normal;
+  border-radius: 0.28571429rem;
+  text-transform: none;
+  text-shadow: none !important;
+  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+}

--- a/digits/static/css/style.css
+++ b/digits/static/css/style.css
@@ -35,25 +35,7 @@ div.progress div.progress-bar {
     cursor: pointer;
     opacity: 0;
 }
-.btn-file {
-    position: relative;
-    overflow: hidden;
-}
-.btn-file input[type=file] {
-    position: absolute;
-    top: 0;
-    right: 0;
-    min-width: 100%;
-    min-height: 100%;
-    font-size: 100px;
-    text-align: right;
-    filter: alpha(opacity=0);
-    opacity: 0;
-    outline: none;
-    background: white;
-    cursor: inherit;
-    display: block;
-}
+
 /* Spinning Glyphicon */
 .glyphicon-spin {
   -webkit-animation: spin 1000ms infinite linear;
@@ -86,8 +68,8 @@ path.c3-line {
 }
 
 /* Hide all data transformation and augmentation by default */
-.data_transformation_input{ display:none; } 
-.data_augmentation_input{ display:none; } 
+.data_transformation_input{ display:none; }
+.data_augmentation_input{ display:none; }
 
 .autocomplete-suggestions { border: 1px solid #999; background: #FFF; overflow: auto; }
 .autocomplete-suggestion { padding: 2px 5px; white-space: nowrap; overflow: visible; }

--- a/digits/static/js/components/PretrainedModel.js
+++ b/digits/static/js/components/PretrainedModel.js
@@ -1,300 +1,303 @@
 // Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 var PretrainedModel = function(params){
-  var props = _.extend({
-    selector: "#pretrainedModelContent",
-    size: 600
-  },params);
 
-  var self = this;
-  var inputs = PretrainedModel.mixins;
-
-  self.actions = new PretrainedModel.Actions(self);
-  self.archive = new Object();
-
-  self.size      = props.size;
-  self.selector  = props.selector;
-
-  self.header            = null;
-  self.container         = null;
-  self.innerContainer    = null;
-  self.frameworkSelector = null;
-
-  self.frameworks = [
-    {text: "Caffe", value: "caffe"},
-    {text: "Torch", value: "torch"}
-  ];
-
-  self.resize_channels = [
-    {text: "Color", value: 3},
-    {text: "Grayscale", value: 1}
-  ];
-
-  self.resize_modes = [
-    {text:"Squash", value: "squash"},
-    {text: "Crop", value: "crop"},
-    {text: "Fill", value: "fill"},
-    {text: "Half Crop, Half Fill", value: "half_crop"}
-  ];
-
-  self.frameworkChanged = function(){
-    var nextFramework = self.frameworkSelector.property("value");
-    if (nextFramework ==  "torch"){
-      self.torchForm();
-    }else{
-      self.caffeForm();
-    }
-  };
-
-  self.newRow = function(){
-    return self.container.append("div").attr("class","row");
-  };
-
-  self.close = function(){
-    d3.select(self.selector).html('');
-    d3.select(".modalOuter").style("display","none");
-  };
-
-  self.render = function(){
-    // Render heading:
-    $("#pretrainedModelTab>a").click();
-    d3.select(self.selector).html('');
-    self.heading();
-
-    self.container = d3.select(self.selector).append("div")
-      .html('')
-      .style({
-        top:"-20px",
-        position: "relative",
-        padding: "10px " + self.size/10 +"px"
-      });
-
-    self.well();
-    var row = self.newRow();
-    inputs.field(row.append("div").attr("class","col-xs-6"),"text","Jobname", "job_name");
-
-    self.frameworkSelector = inputs.select(
-      row.append("div").attr("class","col-xs-6"),self.frameworks,"Framework","framework"
-    );
-    row = self.newRow();
-    row.style("border-radius", "5px 5px 0px 0px");
-    inputs.select(
-      row.append("div").attr("class","col-xs-6"),
-        self.resize_channels,"Image Type","image_type"
-    );
-
-    inputs.select(
-      row.append("div").attr("class","col-xs-6"),
-        self.resize_modes,"Resize Mode","resize_mode"
-    );
-
-    row = self.newRow();
-    row.style("border-radius", "0px 0px 5px 5px");
-    inputs.field(row.append("div").attr("class","col-xs-6"),"number","Width", "width").attr("value",256);
-    inputs.field(row.append("div").attr("class","col-xs-6"),"number","Height", "height").attr("value",256);
-
-    self.frameworkSelector.on("change", self.frameworkChanged);
-    self.innerContainer = self.container.append("div");
-    self.caffeForm();
-  };
-
-  self.dispatchUpload = function(){
-    var file = self.archive.input.node().files[0];
-    // var spinner = self.archive.button.select("span").text("")
-    //   .attr("class", "");
-    self.well({
-      text: "",
-      class: "glyphicon glyphicon-refresh glyphicon-spin"
-    });
-    self.actions.uploadArchive(file);
-  };
-
-  self.well = function(params){
     var props = _.extend({
-      text: "Upload Tar or Zip Archive",
-      class: "",
-      state: "primary"
+        selector: "#pretrainedModelContent",
+        size: 600
     },params);
 
-    self.container.select(".well").remove();
+    var self = this;
+    var inputs = PretrainedModel.mixins;
 
-    var well = self.container.insert("div",":first-child")
-      .attr("class","well text-center")
-      .style("padding","0px");
+    self.actions = new PretrainedModel.Actions(self);
+    self.archive = new Object();
 
-    well.append("div").attr("class", "btn btn-sm btn-default")
-      .style("margin","3px")
-      .attr("disabled","")
-      .html("Manual Entry");
+    self.size      = props.size;
+    self.selector  = props.selector;
 
-    var archive = self.archive;
+    self.header            = null;
+    self.container         = null;
+    self.innerContainer    = null;
+    self.frameworkSelector = null;
 
-    archive.button = well.append("div")
-      .attr("class","file-upload btn btn-sm btn-"+props.state)
-      .style({position: "relative", display: "inline-block !important"});
+    self.frameworks = [
+        {text: "Caffe", value: "caffe"},
+        {text: "Torch", value: "torch"}
+    ];
+
+    self.resize_channels = [
+        {text: "Color", value: 3},
+        {text: "Grayscale", value: 1}
+    ];
+
+    self.resize_modes = [
+        {text:"Squash", value: "squash"},
+        {text: "Crop", value: "crop"},
+        {text: "Fill", value: "fill"},
+        {text: "Half Crop, Half Fill", value: "half_crop"}
+    ];
+
+    self.frameworkChanged = function(){
+        var nextFramework = self.frameworkSelector.property("value");
+        if (nextFramework ==  "torch"){
+            self.torchForm();
+        }else{
+            self.caffeForm();
+        }
+    };
+
+    self.newRow = function(){
+        return self.container.append("div").attr("class","row");
+    };
+
+    self.close = function(){
+        d3.select(self.selector).html('');
+        d3.select(".modalOuter").style("display","none");
+    };
+
+    self.render = function(){
+        // Render heading:
+        $("#pretrainedModelTab>a").click();
+        d3.select(self.selector).html('');
+        self.heading();
+
+        self.container = d3.select(self.selector).append("div")
+          .html('')
+          .style({
+            top:"-20px",
+            position: "relative",
+            padding: "10px " + self.size/10 +"px"
+          });
+
+        self.well();
+        var row = self.newRow();
+        inputs.field(row.append("div").attr("class","col-xs-6"),"text","Jobname", "job_name");
+
+        self.frameworkSelector = inputs.select(
+          row.append("div").attr("class","col-xs-6"),self.frameworks,"Framework","framework"
+        );
+        row = self.newRow();
+        row.style("border-radius", "5px 5px 0px 0px");
+        inputs.select(
+          row.append("div").attr("class","col-xs-6"),
+            self.resize_channels,"Image Type","image_type"
+        );
+
+        inputs.select(
+          row.append("div").attr("class","col-xs-6"),
+            self.resize_modes,"Resize Mode","resize_mode"
+        );
+
+        row = self.newRow();
+        row.style("border-radius", "0px 0px 5px 5px");
+        inputs.field(row.append("div").attr("class","col-xs-6"),"number","Height", "height").attr("value",224);
+        inputs.field(row.append("div").attr("class","col-xs-6"),"number","Width", "width").attr("value",224);
+
+        self.frameworkSelector.on("change", self.frameworkChanged);
+        self.innerContainer = self.container.append("div");
+        self.caffeForm();
+    };
+
+    self.dispatchUpload = function(){
+        var file = self.archive.input.node().files[0];
+        // var spinner = self.archive.button.select("span").text("")
+        //   .attr("class", "");
+        self.well({
+          text: "",
+          class: "glyphicon glyphicon-refresh glyphicon-spin"
+        });
+        self.actions.uploadArchive(file);
+    };
+
+    self.well = function(params){
+        var props = _.extend({
+          text: "Upload Tar or Zip Archive",
+          class: "",
+          state: "primary"
+        },params);
+
+        self.container.select(".well").remove();
+
+        var well = self.container.insert("div",":first-child")
+          .attr("class","well text-center")
+          .style("padding","0px");
+
+        well.append("div").attr("class", "btn btn-sm btn-default")
+          .style("margin","3px")
+          .attr("disabled","")
+          .html("Manual Entry");
+
+        var archive = self.archive;
+
+        archive.button = well.append("div")
+          .attr("class","file-upload btn btn-sm btn-"+props.state)
+          .style({position: "relative", display: "inline-block !important"});
 
 
-    archive.button.append("span").attr("class", props.class).text(props.text);
+        archive.button.append("span").attr("class", props.class).text(props.text);
 
-    archive.input = archive.button.append("input").attr({
-      type: "file",
-      class: "upload",
-      multiple: ""
-    });
+        archive.input = archive.button.append("input").attr({
+          type: "file",
+          class: "upload",
+          multiple: ""
+        });
 
-    archive.input.node().onchange = self.dispatchUpload;
+        archive.input.node().onchange = self.dispatchUpload;
 
-  };
+    };
 
-  self.heading = function(params){
-    var props = _.extend({
-      text: "Upload Pretrained Model",
-      classed: false
-    },params);
+    self.heading = function(params){
+        var props = _.extend({
+          text: "Upload Pretrained Model",
+          classed: false
+        },params);
 
-    if (!_.isNull(self.header)) self.header.remove();
+        if (!_.isNull(self.header)) self.header.remove();
 
-    var header  =
-    self.header = d3.select(self.selector)
-      .classed("panel-danger", props.classed)
-      .insert("div",":first-child")
-        .attr("class", "panel-heading text-center");
+        var header  =
+        self.header = d3.select(self.selector)
+          .classed("panel-danger", props.classed)
+          .insert("div",":first-child")
+            .attr("class", "panel-heading text-center");
 
-    header.append("span").html(props.text);
-    header.append("a")
-      .attr("class","btn btn-danger btn-xs closeButton")
-      .style("float","right")
-      .on("click", self.close)
-      .append("span")
-        .attr("class","glyphicon glyphicon-remove");
+        header.append("span").html(props.text);
+        header.append("a")
+          .attr("class","btn btn-danger btn-xs closeButton")
+          .style("float","right")
+          .on("click", self.close)
+          .append("span")
+            .attr("class","glyphicon glyphicon-remove");
 
-    d3.select(self.selector).append("br");
+        d3.select(self.selector).append("br");
 
-  };
+    };
 
-  self.caffeForm = function(){
-    self.innerContainer.html('');
+    self.caffeForm = function(){
+        self.innerContainer.html('');
 
-    inputs.file(self.innerContainer,"Weights (**.caffemodel)", "weights_file");
-    inputs.file(self.innerContainer,"Model Definition (original.prototxt)", "model_def_file");
-    inputs.file(self.innerContainer,"Labels file: (labels.txt)", "labels_file");
+        inputs.file(self.innerContainer,"Weights (**.caffemodel)", "weights_file");
+        inputs.file(self.innerContainer,"Model Definition (original.prototxt)", "model_def_file");
+        inputs.file(self.innerContainer,"Labels file: (labels.txt)", "labels_file");
+        inputs.file(self.innerContainer,"Mean file: (mean.binaryproto)", "mean_file");
 
-    self.innerContainer.append("button").attr({type: "submit",class: "btn btn-default"})
-      .on("click",self.submit)
-      .style("background","white")
-      .html("Upload Model");
-  };
+        self.innerContainer.append("button").attr({type: "submit",class: "btn btn-default"})
+          .on("click",self.submit)
+          .style("background","white")
+          .html("Upload Model");
+    };
 
-  self.torchForm = function(e){
-    self.innerContainer.html('');
+    self.torchForm = function(e){
+        self.innerContainer.html('');
 
-    inputs.file(self.innerContainer,"Weights (**.t7)", "weights_file");
-    inputs.file(self.innerContainer,"Model Definition: (model.lua)", "model_def_file");
-    inputs.file(self.innerContainer,"Labels file: (Optional)", "labels_file");
+        inputs.file(self.innerContainer,"Weights (**.t7)", "weights_file");
+        inputs.file(self.innerContainer,"Model Definition: (model.lua)", "model_def_file");
+        inputs.file(self.innerContainer,"Labels file: (Optional)", "labels_file");
+        inputs.file(self.innerContainer,"Mean file: (mean.binaryproto)", "mean_file");
 
-    self.innerContainer.append("button").attr({type: "submit",class: "btn btn-default"})
-      .on("click",self.submit)
-      .style("background","white")
-      .html("Upload Model");
-  };
+        self.innerContainer.append("button").attr({type: "submit",class: "btn btn-default"})
+          .on("click",self.submit)
+          .style("background","white")
+          .html("Upload Model");
+    };
 
 };
 
 PretrainedModel.Actions = function(props){
-  var self = this;
-  var props  = _.isUndefined(props) ? {} : props;
-  var parent = !_.isUndefined(props.parent) ? props.parent : props;
+    var self = this;
+    var props  = _.isUndefined(props) ? {} : props;
+    var parent = !_.isUndefined(props.parent) ? props.parent : props;
 
-  self.uploadArchive = function(file){
-       var upload_url = "/pretrained_models/upload_archive";
-       parent.heading({classed: false, text: "Uploading archive, one moment..."});
+    self.uploadArchive = function(file){
+         var upload_url = "/pretrained_models/upload_archive";
+         parent.heading({classed: false, text: "Uploading archive, one moment..."});
 
-       var formData = new FormData();
-       // Check file type.
-       if (file.type.indexOf("zip") == -1) {
-         parent.heading({classed: true, text: "Bad File Type"});
-         parent.well({class: "", text: "Try Upload Again?", state: "danger"});
-         console.error("Bad File Type");
-         return;
-       }
+         var formData = new FormData();
+         // Check file type.
+         if (file.type.indexOf("zip") == -1) {
+           parent.heading({classed: true, text: "Bad File Type"});
+           parent.well({class: "", text: "Try Upload Again?", state: "danger"});
+           console.error("Bad File Type");
+           return;
+         }
 
-       // Add the file to the request.
-       formData.append('archive', file, file.name);
-       var xhr = new XMLHttpRequest();
-       xhr.onload = function () {
-          if (xhr.status === 200) {
-            var json = JSON.parse(xhr.responseText);
-            $("#pretrainedModelTab>a").click();
-            parent.close();
-          } else {
-            parent.heading({classed: true, text: "Upload Failed"});
-            parent.well({class: "", text: "Try Upload Again?", state: "danger"});
-            console.error("Failed to Upload File");
-            console.error(xhr.responseText);
-            var json = JSON.parse(xhr.responseText);
-            console.error(json.status);
-            parent.heading({classed: true, text: json.status});
-          }
-       };
-      // Send Request:
-      xhr.open("POST", upload_url, true);
-      xhr.send(formData);
-    };
+         // Add the file to the request.
+         formData.append('archive', file, file.name);
+         var xhr = new XMLHttpRequest();
+         xhr.onload = function () {
+            if (xhr.status === 200) {
+              var json = JSON.parse(xhr.responseText);
+              $("#pretrainedModelTab>a").click();
+              parent.close();
+            } else {
+              parent.heading({classed: true, text: "Upload Failed"});
+              parent.well({class: "", text: "Try Upload Again?", state: "danger"});
+              console.error("Failed to Upload File");
+              console.error(xhr.responseText);
+              var json = JSON.parse(xhr.responseText);
+              console.error(json.status);
+              parent.heading({classed: true, text: json.status});
+            }
+         };
+        // Send Request:
+        xhr.open("POST", upload_url, true);
+        xhr.send(formData);
+      };
 };
 
 PretrainedModel.mixins = {
-  select: function(obj,data,label,name){
-    var group = obj.append("div").attr("class","form-group");
-    group.append("label")
-        .attr("for",name).html(label);
+    select: function(obj,data,label,name){
+      var group = obj.append("div").attr("class","form-group");
+      group.append("label")
+          .attr("for",name).html(label);
 
-    var mySelect = group.append("select").attr({
-        class: "form-control",
-        name: name
+      var mySelect = group.append("select").attr({
+          class: "form-control",
+          name: name
+        });
+
+      mySelect.selectAll('option').data(data).enter()
+        .append("option")
+          .attr("value",function(d){return d.value})
+          .text(function(d){return d.text});
+
+      return mySelect;
+
+    },
+
+    file: function(obj,label,name){
+      var group = obj.append("div").attr("class","input-group").style({
+        margin: "6px 0px",
+        width: "100%"
       });
 
-    mySelect.selectAll('option').data(data).enter()
-      .append("option")
-        .attr("value",function(d){return d.value})
-        .text(function(d){return d.text});
+      // Show file select as a button:
+      var btn   = group.append("span").attr("class", "input-group-btn")
+        .append("span")
+          .attr("class","btn btn-default btn-file")
+          .style({width: "205px", background: "whitesmoke"});
+      btn.append("span").style("font-size", "12px").text(label);
+      var input = btn.append("input").attr({type: "file", name: name})
 
-    return mySelect;
+      // Draw textfield beside button:
+      var textfield = group.append("input").attr({
+        type: "text",
+        class: "form-control",
+        readonly: ""
+      });
+      // When file selected, fill text-field with the filename
+      input.on("change", function(){
+          var name = this.files[0].name;
+          textfield.attr("value",name);
+      });
+      return group;
+    },
 
-  },
-
-  file: function(obj,label,name){
-    var group = obj.append("div").attr("class","input-group").style({
-      margin: "6px 0px",
-      width: "100%"
-    });
-
-    // Show file select as a button:
-    var btn   = group.append("span").attr("class", "input-group-btn")
-      .append("span")
-        .attr("class","btn btn-default btn-file")
-        .style({width: "205px", background: "whitesmoke"});
-    btn.append("span").style("font-size", "12px").text(label);
-    var input = btn.append("input").attr({type: "file", name: name})
-
-    // Draw textfield beside button:
-    var textfield = group.append("input").attr({
-      type: "text",
-      class: "form-control",
-      readonly: ""
-    });
-    // When file selected, fill text-field with the filename
-    input.on("change", function(){
-        var name = this.files[0].name;
-        textfield.attr("value",name);
-    });
-    return group;
-  },
-
-  field: function(obj,type,label,name){
-    var group = obj.append("div").attr("class","form-group");
-    group.append("label")
-        .attr("for",name).html(label);
-    return group.append("input")
-      .attr({type: type, class: "form-control", name: name});
-  }
+    field: function(obj,type,label,name){
+      var group = obj.append("div").attr("class","form-group");
+      group.append("label")
+          .attr("for",name).html(label);
+      return group.append("input")
+        .attr({type: type, class: "form-control", name: name});
+    }
 
 };

--- a/digits/static/js/home_app.js
+++ b/digits/static/js/home_app.js
@@ -557,6 +557,7 @@ try {
                          {name: 'framework',    show: true,  min_width: 0},
                          {name: 'username',     show: true,  min_width: 0},
                          {name: 'has_labels',   show: true,  min_width: 0},
+                         {name: 'has_mean_file',   show: true,  min_width: 0},
                          {name: 'status',       show: true,  min_width: 0},
                          {name: 'elapsed',      show: true,  min_width: 0},
                          {name: 'submitted',    show: true,  min_width: 0}];
@@ -722,7 +723,16 @@ try {
                 '\'glyphicon-remove\']}" style="width:14px"/>',
         };
     });
-
+    app.directive('dgHasMeanFile', function() {
+        console.log('has-mean-file');
+        return {
+            restrict: 'AE',
+            replace: true,
+            template: '<i class="glyphicon '+
+                ' {[job.has_mean_file ? \'glyphicon-ok\' : ' +
+                '\'glyphicon-remove\']}" style="width:14px"/>',
+        };
+    });
     // Because jinja uses {{ and }}, tell angular to use {[ and ]}
     app.config(['$interpolateProvider', function($interpolateProvider) {
         $interpolateProvider.startSymbol('{[');

--- a/digits/templates/partials/home/pretrained_model_pane.html
+++ b/digits/templates/partials/home/pretrained_model_pane.html
@@ -84,10 +84,11 @@
                         ng-click="click($index, $event)"
                         ng-keydown="keydown($event)"
                         ng-class="{selected:job.selected}">
-                        <td ng-bind="job.name"></td>
+                        <td ><div ng-bind="job.name"></div></td>
                         <td><dg-framework/></td>
                         <td ng-bind-html="job.username|html"></td>
                         <td><dg-has-labels/></td>
+                        <td><dg-has-mean-file/></td>
                         <td class="text-{[job.status_css]}">
                             {[ job.status ]}
                         </td>

--- a/digits/templates/partials/home/upload_pretrained_model.html
+++ b/digits/templates/partials/home/upload_pretrained_model.html
@@ -1,7 +1,7 @@
 {# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
 <script type="text/javascript" src="{{ url_for('static', filename='js/components/PretrainedModel.js', ver=dir_hash) }}"></script>
 
-{% set size = 500 %}
+{% set size = 600 %}
 {% set url  = "/pretrained_models/new" %}
 
 <style>

--- a/digits/views.py
+++ b/digits/views.py
@@ -184,12 +184,14 @@ def json_dict(job, model_output_fields):
 
     if isinstance(job, pretrained_model.PretrainedModelJob):
         model_output_fields.add("has_labels")
+        model_output_fields.add("has_mean_file")
         model_output_fields.add("username")
         d.update({
             'type': 'pretrained_model',
             'framework': job.framework,
             'username': job.username,
-            'has_labels': job.has_labels,
+            'has_labels': job.has_labels_file(),
+            'has_mean_file': job.has_mean_file()
         })
     return d
 
@@ -346,8 +348,6 @@ def show_job(job_id):
         return flask.redirect(flask.url_for('digits.dataset.views.show', job_id=job_id))
     if isinstance(job, model.ModelJob):
         return flask.redirect(flask.url_for('digits.model.views.show', job_id=job_id))
-    if isinstance(job, pretrained_model.PretrainedModelJob):
-        return flask.redirect(flask.url_for('digits.pretrained_model.views.show', job_id=job_id))
     else:
         raise werkzeug.exceptions.BadRequest('Invalid job type')
 


### PR DESCRIPTION
Includes all changes made outside of visualizations in LayerVis and Gradient Ascent pull requests

- Moved cleanedUpGenericNetwork to helpers file
- Change image dimensions from width -> height, to height -> width in pretrained model job
- Used constants for model definition, deploy.prototxt etc.
- Cleaned up import statements
- Added missing headers
- Fixed errors when converting old models
- Added hash_dir to PretrainedModel javascript component
- Fixed tab spacing in PretrainedModel
- Removed "path" + "/" + "file" with os.path.join
- Changed has_labels to method has_labels_file()
