### PR TITLE
Fix bug in digits/__main__.py

### DIFF
--- a/digits/__main__.py
+++ b/digits/__main__.py
@@ -1,7 +1,19 @@
 # Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
 import argparse
+import os.path
 import sys
+
+
+# Update PATH to include the local DIGITS directory
+PARENT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+found_parent_dir = False
+for p in sys.path:
+    if os.path.abspath(p) == PARENT_DIR:
+        found_parent_dir = True
+        break
+if not found_parent_dir:
+    sys.path.insert(0, PARENT_DIR)
 
 
 def main():


### PR DESCRIPTION
Fix another bug from https://github.com/NVIDIA/DIGITS/pull/1121 - sorry guys.

Without this fix:
```
$ ./digits-devserver -d
  ___ ___ ___ ___ _____ ___
 |   \_ _/ __|_ _|_   _/ __|
 | |) | | (_ || |  | | \__ \
 |___/___\___|___| |_| |___/ 4.1-dev

2016-09-27 09:20:27 [INFO ] Loaded 3 jobs.
 * Restarting with stat
Traceback (most recent call last):
  File "/home/lyeager/digits/digits/__main__.py", line 54, in <module>
    main()
  File "/home/lyeager/digits/digits/__main__.py", line 25, in main
    import digits
ImportError: No module named digits
```