### PR TITLE
Update BuildCaffe.md

### DIFF
--- a/docs/BuildCaffe.md
+++ b/docs/BuildCaffe.md
@@ -39,6 +39,12 @@ If you hit some errors about missing imports, then use this command to install t
 cat $CAFFE_HOME/python/requirements.txt | xargs -n1 sudo pip install
 ```
 
+### Check gcc version
+On Ubuntu 16.04, you would need to make sure your gcc/g++ is of version 5 (5.4.0) not 4.9 or lower. Otherwise, you would encounter issues compiling Caffee, such as https://github.com/BVLC/caffe/issues/3438.
+```
+gcc --version
+gcc (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609
+```
 ## Build
 
 We recommend using CMake to configure Caffe rather than the raw Makefile build for automatic dependency detection:


### PR DESCRIPTION
I was bitten by Coffee compilation errors when I found out that my gcc version is 4.9.3 due to the fact that I was trying to compile CUDA - which doesn't support gcc 5.0+. I think it is worth mentioning it here to save people's time on troubleshooting. It should be made clear that gcc 5 is required, at least on Ubuntu 16.04.