### PR TITLE
Add threshold option in image output extension

### DIFF
--- a/digits/extensions/view/imageOutput/config_template.html
+++ b/digits/extensions/view/imageOutput/config_template.html
@@ -17,3 +17,26 @@
     {{ form.pixel_conversion.tooltip }}
     {{ form.pixel_conversion(class='form-control') }}
 </div>
+
+<div style="display:none;" class="form-group{{mark_errors([form.threshold_val])}} cl-threshold">
+    {{ form.threshold_val.label }}
+    {{ form.threshold_val.tooltip }}
+    {{ form.threshold_val(class='form-control autocomplete_path') }}
+</div>
+
+<script>
+function hasPixelConversionChanged() {
+	if ($("#pixel_conversion").val() == "threshold")
+    {
+        $("#threshold_val").prop("disabled", false);
+        $(".cl-threshold").show();
+    }
+    else
+    {
+        $(".cl-threshold").hide();
+        $("#threshold_val").prop("disabled", true);
+    }
+}
+$("#pixel_conversion").click(hasPixelConversionChanged);
+hasPixelConversionChanged();
+</script>

--- a/digits/extensions/view/imageOutput/forms.py
+++ b/digits/extensions/view/imageOutput/forms.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from flask.ext.wtf import Form
+from wtforms import validators
 
 from digits import utils
 from digits.utils import subclass
@@ -28,8 +29,18 @@ class ConfigForm(Form):
         choices=[
             ('normalize', 'Normalize'),
             ('clip', 'Clip'),
+            ('threshold', 'Binary threshold')
             ],
         default='normalize',
         tooltip='Select method to convert pixel values to the target bit '
                 'range'
+        )
+
+    threshold_val = utils.forms.IntegerField(
+        u'Threshold',
+        default=128,
+        validators=[
+            validators.NumberRange(min=0, max=255)
+            ],
+        tooltip="Threshold value"
         )


### PR DESCRIPTION
Add option to apply binary threshold on output image:

![vis](https://cloud.githubusercontent.com/assets/3889770/18044094/3d6949d4-6dcc-11e6-83a7-3a9d09215c6c.png)

Values lower than threshold will be zeroed.
Values higher than threshold will be set to 255. 

cc @jbarker-nvidia
