### PR TITLE
Fix unhandled unicode from date_print

### DIFF
--- a/digits/utils/time_filters.py
+++ b/digits/utils/time_filters.py
@@ -13,13 +13,13 @@ def print_time(t, ref_time = None):
         now = time.localtime(ref_time)
 
     if lt.tm_year != now.tm_year:
-        return time.strftime('%b %d %Y, %I:%M:%S %p', lt)
+        return time.strftime('%b %d %Y, %I:%M:%S %p', lt).decode('utf-8')
     elif lt.tm_mon != now.tm_mon:
-        return time.strftime('%b %d, %I:%M:%S %p', lt)
+        return time.strftime('%b %d, %I:%M:%S %p', lt).decode('utf-8')
     elif lt.tm_mday != now.tm_mday:
-        return time.strftime('%a %b %d, %I:%M:%S %p', lt)
+        return time.strftime('%a %b %d, %I:%M:%S %p', lt).decode('utf-8')
     else:
-        return time.strftime('%I:%M:%S %p', lt)
+        return time.strftime('%I:%M:%S %p', lt).decode('utf-8')
 
 def print_time_diff(diff):
     if diff is None:


### PR DESCRIPTION
After re-installing a bunch of Python packages I ended up with a combination of packages that couldn't support the unicode characters coming out of [print_date](https://github.com/NVIDIA/DIGITS/blob/v4.0.0/digits/utils/time_filters.py#L6). I got errors like below due to the presence of accents in French for "August".

```
UnicodeDecodeError

'ascii' codec can't decode byte 0xc3 in position 7: ordinal not in range(128)

Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/greg/ws/digits/digits/webapp.py", line 69, in decorated
    return f(*args, **kwargs)
  File "/home/greg/ws/digits/digits/model/views.py", line 47, in show
    return model_images.generic.views.show(job, related_jobs=related_jobs)
  File "/home/greg/ws/digits/digits/model/images/generic/views.py", line 296, in show
    related_jobs=related_jobs)
  File "/usr/lib/python2.7/dist-packages/flask/templating.py", line 128, in render_template
    context, ctx.app)
  File "/usr/lib/python2.7/dist-packages/flask/templating.py", line 110, in _render
    rv = template.render(context)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 969, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/greg/ws/digits/digits/templates/models/images/generic/show.html", line 4, in top-level template code
    {% from "helper.html" import serve_file %}
  File "/home/greg/ws/digits/digits/templates/job.html", line 5, in top-level template code
    {% extends "layout.html" %}
  File "/home/greg/ws/digits/digits/templates/layout.html", line 77, in top-level template code
    {% block content %}
  File "/home/greg/ws/digits/digits/templates/job.html", line 190, in block "content"
    {% include "status_updates.html" %}
  File "/home/greg/ws/digits/digits/templates/status_updates.html", line 7, in top-level template code
    at {{updates[i][1]|print_time}}
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 7: ordinal not in range(128)
```

This was fixed by this patch. Let me know if you need any more info on my package versions. This is my `pip list`:

```
$ pip list
adium-theme-ubuntu (0.3.4)
apt-xapian-index (0.45)
argparse (1.2.1)
blinker (1.3)
CDDB (1.4)
chardet (2.0.1)
colorama (0.2.5)
command-not-found (0.3)
debtagshw (0.1)
decorator (3.4.0)
defer (1.0.6)
dirspec (13.10)
dnspython (1.11.1)
duplicity (0.6.23)
flake8 (2.1.0)
Flask (0.10.1)
Flask-WTF (0.11)
gevent (1.0)
greenlet (0.4.2)
gunicorn (17.5)
gyp (0.1)
h5py (2.2.1)
html5lib (0.999)
httplib2 (0.8)
ipython (2.3.0)
itsdangerous (0.22)
Jinja2 (2.7.2)
joblib (0.7.1)
lockfile (0.8)
lxml (3.3.3)
MarkupSafe (0.18)
matplotlib (1.3.1)
mccabe (0.2.1)
mutagen (1.22)
nose (1.3.1)
numpy (1.8.2)
oauthlib (0.6.1)
oneconf (0.3.7.14.04.1)
PAM (0.4.2)
pep8 (1.4.6)
pexpect (3.1)
Pillow (2.3.0)
pip (1.5.4)
piston-mini-client (0.7.5)
protobuf (2.5.0)
pycrypto (2.6.1)
pycups (1.9.66)
pycurl (7.19.3)
pyflakes (0.8.1)
pygobject (3.12.0)
pyinotify (0.9.4)
pyOpenSSL (0.13)
pyparsing (2.0.1)
pyserial (2.6)
pysmbc (1.0.14.1)
Pyste (0.9.10)
python-apt (0.9.3.5ubuntu2)
python-dateutil (1.5)
python-debian (0.1.21-nmu2ubuntu2)
pytz (2012c)
pyxdg (0.25)
remastersys-gtk (3.0.4)
reportlab (3.0)
requests (2.2.1)
scikit-image (0.9.3)
scikit-learn (0.14.1)
scipy (0.13.3)
sessioninstaller (0.0.0)
setuptools (3.3)
simplegeneric (0.8.1)
simplejson (3.3.1)
six (1.5.2)
software-center-aptd-plugins (0.0.0)
ssh-import-id (3.21)
system-service (0.1.6)
Twisted-Core (13.2.0)
Twisted-Web (13.2.0)
unity-lens-photos (1.0)
urllib3 (1.7.1)
virtualenv (13.1.2)
Werkzeug (0.9.4)
wheel (0.24.0)
wsgiref (0.1.2)
WTForms (2.0.1)
xdiagnose (3.6.3build2)
zope.interface (4.0.5)
```

Now I get proper display of the date:
![tmp_](https://cloud.githubusercontent.com/assets/3889770/18094535/2150a4a0-6ed4-11e6-996d-68349e5220d1.png)
