### PR TITLE
Allow min_box_size to be zero in Object Detection extension

### DIFF
--- a/digits/extensions/data/objectDetection/forms.py
+++ b/digits/extensions/data/objectDetection/forms.py
@@ -114,7 +114,7 @@ class DatasetForm(Form):
         u'Minimum box size (in pixels) for validation set',
         default='25',
         validators=[
-            validators.DataRequired(),
+            validators.InputRequired(),
             validators.NumberRange(min=0),
             ],
         tooltip="Retain only the boxes that are larger than the specified "


### PR DESCRIPTION
Using validators.InputRequired() instead of validators.DataRequired() as the latter requires the data to be both present and un-falsey.

fix #1030