### PR TITLE
Add how to install Pillow in Windows.

### DIFF
--- a/docs/BuildDigitsWindows.md
+++ b/docs/BuildDigitsWindows.md
@@ -72,6 +72,15 @@ Then type
 python -m pip install -r requirements.txt
 ```
 
+You may see error about Pillow, like
+``` ValueError: jpeg is required unless explicitly disabled using --disable-jpeg, aborting ```
+If this happens, download Pillow Windows Installer (Pillow-3.1.1.win-amd64-py2.7.exe) at https://pypi.python.org/pypi/Pillow/3.1.1 and run the exectuables.
+After installing Pillow in the above way, run
+```
+python -m pip install -r requirements.txt
+```
+again.
+
 After the above command, check if all required Python dependencies are met by comparing requirements.txt and output of the following command.
 ```
 python -m pip list


### PR DESCRIPTION
Test DIGITS master branch with new requirements.txt on Windows.  The Pillow package can't be installed via pip due to missing jpeg library.  Users can install Pillow 3.1.1 via Windows installer executable instead.
