### PR TITLE
Remove changes to socketio logger

### DIFF
--- a/digits/log.py
+++ b/digits/log.py
@@ -50,9 +50,6 @@ class JobIdLoggerAdapter(logging.LoggerAdapter):
         return msg, kwargs
 
 def setup_logging():
-    socketio_logger = logging.getLogger('socketio')
-    socketio_logger.addHandler(logging.StreamHandler(sys.stdout))
-
     # Set custom logger
     logging.setLoggerClass(JobIdLogger)
 


### PR DESCRIPTION
I can't remember why I had added this originally. Some older version of socketio wasn't interacting well with my custom logger class or something. I want to remove it now because there are a bunch of socketio messages clogging up the testsuite output.