### PR TITLE
Torch - use absolute path to wrapper

### DIFF
--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -140,7 +140,9 @@ class TorchTrainTask(TrainTask):
         assert dataset_backend=='lmdb' or dataset_backend=='hdf5'
 
         args = [config_value('torch')['executable'],
-                os.path.join(os.path.dirname(digits.__file__),'tools','torch','wrapper.lua'),
+                os.path.join(
+                    os.path.dirname(os.path.abspath(digits.__file__)),
+                    'tools', 'torch', 'wrapper.lua'),
                 'main.lua',
                 '--network=%s' % self.model_file.split(".")[0],
                 '--epoch=%d' % int(self.train_epochs),
@@ -525,7 +527,9 @@ class TorchTrainTask(TrainTask):
         file_to_load = self.get_snapshot(snapshot_epoch)
 
         args = [config_value('torch')['executable'],
-                os.path.join(os.path.dirname(digits.__file__),'tools','torch','wrapper.lua'),
+                os.path.join(
+                    os.path.dirname(os.path.abspath(digits.__file__)),
+                    'tools', 'torch', 'wrapper.lua'),
                 'test.lua',
                 '--image=%s' % temp_image_path,
                 '--network=%s' % self.model_file.split(".")[0],
@@ -823,7 +827,9 @@ class TorchTrainTask(TrainTask):
             file_to_load = self.get_snapshot(snapshot_epoch)
 
             args = [config_value('torch')['executable'],
-                    os.path.join(os.path.dirname(digits.__file__),'tools','torch','wrapper.lua'),
+                    os.path.join(
+                        os.path.dirname(os.path.abspath(digits.__file__)),
+                        'tools', 'torch', 'wrapper.lua'),
                     'test.lua',
                     '--testMany=yes',
                     '--allPredictions=yes',   #all predictions are grabbed and formatted as required by DIGITS


### PR DESCRIPTION
I keep running into this issue occasionally. We can keep trying to fix it on the entry-point to DIGITS, but it's simpler to just double-check in the Torch code.