### PR TITLE
Bugfix for customizing previous models

### DIFF
--- a/digits/model/views.py
+++ b/digits/model/views.py
@@ -91,6 +91,7 @@ def customize():
         python_layer = job.get_python_layer_path()
     else:
         network = job.train_task().get_network_desc()
+        python_layer = None
 
     return json.dumps({
             'network': network,


### PR DESCRIPTION
*Fix #1215*
*Bug comes from https://github.com/NVIDIA/DIGITS/pull/1156*

To reproduce:
* Go to "New Image Classification Model"
* Click on "Previous Networks"
* Pick a network and try to "Customize" it