### PR TITLE
Remove deb build from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,7 @@ before_script:
     - export OMP_NUM_THREADS=1
 
 script:
-    - ./digits-test -v --with-coverage --cover-package=digits
-    - git fetch --tags
-    - ./packaging/deb/build.sh
+    ./digits-test -v --with-coverage --cover-package=digits
 
 after_success:
     coveralls


### PR DESCRIPTION
*Reverts https://github.com/NVIDIA/DIGITS/commit/918b545693198e58a7d35a20f4d6099781326fd7 from https://github.com/NVIDIA/DIGITS/pull/1113*

It makes it much harder to see why tests failed in the logs.

e.g. https://travis-ci.org/lukeyeager/DIGITS/builds/163531598