### PR TITLE
Rearranged group elements and pills on the front page

### DIFF
--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -52,10 +52,6 @@
     {[jc.model_jobs = (jobs | filter:is_model);'']}
     {[jc.pretrained_model_jobs = (jobs | filter:is_pretrained_model);'']}
     <section ng-controller="tab_controller as tab" ng-init="init({{request.args['tab']}})">
-        <label>Group Jobs:
-            <input type="checkbox"
-                   ng-model="jc.storage.show_groups">
-        </label>
         <div ng-controller="running_controller as c">
             <div ng-if="jc.running_jobs.length">
                 {[jobs = (jc.running_jobs | filter:search_text | sort_with_empty_at_end:this:jc.storage.show_groups);'']}
@@ -209,7 +205,7 @@
 
         <!-- Tabs -->
         <div class="row">
-            <div class="col-md-6">
+            <div class="col-md-12">
                 <ul class="nav nav-tabs" role="tablist">
                     <li ng-class="{active:tab.isSet(1)}">
                         <a href ng-click="tab.setTab(1, $event)">
@@ -242,50 +238,6 @@
                         </a>
                     </li>
                 </ul>
-            </div>
-            <div class="col-md-6">
-                <div class="row">
-                    <div class="col-md-12">
-                        <div class="pull-right">
-                            New Model
-                            <ul class="nav nav-pills">
-                                {% for category in new_model_options.keys()|sort %}
-                                {% set options = new_model_options[category] %}
-                                <li class="dropdown active">
-                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                                        {{category}} <span class="caret"></span>
-                                    </a>
-                                    <ul class="dropdown-menu">
-                                        {% for id in options.keys()|sort %}
-                                        {% set option = options[id] %}
-                                        <li><a id="{{option["id"]}}" href="{{option["url"]}}">{{option["title"]}}</a></li>
-                                        {% endfor %}
-                                    </ul>
-                                </li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                        <div class="pull-right" style="margin-right:10px">
-                            New Dataset
-                            <ul class="nav nav-pills">
-                                {% for category in new_dataset_options.keys()|sort %}
-                                {% set options = new_dataset_options[category] %}
-                                <li class="dropdown active">
-                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                                        {{category}} <span class="caret"></span>
-                                    </a>
-                                    <ul class="dropdown-menu">
-                                        {% for id in options.keys()|sort %}
-                                        {% set option = options[id] %}
-                                        <li><a href="{{option["url"]}}">{{option["title"]}}</a></li>
-                                        {% endfor %}
-                                    </ul>
-                                </li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
 

--- a/digits/templates/layout.html
+++ b/digits/templates/layout.html
@@ -62,7 +62,7 @@
             </li>
             <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">About<span class="caret"></span></a>
-                <ul class="dropdown-menu navbar-inverse">
+                <ul class="dropdown-menu about-menu navbar-inverse">
                     <li><span class="navbar-text brightness"><a target="_blank" href="https://developer.nvidia.com/digits">
                         DIGITS on developer.nvidia.com
                     </a></span></li>
@@ -105,7 +105,7 @@ window.onload = function () {
 </script>
 
 <style>
- .dropdown-menu {
+ .about-menu {
      width: 240px !important;
  }
  .brightness {

--- a/digits/templates/partials/home/datasets_pane.html
+++ b/digits/templates/partials/home/datasets_pane.html
@@ -1,11 +1,40 @@
 {# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
 <!-- Datasets -->
 <div class="col-md-12" ng-show="tab.isSet(1)">
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="pull-right">
+                New Dataset
+                <ul class="nav nav-pills">
+                    {% for category in new_dataset_options.keys()|sort %}
+                    {% set options = new_dataset_options[category] %}
+                    <li class="dropdown active">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                            {{category}} <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            {% for id in options.keys()|sort %}
+                            {% set option = options[id] %}
+                            <li><a href="{{option["url"]}}">{{option["title"]}}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            <div style="position:absolute; bottom:0">
+                <label>Group Jobs:
+                    <input type="checkbox"
+                           ng-model="jc.storage.show_groups">
+                </label>
+            </div>
+        </div>
+    </div>
     <div class="well">
         <div ng-controller="datasets_controller as c">
             {[jobs = (jc.dataset_jobs | filter:search_text | sort_with_empty_at_end:this:jc.storage.show_groups);'']}
             <div class="row">
-                <div class="col-md-12">
+                <div class="col-xs-12">
                     <!-- Filter -->
                     <div class="pull-right">
                         <form>

--- a/digits/templates/partials/home/model_pane.html
+++ b/digits/templates/partials/home/model_pane.html
@@ -1,11 +1,40 @@
 {# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
 <!-- Models -->
 <div class="col-md-12" ng-show="tab.isSet(2)">
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="pull-right">
+                New Model
+                <ul class="nav nav-pills">
+                    {% for category in new_model_options.keys()|sort %}
+                    {% set options = new_model_options[category] %}
+                    <li class="dropdown active">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                            {{category}} <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            {% for id in options.keys()|sort %}
+                            {% set option = options[id] %}
+                            <li><a id="{{option["id"]}}" href="{{option["url"]}}">{{option["title"]}}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            <div style="position:absolute; bottom:0">
+                <label>Group Jobs:
+                    <input type="checkbox"
+                           ng-model="jc.storage.show_groups">
+                </label>
+            </div>
+        </div>
+    </div>
     <div class="well">
         <div ng-controller="models_controller as c">
             {[ jobs = (jc.model_jobs | filter:search_text | sort_with_empty_at_end:this:jc.storage.show_groups); '' ]}
             <div class="row">
-                <div class="col-md-12">
+                <div class="col-xs-12">
                     <!-- Output Field Options -->
                     <div class="button-group pull-right">
                         <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">

--- a/digits/templates/partials/home/pretrained_model_pane.html
+++ b/digits/templates/partials/home/pretrained_model_pane.html
@@ -7,11 +7,40 @@
 </style>
 
 <div class="col-md-12" ng-show="tab.isSet(3)">
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="pull-right">
+                Load Model
+                <ul class="nav nav-pills">
+                    {% for category in load_model_options.keys()|sort %}
+                    {% set options = load_model_options[category] %}
+                    <li class="dropdown active">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                            {{category}} <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            {% for id in options.keys()|sort %}
+                            {% set option = options[id] %}
+                            <li><a id="{{option["id"]}}" href="{{option["url"]}}">{{option["title"]}}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            <div style="position:absolute; bottom:0">
+                <label>Group Jobs:
+                    <input type="checkbox"
+                           ng-model="jc.storage.show_groups">
+                </label>
+            </div>
+        </div>
+    </div>
     <div class="well">
         <div ng-controller="pretrained_models_controller as c">
             {[ jobs = (jc.pretrained_model_jobs | filter:search_text | sort_with_empty_at_end:this:jc.storage.show_groups); '' ]}
             <div class="row">
-                <div class="col-md-12">
+                <div class="col-xs-12">
                     <!-- Filter -->
                     <div class="pull-right">
                         <form>

--- a/digits/views.py
+++ b/digits/views.py
@@ -79,6 +79,11 @@ def home(tab=2):
                     'url': flask.url_for(
                         'digits.model.images.generic.views.new'),
                     },
+                },
+            }
+
+        load_model_options = {
+            'Images': {
                 'pretrained-model': {
                     'title': 'Upload Pretrained Model',
                     'id': 'uploadPretrainedModel',
@@ -120,6 +125,7 @@ def home(tab=2):
             new_model_options=new_model_options,
             running_models=running_models,
             completed_models=completed_models,
+            load_model_options=load_model_options,
             total_gpu_count=len(scheduler.resources['gpus']),
             remaining_gpu_count=sum(r.remaining()
                                     for r in scheduler.resources['gpus']),


### PR DESCRIPTION
Moved the "Group Jobs" button to be closer to the well containing the table.
Moved the New Dataset and New Model pills to their respective tabs.
The "Upload Pretrained Model" has been moved to a new "Load Model" on the "Pretrained Models" tab.
Changed the "Group" button to be disabled when the "Group Jobs" is unchecked.

From this:
![screen shot 2016-09-07 at 5 04 55 pm](https://cloud.githubusercontent.com/assets/13259615/18332779/47217236-751e-11e6-9864-76a02eb13d39.png)

To this:
![screen shot 2016-09-07 at 5 12 57 pm](https://cloud.githubusercontent.com/assets/13259615/18332793/6b1a7b56-751e-11e6-8fd4-e1416c2677e2.png)
