### PR TITLE
[Debuild] Tell pydist which package provides skfmm

### DIFF
--- a/packaging/deb/templates/pydist-overrides
+++ b/packaging/deb/templates/pydist-overrides
@@ -1,1 +1,2 @@
 flask-socketio python-flaskext.socketio
+scikit-fmm python-skfmm


### PR DESCRIPTION
*Close https://github.com/NVIDIA/DIGITS/issues/1158*

I built a package for scikit-fmm that we'll provide going forward.