### PR TITLE
Print a little more info for errors in job.save()

### DIFF
--- a/digits/job.py
+++ b/digits/job.py
@@ -275,7 +275,7 @@ class Job(StatusCls):
         except KeyboardInterrupt:
             pass
         except Exception as e:
-            print 'Caught %s while saving job: %s' % (type(e).__name__, e)
+            print 'Caught %s while saving job %s: %s' % (type(e).__name__, self.id(), e)
         return False
 
     def disk_size_fmt(self):


### PR DESCRIPTION
I always end up with weird errors because I switch around between PR branches so often. This just adds a little more info to help debug the error messages. Shouldn't affect normal users at all.