### PR TITLE
Modularization of inference

### DIFF
--- a/digits/extensions/data/imageGradients/forms.py
+++ b/digits/extensions/data/imageGradients/forms.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 from digits import utils
 from digits.utils import subclass
+from digits.utils.forms import validate_required_iff
 from flask.ext.wtf import Form
 import wtforms
 from wtforms import validators
@@ -54,4 +55,38 @@ class DatasetForm(Form):
         u'Image Height',
         default=32,
         validators=[validators.DataRequired()]
+        )
+
+
+@subclass
+class InferenceForm(Form):
+    """
+    A form used to perform inference on a gradient regression model
+    """
+
+    gradient_x = utils.forms.FloatField(
+        'Gradient (x)',
+        validators=[
+            validate_required_iff(test_image_count=None),
+            validators.NumberRange(min=-0.5, max=0.5),
+            ],
+        tooltip="Specify a number between -0.5 and 0.5"
+        )
+
+    gradient_y = utils.forms.FloatField(
+        'Gradient (y)',
+        validators=[
+            validate_required_iff(test_image_count=None),
+            validators.NumberRange(min=-0.5, max=0.5),
+            ],
+        tooltip="Specify a number between -0.5 and 0.5"
+        )
+
+    test_image_count = utils.forms.IntegerField(
+        'Test Image count',
+        validators=[
+            validators.Optional(),
+            validators.NumberRange(min=0),
+            ],
+        tooltip="Number of images to create in test set"
         )

--- a/digits/extensions/data/imageGradients/inference_template.html
+++ b/digits/extensions/data/imageGradients/inference_template.html
@@ -1,0 +1,34 @@
+{# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
+
+{% from "helper.html" import print_flashes %}
+{% from "helper.html" import print_errors %}
+{% from "helper.html" import mark_errors %}
+
+<div class="row">
+    <div class="col-sm-6">
+        <h3>Test an image</h3>
+        <div class="form-group{{mark_errors([form.gradient_x])}}">
+            {{ form.gradient_x.label }}
+            {{ form.gradient_x.tooltip }}
+            {{ form.gradient_x(class='form-control') }}
+        </div>
+
+        <div class="form-group{{mark_errors([form.gradient_y])}}">
+            {{ form.gradient_y.label }}
+            {{ form.gradient_y.tooltip }}
+            {{ form.gradient_y(class='form-control') }}
+        </div>
+    </div>
+
+    <div class="col-sm-6">
+        <h3>Test a list of images</h3>
+        <div class="form-group">
+            <div class="form-group{{mark_errors([form.test_image_count])}}">
+                {{ form.test_image_count.label }}
+                {{ form.test_image_count.tooltip }}
+                {{ form.test_image_count(class='form-control') }}
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/digits/extensions/data/interface.py
+++ b/digits/extensions/data/interface.py
@@ -7,7 +7,16 @@ class DataIngestionInterface(object):
     A data ingestion extension
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, is_inference_db=False, **kwargs):
+        """
+        Initialize the data ingestion extension
+        Parameters:
+        - is_inference_db: boolean value, indicates whether the database is
+          created for inference. If this is true then the extension needs to
+          use the data from the inference form and create a database only for
+          the test phase (stage == constants.TEST_DB)
+        - kwargs: dataset form fields
+        """
         # save all data there - no other fields will be persisted
         self.userdata = kwargs
 
@@ -58,19 +67,24 @@ class DataIngestionInterface(object):
         """
         raise NotImplementedError
 
-    @staticmethod
-    def get_inference_form():
+    def get_inference_form(self):
         """
-        For later use
+        Return a Form object with all fields required to create an inference dataset
         """
-        raise NotImplementedError
+        return None
 
     @staticmethod
-    def get_inference_template():
+    def get_inference_template(form):
         """
-        For later use
+        Parameters:
+        - form: form returned by get_inference_form().
+        return:
+        - (template, context) tuple
+          - template is a Jinja template to use for rendering the inference form
+          - context is a dictionary of context variables to use for rendering
+          the form
         """
-        raise NotImplementedError
+        return (None, None)
 
     @staticmethod
     def get_title():

--- a/digits/model/images/generic/test_views.py
+++ b/digits/model/images/generic/test_views.py
@@ -703,6 +703,21 @@ class BaseTestCreatedWithGradientDataExtension(BaseTestCreatedWithAnyDataset,
         # note: model created in BaseTestCreatedWithAnyDataset.setUpClass method
         super(BaseTestCreatedWithGradientDataExtension, cls).setUpClass()
 
+    def test_infer_extension_json(self):
+        rv = self.app.post(
+                '/models/images/generic/infer_extension.json?job_id=%s' % self.model_id,
+                data = {
+                    'gradient_x': 0.5,
+                    'gradient_y': -0.5,
+                    }
+                )
+        assert rv.status_code == 200, 'POST failed with %s' % rv.status_code
+        data = json.loads(rv.data)
+        output = data['outputs'][data['outputs'].keys()[0]]['output']
+        assert output[0] > 0 and \
+                output[1] < 0, \
+                'image regression result is wrong: %s' % data['outputs']['output']
+
 
 class BaseTestCreatedWithImageProcessingExtension(
         BaseTestCreatedWithAnyDataset,

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -17,6 +17,7 @@ from digits.dataset import GenericDatasetJob, GenericImageDatasetJob
 from digits.inference import ImageInferenceJob
 from digits.status import Status
 from digits.utils import filesystem as fs
+from digits.utils import constants
 from digits.utils.forms import fill_form_if_cloned, save_form_to_job
 from digits.utils.routing import get_request_arg, request_wants_json, job_from_request
 from digits.webapp import scheduler
@@ -289,11 +290,29 @@ def show(job, related_jobs=None):
     Called from digits.model.views.models_show()
     """
     view_extensions = get_view_extensions()
+
+    inference_form_html = None
+    if isinstance(job.dataset, GenericDatasetJob):
+        extension_class = extensions.data.get_extension(job.dataset.extension_id)
+        if not extension_class:
+            raise RuntimeError("Unable to find data extension with ID=%s"
+                % job.dataset.extension_id)
+        extension_userdata = job.dataset.extension_userdata
+        extension_userdata.update({'is_inference_db':True})
+        extension = extension_class(**extension_userdata)
+
+        form = extension.get_inference_form()
+        if form:
+            template, context = extension.get_inference_template(form)
+            inference_form_html = flask.render_template_string(template, **context)
+
     return flask.render_template(
         'models/images/generic/show.html',
         job=job,
         view_extensions=view_extensions,
-        related_jobs=related_jobs)
+        related_jobs=related_jobs,
+        inference_form_html=inference_form_html,
+        )
 
 
 @blueprint.route('/large_graph', methods=['GET'])
@@ -391,6 +410,97 @@ def infer_one():
             job=inference_job,
             image_src=image,
             inference_view_html=inference_view_html,
+            header_html=header_html,
+            app_begin_html=app_begin_html,
+            app_end_html=app_end_html,
+            visualizations=model_visualization,
+            total_parameters=sum(v['param_count'] for v in model_visualization
+                                 if v['vis_type'] == 'Weights'),
+            ), status_code
+
+
+@blueprint.route('/infer_extension.json', methods=['POST'])
+@blueprint.route('/infer_extension', methods=['POST', 'GET'])
+def infer_extension():
+    """
+    Perform inference using the data from an extension inference form
+    """
+    model_job = job_from_request()
+
+    inference_db_job = None
+    try:
+        # create an inference database
+        inference_db_job = create_inference_db(model_job)
+        db_path = inference_db_job.get_feature_db_path(constants.TEST_DB)
+
+        # create database creation job
+        epoch = None
+        if 'snapshot_epoch' in flask.request.form:
+            epoch = float(flask.request.form['snapshot_epoch'])
+
+        layers = 'none'
+        if 'show_visualizations' in flask.request.form and flask.request.form['show_visualizations']:
+            layers = 'all'
+
+        # create inference job
+        inference_job = ImageInferenceJob(
+            username=utils.auth.get_username(),
+            name="Inference",
+            model=model_job,
+            images=db_path,
+            epoch=epoch,
+            layers=layers,
+            resize=False,
+            )
+
+        # schedule tasks
+        scheduler.add_job(inference_job)
+
+        # wait for job to complete
+        inference_job.wait_completion()
+
+    finally:
+        if inference_db_job:
+            scheduler.delete_job(inference_db_job)
+
+    # retrieve inference data
+    inputs, outputs, model_visualization = inference_job.get_data()
+
+    # set return status code
+    status_code = 500 if inference_job.status == 'E' else 200
+
+    # delete job folder and remove from scheduler list
+    scheduler.delete_job(inference_job)
+
+    if outputs is not None and len(outputs) < 1:
+        # an error occurred
+        outputs = None
+
+    if inputs is not None:
+        keys = [str(idx) for idx in inputs['ids']]
+        inference_views_html, header_html, app_begin_html, app_end_html = get_inference_visualizations(
+            model_job.dataset,
+            inputs,
+            outputs)
+    else:
+        inference_views_html = None
+        header_html = None
+        keys = None
+        app_begin_html = None
+        app_end_html = None
+
+    if request_wants_json():
+        result = {}
+        for i, key in enumerate(keys):
+            result[key] = dict((name, blob[i].tolist()) for name,blob in outputs.iteritems())
+        return flask.jsonify({'outputs': result}), status_code
+    else:
+        return flask.render_template(
+            'models/images/generic/infer_extension.html',
+            model_job=model_job,
+            job=inference_job,
+            keys=keys,
+            inference_views_html=inference_views_html,
             header_html=header_html,
             app_begin_html=app_begin_html,
             app_end_html=app_end_html,
@@ -599,6 +709,54 @@ def infer_many():
             app_begin_html=app_begin_html,
             app_end_html=app_end_html,
             ), status_code
+
+
+def create_inference_db(model_job):
+    # create instance of extension class
+    extension_class = extensions.data.get_extension(model_job.dataset.extension_id)
+    extension_userdata = model_job.dataset.extension_userdata
+    extension_userdata.update({'is_inference_db':True})
+    extension = extension_class(**extension_userdata)
+
+    extension_form = extension.get_inference_form()
+    extension_form_valid = extension_form.validate_on_submit()
+
+    if not extension_form_valid:
+        errors = extension_form.errors.copy()
+        raise werkzeug.exceptions.BadRequest(repr(errors))
+
+    extension.userdata.update(extension_form.data)
+
+    # create job
+    job = GenericDatasetJob(
+        username=utils.auth.get_username(),
+        name='Inference dataset',
+        group=None,
+        backend='lmdb',
+        feature_encoding='none',
+        label_encoding='none',
+        batch_size=1,
+        num_threads=1,
+        force_same_shape=0,
+        extension_id=model_job.dataset.extension_id,
+        extension_userdata=extension.get_user_data(),
+        )
+
+    # schedule tasks and wait for job to complete
+    scheduler.add_job(job)
+    job.wait_completion()
+
+    # check for errors
+    if job.status != Status.DONE:
+        msg = ""
+        for task in job.tasks:
+            if task.exception:
+                msg = msg + task.exception
+            if task.traceback:
+                msg = msg + task.exception
+        raise RuntimeError(msg)
+
+    return job
 
 
 def get_datasets(extension_id):

--- a/digits/templates/models/images/generic/infer_extension.html
+++ b/digits/templates/models/images/generic/infer_extension.html
@@ -1,0 +1,176 @@
+{# Copyright (c) 2015-2016, NVIDIA CORPORATION.  All rights reserved. #}
+{% extends "job.html" %}
+
+{% block head %}
+<script type="text/javascript" src="{{ url_for('static', filename='js/angular.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/ngStorage.min.js') }}"></script>
+{% endblock %}
+
+{% block nav %}
+<li><a href="{{url_for('digits.model.views.show', job_id=model_job.id())}}">{{model_job.name()}}</a></li>
+<li class="active"><a>Test Many</a></li>
+{% endblock %}
+
+{% block job_content %}
+
+<div class="page-header">
+    <h1>
+        {{model_job.name()}}
+        <small>
+            {{job.job_type()}}
+        </small>
+    </h1>
+</div>
+
+{% if not keys %}
+<div class="alert alert-danger">
+    <p>Inference failed, see job log</p>
+</div>
+{% endif %}
+
+{% endblock %}
+
+{% block job_content_details %}
+
+{% if header_html %}
+<div class="row">
+    <h3>Summary</h3>
+    {{header_html|safe}}
+</div>
+{% endif %}
+
+{% if app_begin_html %}
+{{app_begin_html|safe}}
+{% endif %}
+
+{% if inference_views_html %}
+    <h3>Output visualizations</h3>
+    {% if keys|length > 1 %}
+    <div class="row">
+        <table class="table">
+            <tr>
+                <th>Index</th>
+                <th>Data</th>
+            </tr>
+            {% for key in keys %}
+            <tr>
+                <td>{{loop.index}}</td>
+                <td>
+                    {% set index=loop.index0 %}
+                    {{ inference_views_html[index]|safe }}
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
+    </div>
+    {% else %}
+    {{ inference_views_html[0]|safe }}
+    {% endif %}
+{% endif %}
+
+<script type="text/javascript">
+    function drawHistogram(id, data) {
+        c3.generate({
+            bindto: id,
+            size: {height: 200},
+            data: {
+                columns: [
+                    ['Count'].concat(data[0]),
+                    ['Value'].concat(data[1]),
+                ],
+                x: 'Value',
+                type: 'area-spline',
+            },
+            axis: {
+                x: {
+                    label: {
+                        text: 'Value',
+                        position: 'outer-center',
+                    },
+                    tick: {
+                        values: data[2],
+                        format: d3.format('.3g'),
+                    },
+                    padding: {left: 0},
+                },
+                y: {
+                    padding: {bottom: 0},
+                },
+            },
+            bar: {
+               width: {ratio: 0.2}
+            },
+            padding: {left: 20, right: 20},
+            legend: {hide: true},
+        });
+    }
+</script>
+<style>
+    div.histogram .c3-axis-y .tick {
+        display: none;
+    }
+</style>
+
+{% if visualizations %}
+<h3>Layer visualizations</h3>
+<table class="table">
+    <tr>
+        <th>Description</th>
+        <th width="20%">Statistics</th>
+        <th>Visualization</th>
+    </tr>
+    {% for vis in visualizations %}
+    <tr>
+        <td>
+            <h3>"{{vis['name']}}"</h3>
+            <p>
+            {{vis['vis_type']}}
+            {% if 'layer_type' in vis %}
+            <small><i>({{vis['layer_type']}} layer)</i></small>
+            {% endif %}
+            </p>
+            {% if 'param_count' in vis %}
+            <p>
+            {{'{:,}'.format(vis['param_count'])}} learned parameters
+            </p>
+            {% endif %}
+        </td>
+        <td>
+            <b>Data shape:</b> {{vis['data_stats']['shape']}}<br>
+            <b>Mean:</b> {{vis['data_stats']['mean']}}<br>
+            <b>Std deviation:</b> {{vis['data_stats']['stddev']}}<br>
+            <div id="histogram-{{loop.index}}" class="histogram"></div>
+            <script>
+                drawHistogram("#histogram-{{loop.index}}", {{vis['data_stats']['histogram']}});
+            </script>
+        </td>
+        <td>
+            {% if vis['image_html'] %}
+            <img style="max-width:100%" src="{{vis['image_html']}}" id="vis_{{ loop.index }}"/>
+            <script>
+                $('#vis_{{ loop.index }}').elevateZoom({zoomType: "inner", cursor: "crosshair",
+                        zoomWindowFadeIn: 500, zoomWindowFadeOut: 750,
+                        scrollZoom: true, scrollZoomIncrement: 0.025});
+            </script>
+            {% else %}
+            <i>Not shown</i>
+            {% endif %}
+        </td>
+    </tr>
+    {% endfor %}
+    <tr>
+        <td><i>Totals</i></td>
+        <td>
+            <b>Total learned parameters:</b>
+            {{'{:,}'.format(total_parameters)}}
+        </td>
+    </tr>
+</table>
+{% endif %}
+
+{% if app_end_html %}
+{{app_end_html|safe}}
+{% endif %}
+
+{% endblock %}
+

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -208,6 +208,29 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                     </div>
                 </div>
 
+{% if inference_form_html %}
+{{ inference_form_html|safe }}
+<div class="form-group">
+    <label for="show_visualizations">
+        <input id="show_visualizations" name="show_visualizations" type="checkbox" value="y">
+        Show visualizations and statistics
+    </label>
+    <span name="show_visualizations_explanation"
+        class="explanation-tooltip glyphicon glyphicon-question-sign"
+        data-container="body"
+        title="For each layer in the network, show statistics for the weights/activations and attempt to represent the data visually. Can delay classification considerably."
+        ></span>
+</div>
+
+<button name="infer-db-btn"
+    formaction="{{url_for('digits.model.images.generic.views.infer_extension', job_id=job.id())}}"
+    formmethod="post"
+    formenctype="multipart/form-data"
+    formtarget="_blank"
+    class="btn btn-primary">
+    Test
+</button>
+{% else %}
                 <div class="row">
                     <div class="col-sm-6">
                         <h3>Test a single image</h3>
@@ -315,6 +338,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             ></span>
                     </div>
                 </div>
+{% endif %}
             </form>
         </div>
     </div>

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -159,7 +159,8 @@ def infer(input_list,
             gpu=gpu,
             resize=resize)
     else:
-        assert layers == 'none'
+        if layers != 'none':
+            raise InferenceError("Layer visualization is not supported for multiple inference")
         outputs = model.train_task().infer_many(
             input_data,
             snapshot_epoch=epoch,


### PR DESCRIPTION
If a dataset extension implements its get_inference_form() method then the standard image inference form is replaced with the extension's inference form:

![inference-form](https://cloud.githubusercontent.com/assets/3889770/18134174/cf3be902-6f9d-11e6-9933-7e03c3137b89.png)

During inference, an inference dataset is created using the data from the inference form and the appropriate visualization can be used to render the output:

![view](https://cloud.githubusercontent.com/assets/3889770/18134257/186ce2ca-6f9e-11e6-961d-247215e53c3e.png)

Tasks:

- [x] Create new `infer_extension` route
- [x] Create inference dataset
- [x] Add example (text classification)
- [x] Add tests


