### PR TITLE
Avoid NaN errors and misclassifications in tests

### DIFF
--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -1112,10 +1112,6 @@ class TestTorchLeNet(BaseTestCreated):
     IMAGE_WIDTH = 28
     IMAGE_HEIGHT = 28
     TRAIN_EPOCHS = 20
-    # need more aggressive learning rate
-    # on such a small dataset
-    LR_POLICY = 'fixed'
-    LEARNING_RATE = 0.1
 
     # standard lenet model will adjust to color
     # or grayscale images


### PR DESCRIPTION
This fixes [some of] the Torch errors we keep getting in the test suite. Before the fix, this command would error out within a few attempts:

    while ./digits-test digits/model/images/classification/test_views.py:TestTorchLeNetHdf5Shuffle.test_classify_one_json; do echo 1; done

After the fix, it runs for many minutes without error. @gheinrich why had you added this originally?