### PR TITLE
Small changes to the "About" dropdown

### DIFF
--- a/digits/templates/layout.html
+++ b/digits/templates/layout.html
@@ -63,13 +63,18 @@
             <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">About<span class="caret"></span></a>
                 <ul class="dropdown-menu about-menu navbar-inverse">
-                    <li><span class="navbar-text brightness"><a target="_blank" href="https://developer.nvidia.com/digits">
+                    <li><span class="navbar-text"><a target="_blank" href="https://developer.nvidia.com/digits">
                         DIGITS on developer.nvidia.com
                     </a></span></li>
-                    <li><span class="navbar-text"><a target="_blank" href="https://github.com/NVIDIA/DIGITS/tree/master/docs">DIGITS docs</a></span></li>
-                    <li><span class="navbar-text"><a target="_blank" href="https://github.com/NVIDIA/DIGITS">DIGITS on github</a></span></li>
-                    <li><span class="navbar-text"><a target="_blank" href="https://groups.google.com/forum/#!forum/digits-users">DIGITS User Group</a></span></li>
-                    <li><span class="navbar-text"><a href="mailto:digits@nvidia.com">digits@nvidia.com</a></span></li>
+                    <li><span class="navbar-text"><a target="_blank" href="https://github.com/NVIDIA/DIGITS">
+                        DIGITS on GitHub
+                    </a></span></li>
+                    <li><span class="navbar-text"><a target="_blank" href="https://groups.google.com/d/forum/digits-users">
+                        DIGITS user group
+                    </a></span></li>
+                    <li><span class="navbar-text"><a href="mailto:digits@nvidia.com">
+                        digits@nvidia.com
+                    </a></span></li>
                 </ul>
             </li>
         </ul>


### PR DESCRIPTION
* Why is `class=brightness` there for just one element?
* I feel like "DIGITS on GitHub" and "DIGITS docs" are nearly redundant
* Capitalization changes

/cc @jmancewicz 