### PR TITLE
Block Delete Jobs popup when no jobs are selected

### DIFF
--- a/digits/static/js/home_app.js
+++ b/digits/static/js/home_app.js
@@ -384,6 +384,7 @@ try {
 
         $scope.delete_jobs = function() {
             var job_ids = $scope.get_selected_job_ids();
+            if (job_ids.length == 0) return;
             bootbox.confirm(
                 ('Are you sure you want to delete the selected' +
                  (job_ids.length == 1 ? 'job?' : job_ids.length + ' jobs?') +
@@ -410,6 +411,7 @@ try {
 
         $scope.abort_jobs = function() {
             var job_ids = $scope.get_selected_job_ids();
+            if (job_ids.length == 0) return;
             bootbox.confirm(
                 ('Are you sure you want to abort the selected ' +
                  (job_ids.length == 1 ? 'job?' : job_ids.length + ' jobs?')),

--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -80,20 +80,21 @@
                                 </form>
                             </div>
                             {[enabled = any_selected();'']}
+                            {[group_enabled = jc.storage.show_groups && enabled;'']}
                             <div>
                                 <a class="btn btn-xs btn-danger"
                                    ng-disabled="!enabled"
-                                   ng-click="delete_jobs();">
+                                   ng-click="!enabled || delete_jobs();">
                                     Delete
                                 </a>
                                 <a class="btn btn-xs btn-warning"
                                    ng-disabled="!enabled"
-                                   ng-click="abort_jobs();">
+                                   ng-click="!enabled || abort_jobs();">
                                     Abort
                                 </a>
                                 <a class="btn btn-xs btn-primary"
-                                   ng-disabled="!enabled"
-                                   ng-click="group_jobs();">
+                                   ng-disabled="!group_enabled"
+                                   ng-click="!group_enabled || group_jobs();">
                                     Group
                                 </a>
                             </div>

--- a/digits/templates/partials/home/datasets_pane.html
+++ b/digits/templates/partials/home/datasets_pane.html
@@ -18,15 +18,16 @@
                         </form>
                     </div>
                     {[enabled = any_selected();'']}
+                    {[group_enabled = jc.storage.show_groups && enabled;'']}
                     <!-- Delete Button -->
                     <a class="btn btn-xs btn-danger"
                        ng-disabled="!enabled"
-                       ng-click="delete_jobs();">
+                       ng-click="!enabled || delete_jobs();">
                         Delete
                     </a>
                     <a class="btn btn-xs btn-primary"
-                       ng-disabled="!enabled"
-                       ng-click="group_jobs();">
+                       ng-disabled="!group_enabled"
+                       ng-click="!group_enabled || group_jobs();">
                         Group
                     </a>
                 </div>

--- a/digits/templates/partials/home/model_pane.html
+++ b/digits/templates/partials/home/model_pane.html
@@ -39,15 +39,16 @@
                         </form>
                     </div>
                     {[enabled = any_selected();'']}
+                    {[group_enabled = jc.storage.show_groups && enabled;'']}
                     <!-- Delete Button -->
                     <a class="btn btn-xs btn-danger"
                        ng-disabled="!enabled"
-                       ng-click="delete_jobs();">
+                       ng-click="!enabled || delete_jobs();">
                         Delete
                     </a>
                     <a class="btn btn-xs btn-primary"
-                       ng-disabled="!enabled"
-                       ng-click="group_jobs();">
+                       ng-disabled="!group_enabled"
+                       ng-click="!group_enabled || group_jobs();">
                         Group
                     </a>
                 </div>

--- a/digits/templates/partials/home/pretrained_model_pane.html
+++ b/digits/templates/partials/home/pretrained_model_pane.html
@@ -24,15 +24,16 @@
                         </form>
                     </div>
                     {[enabled = any_selected();'']}
+                    {[group_enabled = jc.storage.show_groups && enabled;'']}
                     <!-- Delete Button -->
                     <a class="btn btn-xs btn-danger"
                        ng-disabled="!enabled"
-                       ng-click="delete_jobs();">
+                       ng-click="!enabled || delete_jobs();">
                         Delete
                     </a>
                     <a class="btn btn-xs btn-primary"
-                       ng-disabled="!enabled"
-                       ng-click="group_jobs();">
+                       ng-disabled="!group_enabled"
+                       ng-click="!group_enabled || group_jobs();">
                         Group
                     </a>
                 </div>


### PR DESCRIPTION
Both the Delete and Abort buttons bring up the confirmation popup when the buttons is disabled.