### PR TITLE
Change DataIngestion to lowercase all class names

### DIFF
--- a/digits/extensions/data/objectDetection/data.py
+++ b/digits/extensions/data/objectDetection/data.py
@@ -37,7 +37,7 @@ class DataIngestion(DataIngestionInterface):
             reader = csv.reader(s)
             self.class_mappings = {}
             for idx, name in enumerate(reader.next()):
-                self.class_mappings[name.strip()] = idx
+                self.class_mappings[name.strip().lower()] = idx
         else:
             self.class_mappings = None
 


### PR DESCRIPTION
I was stuck for a long time trying to train my own data when I realized that the reason my object detection model wasn't training was because when I created the database, I used capitalized custom class names like `DontCare,Pedestrian` instead of lower cased names, ie. `dontcare,pedestrian`. I thought that since my labels had capitalized names (like `Pedestrian`) the custom class names could also be capitalized.

In the file `digits/extensions/data/objectDetection/utils.py` the class names are lower cased when read from the label files (line `183` shown below).
``` python
gt.stype = row[0].lower()
```
However, when the custom classes are created from the Object Detection dataset page, they aren't lower cased. I changed a line to make this happen so that the custom classes and the classes read from the labels will match even if they are both capitalized when sent to DIGITS
