### PR TITLE
Additional image segmentation view options

### DIFF
--- a/digits/extensions/view/imageSegmentation/app_begin_template.html
+++ b/digits/extensions/view/imageSegmentation/app_begin_template.html
@@ -2,6 +2,64 @@
 
 <div ng-app="visualization_app" class="ng-cloak">
     <div ng-controller="display_controller as dispaly">
+        <?xml version="1.0"?>
+        <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="0px">
+            <defs>
+                <filter id="Gamma">
+                    <feComponentTransfer>
+                        <feFuncR type="gamma" amplitude="1" exponent="{[storage.gamma]}" offset="0"/>
+                        <feFuncG type="gamma" amplitude="1" exponent="{[storage.gamma]}" offset="0"/>
+                        <feFuncB type="gamma" amplitude="1" exponent="{[storage.gamma]}" offset="0"/>
+                    </feComponentTransfer>
+                </filter>
+                <filter id="Colormap">
+                    <!-- Convert to graysclae -->
+                    <feColorMatrix
+                            type="matrix"
+                            values="0.2126 0.7152 0.0722 0 0 0.2126 0.7152 0.0722 0 0 0.2126 0.7152 0.0722 0 0 0 0 0 1 0"/>
+
+                    <!-- The result of the feColorMatrix will be fed into the feComponentTransfer -->
+                    <feComponentTransfer >
+                        <feFuncR type="table" tableValues="0,0,0,0,0.5,1,1,1,0.5"/>
+                        <feFuncG type="table" tableValues="0,0,0.5,1,1,1,0.5,0,0"/>
+                        <feFuncB type="table" tableValues="0.5,1,1,1,0.5,0,0,0,0"/>
+                    </feComponentTransfer>
+                </filter>
+                <filter id="Segment">
+                    <feComponentTransfer>
+                        <feFuncA type="table" id="segment-a"/>
+                    </feComponentTransfer>
+                </filter>
+                <filter id="BinarySegment">
+                    <feColorMatrix
+                            type="matrix"
+                            values="0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0"/>
+
+                    <feComponentTransfer>
+                        <feFuncR type="table" id="binary-segment-r"/>
+                        <feFuncG type="table" id="binary-segment-g"/>
+                        <feFuncB type="table" id="binary-segment-b"/>
+                        <feFuncA type="table" id="binary-segment-a"/>
+                    </feComponentTransfer>
+                </filter>
+            </defs>
+        </svg>
+        <style>
+         img.gamma {
+             filter: url(#Gamma);
+         }
+         div.colormap {
+             filter: url(#Colormap);
+         }
+         img.segment {
+             filter: url(#Segment);
+         }
+         img.binary-segment {
+             filter: url(#BinarySegment);
+         }
+        </style>
         <!-- Display Options -->
         <div class="pull-right">
             <div class="row">
@@ -22,10 +80,28 @@
                                 <small>Mask {[storage.mask * 100 | number : 0]}%</small>
                                 <input type="range" min="0" max="1" step="0.01" ng-model="storage.mask">
                             </li>
+                            <li ng-hide="!is_binary">
+                                <small>Threshold {[storage.threshold]}</small>
+                                <input type="range" min="-126" max="127" step="1" ng-model="storage.threshold">
+                            </li>
+                            <li>
+                                <small>Line Width {[storage.line_width]}</small>
+                                <input type="range" min="0" max="6" step="1" ng-model="storage.line_width">
+                            </li>
+                            <li>
+                                <small>Gamma {[storage.gamma | number : 2]}</small>
+                                <input type="range" min="0.01" max="1" step="0.01" ng-model="storage.gamma">
+                            </li>
+                            <li>
+                                <label style="font-weight: normal !important;">
+                                    <input type="checkbox" ng-model='storage.colormap'>
+                                    Colormap
+                                </label>
+                            </li>
                             <!-- reset -->
                             <li>
                                 <button type="button" class="btn btn-default btn-sm dropdown-toggle"
-                                        ng-click="storage.opacity = 0.3; storage.mask = 0;"
+                                        ng-click="defaults();"
                                         title="Reset to defaults">
                                     <span class="glyphicon glyphicon-refresh"></span>
                                 </button>

--- a/digits/extensions/view/imageSegmentation/static/css/app.css
+++ b/digits/extensions/view/imageSegmentation/static/css/app.css
@@ -9,12 +9,6 @@
      left: 0px;
      top: 0px;
  }
- img.fill {
-     z-index: 1;
- }
- img.mask {
-     z-index: 2;
- }
  caption {
      caption-side: bottom;
  }

--- a/digits/extensions/view/imageSegmentation/static/js/app.js
+++ b/digits/extensions/view/imageSegmentation/static/js/app.js
@@ -8,23 +8,57 @@ app.controller('display_controller',
                ['$scope', '$rootScope', '$localStorage',
                 function($scope, $rootScope, $localStorage) {
                     $rootScope.storage = $localStorage.$default({
-                        opacity: .3,
+                        gamma: 1.0,
+                        opacity: 0.3,
                         mask: 0.0,
+                        threshold: 0,
+                        line_width: 3,
+                        colormap: false,
                     });
-                    $scope.fill_style = {'opacity': $localStorage.opacity};
-                    $scope.mask_style = {'opacity': $localStorage.mask};
-                    // Broadcast to child scopes that the opacity has changed.
+                    $scope.is_binary = false;
+                    $scope.build_segment = function () {
+                        var c = new Array(256);
+                        var a = new Array(256);
+                        // The segmentation boundary distance 128
+                        var threshold = $scope.is_binary ? Number($localStorage.threshold) + 128 : 128;
+                        for (var i = 0; i < 256; i++) {
+                            c[i] = (i < threshold ? 0.0 : 1.0);
+                            a[i] = (i == 0 ? 0 :
+                                i < threshold ? $localStorage.mask :
+                                    i < threshold + Number($localStorage.line_width) ? 1 :
+                                        $localStorage.opacity);
+                        }
+                        var color = c.join(',');
+                        var alpha = a.join(',');
+                        // For some reason, the tableValues can not reference an angular variable, so set it here.
+                        if ($scope.is_binary) {
+                            document.getElementById("binary-segment-r").setAttribute("tableValues", color);
+                            document.getElementById("binary-segment-g").setAttribute("tableValues", color);
+                            document.getElementById("binary-segment-b").setAttribute("tableValues", color);
+                            document.getElementById("binary-segment-a").setAttribute("tableValues", alpha);
+                        } else {
+                            document.getElementById("segment-a").setAttribute("tableValues", alpha);
+                        }
+                    };
+                    $scope.build_segment();
+                    $scope.set_binary = function (v) {
+                        if ($scope.is_binary == v) return;
+                        $scope.is_binary = v;
+                        $scope.build_segment();
+                    };
                     $scope.$watch(function() {
-                        return $localStorage.opacity;
+                        return [$localStorage.opacity, $localStorage.mask, $localStorage.line_width, $localStorage.threshold].join(',');
                     }, function() {
-                        $scope.fill_style = {'opacity': $localStorage.opacity};
+                        $scope.build_segment();
                     });
-                    // Broadcast to child scopes that the mask has changed.
-                    $scope.$watch(function() {
-                        return $localStorage.mask;
-                    }, function() {
-                        $scope.mask_style = {'opacity': $localStorage.mask};
-                    });
+                    $scope.defaults = function() {
+                        $localStorage.gamma = 1.0;
+                        $localStorage.opacity = 0.3;
+                        $localStorage.mask = 0.0;
+                        $localStorage.threshold = 0;
+                        $localStorage.line_width = 3;
+                        $localStorage.colormap = false;
+                    };
                 }]);
 
 // Because jinja uses {{ and }}, tell angular to use {[ and ]}

--- a/digits/extensions/view/imageSegmentation/view_template.html
+++ b/digits/extensions/view/imageSegmentation/view_template.html
@@ -1,21 +1,20 @@
 {# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved. #}
 
+{[ set_binary('{{ is_binary }}' == 'True');'' ]}
 <div>
 	<!-- table is used for the sake of the caption -->
     <table>
         <tr>
             <td>
                 <div class="vis-div">
-                    <img src="{{input_image}}"
-                         style="max-width:100%;"/>
-                    <img src="{{fill_image}}"
+                    <div ng-class="{colormap : storage.colormap}">
+                        <img src="{{input_image}}"
+                             class="gamma"
+                             style="max-width:100%;"/>
+                    </div>
+                    <img src="{{seg_image}}"
                          style="max-width:100%;"
-                         ng-style="fill_style;"
-                         class="fill overlay"/>
-                    <img src="{{mask_image}}"
-                         style="max-width:100%;"
-                         ng-style="mask_style;"
-                         class="mask overlay"
+                         class="overlay {{ 'binary-segment' if is_binary else 'segment' }}"
                          id="image-{{ input_id }}"/>
                 </div>
             </td>
@@ -39,7 +38,6 @@
 </div>
 
 <script>
-
  function get_mouse_pos(event) {
      var rect = event.target.getBoundingClientRect();
      return {


### PR DESCRIPTION
Adding view options for image segmentation. 

![screen shot 2016-10-19 at 12 20 01 pm](https://cloud.githubusercontent.com/assets/13259615/19533874/68c4499c-95f6-11e6-8d0a-863f609bf591.png)

The existing Opacity slider changes the opacity of the fill region.
![screen shot 2016-10-19 at 12 21 43 pm](https://cloud.githubusercontent.com/assets/13259615/19534156/9433b60c-95f7-11e6-98bf-c78424501691.png)

The Mask slider changes the opacity of the non-segmented area. I find this useful to find small segments.
![screen shot 2016-10-19 at 12 22 00 pm](https://cloud.githubusercontent.com/assets/13259615/19534161/987fd01a-95f7-11e6-8bb1-fa2030bb0cae.png)

The Threshold slider changes the moves in the distance field around segmentation boundaries.
![screen shot 2016-10-19 at 12 22 18 pm](https://cloud.githubusercontent.com/assets/13259615/19534228/d9926fe0-95f7-11e6-929d-a5cc2a7a0952.png)

The Line Width does what you think
![screen shot 2016-10-19 at 12 22 32 pm](https://cloud.githubusercontent.com/assets/13259615/19534254/ee199c68-95f7-11e6-8018-48384afd581d.png)

Gamma along with the Colormap can make the grey scale medical images a little easier to read.
![screen shot 2016-10-19 at 12 23 16 pm](https://cloud.githubusercontent.com/assets/13259615/19534344/409c4f4e-95f8-11e6-842f-9d5f5d43b00b.png)

Also, if the inference feature image comes through as a float array, and PIL won't convert it to an image, then the data is normalized to its range and converted to uint8 so that it will be converted to a PIL.Image.