### PR TITLE
Supress numpy VisibleDeprecationWarning

### DIFF
--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -105,7 +105,7 @@ def upscale(image, ratio):
     channels = image.shape[2]
     out = np.ndarray((height, width, channels),dtype=np.uint8)
     for x, y in np.ndindex((width,height)):
-        out[y,x] = image[math.floor(y/ratio), math.floor(x/ratio)]
+        out[y,x] = image[int(math.floor(y/ratio)), int(math.floor(x/ratio))]
     return out
 
 


### PR DESCRIPTION
```
/home/lyeager/digits/digits/utils/image.py:108:
  VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  out[y,x] = image[math.floor(y/ratio), math.floor(x/ratio)]
```
Counter-intuitively, `math.floor()` returns a float.
```py
>>> type(math.floor(0))
<type 'float'>
```