### PR TITLE
Various small ObjectDetection dataset improvements

### DIFF
--- a/digits/extensions/data/objectDetection/README.md
+++ b/digits/extensions/data/objectDetection/README.md
@@ -160,4 +160,4 @@ Class name | Class ID
 dontcare | 0
 pedestrian | 1
 
-All labeled objects other than "pedestrian" in your dataset will be mapped to 0.
+All labeled objects other than "pedestrian" in your dataset will be mapped to 0, along with any objects explicitly labeled as "dontcare".

--- a/digits/extensions/data/objectDetection/README.md
+++ b/digits/extensions/data/objectDetection/README.md
@@ -150,7 +150,8 @@ All classes which don't exist in the provided mapping are implicitly mapped to 0
 DetectNet is a single-class object detection network, and only cares about the "Car" class, which is expected to be ID 1.
 You can change the mapping in the DetectNet prototxt, but it's simplest to just make the class you care about map to 1.
 
-Custom class mappings may be used by specifiying a comma-separated list of lower-case class names in the Object Detection dataset creation form.
+Custom class mappings may be used by specifiying a comma-separated list of class names in the Object Detection dataset creation form.
+All labels are converted to lower-case, so the matching is case-insensitive.
 
 For example, if you only want to detect pedestrians, enter `dontcare,pedestrian` in the "Custom classes" field to generate this mapping:
 

--- a/digits/extensions/data/objectDetection/data.py
+++ b/digits/extensions/data/objectDetection/data.py
@@ -97,10 +97,7 @@ class DataIngestion(DataIngestionInterface):
         # (2) label part
 
         # make sure label exists
-        try:
-            label_id = int(os.path.splitext(os.path.basename(entry))[0])
-        except:
-            raise ValueError("Unable to extract numerical id from file name %s" % entry)
+        label_id = os.path.splitext(os.path.basename(entry))[0]
 
         if not label_id in self.datasrc_annotation_dict:
             raise ValueError("Label key %s not found in label folder" % label_id)

--- a/digits/extensions/data/objectDetection/forms.py
+++ b/digits/extensions/data/objectDetection/forms.py
@@ -127,7 +127,7 @@ class DatasetForm(Form):
         validators=[
             validators.Optional(),
             ],
-        tooltip="Enter a comma-separated list of lower-case class names. "
+        tooltip="Enter a comma-separated list of class names. "
                 "Class IDs are assigned sequentially, starting from 0. "
                 "Leave this field blank to use default class mappings. "
                 "See object detection extension documentation for more "

--- a/digits/extensions/data/objectDetection/forms.py
+++ b/digits/extensions/data/objectDetection/forms.py
@@ -129,6 +129,7 @@ class DatasetForm(Form):
             ],
         tooltip="Enter a comma-separated list of class names. "
                 "Class IDs are assigned sequentially, starting from 0. "
+                "Unmapped class names automatically map to 0. "
                 "Leave this field blank to use default class mappings. "
                 "See object detection extension documentation for more "
                 "information."

--- a/digits/extensions/data/objectDetection/utils.py
+++ b/digits/extensions/data/objectDetection/utils.py
@@ -203,7 +203,7 @@ class GroundTruth:
                             gt.stype = ''
                             gt.object = ObjectType.Dontcare
                     objects_per_image.append(gt)
-                    key = int(os.path.splitext(label_file)[0])
+                    key = os.path.splitext(label_file)[0]
                 self.update_objects_all(key, objects_per_image)
 
     @property


### PR DESCRIPTION
* Allow non-numeric filenames (close #940)
  * This should also address the issue on Windows where, because symlinks are not supported, the `prepare_kitti_data.py` script creates filenames like `000000039_002994.png`.
* Improve documentation about case sensitivity
* Improve documentation about mapping classes to 0 during dataset creation