### PR TITLE
Modelstore ui

### DIFF
--- a/digits/static/js/digits.js
+++ b/digits/static/js/digits.js
@@ -1,13 +1,13 @@
 // Copyright (c) 2014-2016, NVIDIA CORPORATION.  All rights reserved.
 
-function errorAlert(data) {
+function errorAlert(response) {
     var title, msg;
-    if (data.status == 0) {
+    if (response.status == 0) {
         title = 'An error occurred!';
         msg = '<p class="text-danger">The server may be down.</p>';
     } else {
-        title = data.status + ': ' + data.statusText;
-        msg = data.responseText;
+        title = response.status + ': ' + response.statusText;
+        msg = response.responseText ? response.responseText : response.data;
     }
     bootbox.alert({
         title: title,

--- a/digits/static/js/store.js
+++ b/digits/static/js/store.js
@@ -1,32 +1,65 @@
 // Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 
 (function(angular) {
-  'use strict';
-  var app = angular.module('modelStore', []);
-  app.controller('ModelListController', function($scope, $http) {
-      var end_point = '/store/models';
-      var get_model_list = function(refresh) {
-          $http({
-              method: 'GET',
-              url: end_point,
-              params: {refresh: refresh}
-          }).then(function successCallback(response) {
-                  $scope.groups = response.data;
-                  $scope.local_error = null;
-                  $scope.groups_length = Object.keys($scope.groups).length;
-                  console.log($scope.groups)
-              }, function errorCallback(response) {
-                  $scope.local_error = response.statusText;
-                  $scope.groups = null;
-                  $scope.groups_length = 0;
-          });
-      };
-      $scope.get_model_list = get_model_list;
-      get_model_list(0);
-  });
-  app.config(['$interpolateProvider', function($interpolateProvider) {
-      $interpolateProvider.startSymbol('{[');
-      $interpolateProvider.endSymbol(']}');
-  }]);
+    'use strict';
+    var app = angular.module('modelStore', []);
+    app.controller('ModelListController', function($scope, $http) {
+        var end_point = '/store/models';
+        var get_model_list = function(refresh) {
+            $http({
+                method: 'GET',
+                url: end_point,
+                params: {refresh: refresh}
+            }).then(function successCallback(response) {
+                $scope.groups = response.data;
+                $scope.local_error = null;
+                $scope.groups_length = Object.keys($scope.groups).length;
+            }, function errorCallback(response) {
+                errorAlert(response);
+                $scope.local_error = response.statusText;
+                $scope.groups = null;
+                $scope.groups_length = 0;
+            });
+        };
+        $scope.get_model_list = get_model_list;
+        get_model_list(0);
 
+        $scope.download = function(id) {
+            $http({
+                method: 'GET',
+                url: '/store/push?id=' + id,
+            }).then(function successCallback(response) {
+                // nothing
+            }, function errorCallback(response) {
+                errorAlert(response);
+            });
+        };
+
+        $scope.set_attribute = function(model_id, name, value) {
+            for (var key in $scope.groups) {
+                var model_list = $scope.groups[key].model_list;
+                for (var i in model_list) {
+                    if (model_list[i].id === model_id) {
+                        model_list[i][name] = value;
+                        return true;
+                    }
+                }
+            }
+            return false;
+        };
+    });
+    app.config(['$interpolateProvider', function($interpolateProvider) {
+        $interpolateProvider.startSymbol('{[');
+        $interpolateProvider.endSymbol(']}');
+    }]);
 })(window.angular);
+
+$(document).ready(function() {
+    socket.on('update', function (msg) {
+        var scope = angular.element(document.getElementById("modelList")).scope();
+        if (msg.update == 'progress') {
+            if (scope.set_attribute(msg.model_id, 'progress', msg.progress))
+                scope.$apply();
+        }
+    });
+});

--- a/digits/templates/store.html
+++ b/digits/templates/store.html
@@ -12,116 +12,153 @@
 <script type="text/javascript" src="{{ url_for('static', filename='js/jquery.sparkline.min.js', ver=dir_hash) }}"></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/store.js', ver=dir_hash) }}"></script>
 <script>
-    $(document).ready(function(){
-        $('[data-toggle="tooltip"]').tooltip();
-    });
+ $(document).ready(function(){
+     $('[data-toggle="tooltip"]').tooltip();
+ });
 </script>
 <link rel="stylesheet" href="{{ url_for('static', filename='css/table_selection.css', ver=dir_hash) }}">
+{% with namespace = "/jobs" %}
+{% set room = "job_management" %}
+{% include 'socketio.html' %}
+{% endwith %}
 <style>
-    body {
-    padding-top: 65px;
-    }
-    .dropdown-menu {
-         width: 220px !important;
-    }
-    .brightness {
-         display: inline-block;
-    }
-    .brightness img:hover {
-         opacity: .75;
-    }
-    .div-ellipsis {
-        white-space: nowrap;
-        max-width: 400px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-    .logo-column { min-width: 100px; }
+ body {
+     padding-top: 65px;
+ }
+ span.glyphicon {
+     color: grey;
+     cursor: pointer;
+ }
+ span.glyphicon:hover {
+     color: black;
+ }
+
+ div.progress-line-parent {
+     position: relative;
+ }
+ div.progress-line {
+     content: "";
+     position: absolute;
+     bottom: 0;
+     left: 0;
+     width: 0;
+     height: 2px;
+     background-color: rgb(51, 122, 183);
+ }
 </style>
 {% endblock %}
 
 {% block content %}
-<div id="modelList" ng-app="modelStore" ng-controller="ModelListController">
-    <div class="panel panel-default col-md-12">
-        <div class="input-group">
-          <span class="input-group-addon" id="basic-addon1">Filter list by:</span>
-          <input type="text" ng-model="query" class="form-control" placeholder="query" aria-describedby="basic-addon1">
-        </div>
-        <button type="button" class="btn btn-info" ng-click="get_model_list(1)">Update model list</button>
-        <div ng-show="groups_length==0"> No models in Model Store</div>
-        <div ng-hide="groups_length==0" ng-repeat="(key, value) in groups">
-            <div class="panel-heading">
-                <div ng-show="local_error != null">{[ local_error ]}</div>
-                <div> model store url: {[value.base_url]} </div>
+<div class="row" style="margin-bottom: 45px;">
+    <h1>Model Store</h1>
+</div>
+<div id="modelList" class="row" ng-app="modelStore" ng-controller="ModelListController">
+    <button type="button" class="btn btn-xs btn-primary" ng-click="get_model_list(1)">Update Model List</button>
+    <div ng-show="groups_length==0">
+        <h4>
+            No models in Model Store
+        </h4>
+    </div>
+    <div ng-hide="groups_length==0" class="well">
+        <!-- Filter -->
+        <div class="col-md-12">
+            <div class="pull-right">
+                <form>
+                    <div class="form-group">
+                        <div class="input-group">
+                            <div class="input-group-addon"><i class="glyphicon glyphicon-search"></i></div>
+                            <input type="text" class="form-control" placeholder="Filter" ng-model="query">
+                        </div>
+                    </div>
+                </form>
             </div>
-            <div class="panel-body">
-                <table class="table table-bordered table-hover" style="word-wrap: break-word">
-                    <thead>
-                    <tr>
-                        <th></th>
-                        <th>Name</th>
-                        <th>Contributor</th>
-                        <th>Affiliate</th>
-                        <th>Note</th>
-                        <th>Data sets</th>
-                        <th>License</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr ng-repeat="model in value.model_list | filter: query">
-                        <td>
-                            <a href="/store/push?id={[model.id]}"> Import </a>
-                        </td>
-                        <td>
+        </div>
+        <table class="table table-bordered table-striped list-group selectable"
+               style="word-wrap: break-word"
+               width="100%">
+            <thead>
+                <tr>
+                    <th style="width:24px"></th>
+                    <th>Name</th>
+                    <th>Contributor</th>
+                    <th>Affiliate</th>
+                    <th>Note</th>
+                    <th>Data sets</th>
+                    <th>License</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat-start="(key, value) in groups" ng-hide="true"> </tr>
+                <!-- group bar -->
+                <tr class="unselectable group-bar">
+                    <td colspan="7" style="background-color:#cccccc" title="{[ value.base_url ]}">
+                        <strong>{[ value.welcome_msg ? value.welcome_msg : value.base_url ]}</strong>
+                        <span ng-show="local_error != null">{[ local_error ]}</span>
+                    </td>
+                </tr>
+                <tr ng-repeat="model in value.model_list | filter: query">
+                    <td>
+                        <span ng-click="download(model.id);"
+                              title="Download"
+                              class="glyphicon glyphicon-download-alt">
+                        </span>
+                    </td>
+                    <td>
+                        <div class="progress-line-parent">
                             {[ model.info.name ]}
-                        </td>
-                        <td>
-                            {[ model.info.username ]}
-                        </td>
-                        <td>
-                            <img ng-show="model.aux.logo" ng-src="{[value.base_url+model.dir_name]}/{[model.aux.logo]}" height="30" width="40"/>
-                        </td>
-                        <td>
-                            <div data-toggle="tooltip" title="{[model.info.note]}">
-                                {[ model.info.note ]}
+                            <div class="progress-line"
+                                 ng-style="{width : ( model.progress + '%' ) }">
                             </div>
-                        </td>
-                        <td>
-                            {[ model.aux.dataset ]}
-                        </td>
-                        <td ng-show="false">
-                            <div>
-                                <!-- Trigger the modal with a button -->
-                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#{[value.id+model.name]}">
-                                    {[model.info.license ]}
-                                </button>
-                            </div>
-                            <div id="{[value.id+model.name]}" class="modal fade" role="dialog">
-                              <div class="modal-dialog">
+                        </div>
+                    </td>
+                    <td>
+                        {[ model.info.username ]}
+                    </td>
+                    <td>
+                        <img ng-show="model.aux.logo" ng-src="{[value.base_url+model.dir_name]}/{[model.aux.logo]}" height="30" width="40"/>
+                    </td>
+                    <td>
+                        <div data-toggle="tooltip" title="{[model.info.note]}">
+                            {[ model.info.note ]}
+                        </div>
+                    </td>
+                    <td>
+                        {[ model.aux.dataset ]}
+                    </td>
+                    <td ng-show="false">
+                        <div>
+                            <!-- Trigger the modal with a button -->
+                            <button type="button" class="btn btn-info" data-toggle="modal" data-target="#{[value.id+model.name]}">
+                                {[model.info.license ]}
+                            </button>
+                        </div>
+                        <div id="{[value.id+model.name]}" class="modal fade" role="dialog">
+                            <div class="modal-dialog">
                                 <!-- Modal content-->
                                 <div class="modal-content">
-                                  <div class="modal-header">
-                                    <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                    <h4 class="modal-title">License</h4>
-                                  </div>
-                                  <div class="modal-body">
-                                    <p> {[model.license_text]} </p>
-                                  </div>
-                                  <div class="modal-footer">
-                                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                                  </div>
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                        <h4 class="modal-title">License</h4>
+                                    </div>
+                                    <div class="modal-body">
+                                        <p> {[model.license_text]} </p>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                    </div>
                                 </div>
-                              </div>
                             </div>
-                        </td>
-                        <td>
-                            <a  ng-show="model.aux.license" href="{[value.base_url+model.dir_name]}/license.txt">{[model.aux.license]}</a>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
+                        </div>
+                    </td>
+                    <td>
+                        <a ng-show="model.aux.license" href="{[value.base_url+model.dir_name]}/license.txt">{[model.aux.license]}</a>
+                    </td>
+                </tr>
+                <tr ng-repeat-end
+                    ng-hide="true">
+                </tr>
+            </tbody>
+        </table>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Making the Model Store page more consistent with the DIGITS front page and adding a download progress bar.

Moving from this look;
![old](https://cloud.githubusercontent.com/assets/13259615/19330671/ae7a7b44-9094-11e6-8737-b212568da2af.png)

To this look;
![new](https://cloud.githubusercontent.com/assets/13259615/19330681/bfa34478-9094-11e6-82a7-96e631e03ca4.png)

I also stopped the redirection to the front page after download was complete.

The progress bar is a progress line at the moment, under the model name to save real estate.
