### PR TITLE
Make it easier to fine-tune FCN-Alexnet for different number of classes

### DIFF
--- a/examples/medical-imaging/README.md
+++ b/examples/medical-imaging/README.md
@@ -254,8 +254,6 @@ Now that we have a dataset of RGB images, we can easily re-use the pre-trained F
 - name your model `FCN-Alexnet-Sunnybrooke_with_dice-pretrained`
 - set the number of training epochs to `30`
 
-You will also need to rename the `score_fr` and `upscore` layers, since those have a different number of outputs from those we used in the semantic segmentation example.
-
 When you are ready, click `Create`.
 You will see that after a small number of epochs, the Dice coefficient starts increasing to finally exceed 0.6:
 

--- a/examples/semantic-segmentation/fcn_alexnet.deploy.prototxt
+++ b/examples/semantic-segmentation/fcn_alexnet.deploy.prototxt
@@ -225,10 +225,10 @@ layer {
   }
 }
 layer {
-  name: "score_fr"
+  name: "score_fr_21classes"
   type: "Convolution"
   bottom: "fc7"
-  top: "score_fr"
+  top: "score_fr_21classes"
   param {
     lr_mult: 1
     decay_mult: 1
@@ -244,10 +244,10 @@ layer {
   }
 }
 layer {
-  name: "upscore"
+  name: "upscore_21classes"
   type: "Deconvolution"
-  bottom: "score_fr"
-  top: "upscore"
+  bottom: "score_fr_21classes"
+  top: "upscore_21classes"
   param {
     lr_mult: 0
   }
@@ -263,7 +263,7 @@ layer {
 layer {
   name: "score"
   type: "Crop"
-  bottom: "upscore"
+  bottom: "upscore_21classes"
   bottom: "data"
   top: "score"
   crop_param {


### PR DESCRIPTION
Update layer names in prototxt used to perform net surgery.
Doing this will mean Caffe won't attempt to re-use those weights.
This removes the need to rename the layer in the user-defined net description when working with a different number of classes.