### PR TITLE
Move digits-devserver to allow "python -m digits"

### DIFF
--- a/digits-devserver
+++ b/digits-devserver
@@ -1,50 +1,6 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+#!/bin/bash
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 
-import argparse
-import sys
+set -e
 
-import digits
-import digits.config
-import digits.log
-from digits.webapp import app, socketio, scheduler
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Run the DIGITS development server')
-    parser.add_argument('-p', '--port',
-            type=int,
-            default=5000,
-            help='Port to run app on (default 5000)'
-            )
-    parser.add_argument('-d', '--debug',
-            action='store_true',
-            help='Run the application in debug mode (reloads when the source changes and gives more detailed error messages)'
-            )
-    parser.add_argument('--version',
-            action='store_true',
-            help='Print the version number and exit'
-            )
-
-    args = vars(parser.parse_args())
-
-    if args['version']:
-        print digits.__version__
-        sys.exit()
-
-    print '  ___ ___ ___ ___ _____ ___'
-    print ' |   \_ _/ __|_ _|_   _/ __|'
-    print ' | |) | | (_ || |  | | \__ \\'
-    print ' |___/___\___|___| |_| |___/', digits.__version__
-    print
-
-    try:
-        if not scheduler.start():
-            print 'ERROR: Scheduler would not start'
-        else:
-            app.debug = args['debug']
-            socketio.run(app, '0.0.0.0', args['port'])
-    except KeyboardInterrupt:
-        pass
-    finally:
-        scheduler.stop()
-
+python -m digits

--- a/digits/__main__.py
+++ b/digits/__main__.py
@@ -7,7 +7,8 @@ import digits
 import digits.config
 import digits.log
 
-if __name__ == '__main__':
+
+def main():
     parser = argparse.ArgumentParser(description='DIGITS development server')
     parser.add_argument('-p', '--port',
             type=int,
@@ -48,3 +49,6 @@ if __name__ == '__main__':
     finally:
         digits.webapp.scheduler.stop()
 
+
+if __name__ == '__main__':
+    main()

--- a/digits/__main__.py
+++ b/digits/__main__.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
+
+import argparse
+import sys
+
+import digits
+import digits.config
+import digits.log
+from digits.webapp import app, socketio, scheduler
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='DIGITS development server')
+    parser.add_argument('-p', '--port',
+            type=int,
+            default=5000,
+            help='Port to run app on (default 5000)'
+            )
+    parser.add_argument('-d', '--debug',
+            action='store_true',
+            help='Run the application in debug mode (reloads when the source changes and gives more detailed error messages)'
+            )
+    parser.add_argument('--version',
+            action='store_true',
+            help='Print the version number and exit'
+            )
+
+    args = vars(parser.parse_args())
+
+    if args['version']:
+        print digits.__version__
+        sys.exit()
+
+
+    print '  ___ ___ ___ ___ _____ ___'
+    print ' |   \_ _/ __|_ _|_   _/ __|'
+    print ' | |) | | (_ || |  | | \__ \\'
+    print ' |___/___\___|___| |_| |___/', digits.__version__
+    print
+
+    try:
+        if not scheduler.start():
+            print 'ERROR: Scheduler would not start'
+        else:
+            app.debug = args['debug']
+            socketio.run(app, '0.0.0.0', args['port'])
+    except KeyboardInterrupt:
+        pass
+    finally:
+        scheduler.stop()
+

--- a/digits/__main__.py
+++ b/digits/__main__.py
@@ -6,7 +6,6 @@ import sys
 import digits
 import digits.config
 import digits.log
-from digits.webapp import app, socketio, scheduler
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='DIGITS development server')
@@ -30,21 +29,22 @@ if __name__ == '__main__':
         print digits.__version__
         sys.exit()
 
-
     print '  ___ ___ ___ ___ _____ ___'
     print ' |   \_ _/ __|_ _|_   _/ __|'
     print ' | |) | | (_ || |  | | \__ \\'
     print ' |___/___\___|___| |_| |___/', digits.__version__
     print
 
+    import digits.webapp
+
     try:
-        if not scheduler.start():
+        if not digits.webapp.scheduler.start():
             print 'ERROR: Scheduler would not start'
         else:
-            app.debug = args['debug']
-            socketio.run(app, '0.0.0.0', args['port'])
+            digits.webapp.app.debug = args['debug']
+            digits.webapp.socketio.run(digits.webapp.app, '0.0.0.0', args['port'])
     except KeyboardInterrupt:
         pass
     finally:
-        scheduler.stop()
+        digits.webapp.scheduler.stop()
 


### PR DESCRIPTION
This is a totally transparent change because I've left a working `digits-devserver` script in place.

Other projects with a `__main__.py`: [Flask](https://github.com/pallets/flask/blob/master/flask/__main__.py), [pip](https://github.com/pypa/pip/blob/master/pip/__main__.py), [lmdb](https://github.com/dw/py-lmdb/blob/master/lmdb/__main__.py), etc.

I think this change is useful as-is. Future changes/improvements could be:

* Get rid of the `digits-devserver` and `digits-server` scripts entirely
* Refactor `__main__.py` to move most code into another file like `digits/main.py` or `digits/cli.py`
* Change `setup.py` to use `entry_points={'console_scripts'=[...]}` ([blog post](https://chriswarrick.com/blog/2014/09/15/python-apps-the-right-way-entry_points-and-scripts/))