### PR TITLE
Bugfix: __all__ misused in plugins/

### DIFF
--- a/plugins/data/imageGradients/digitsDataPluginImageGradients/__init__.py
+++ b/plugins/data/imageGradients/digitsDataPluginImageGradients/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 
 from .data import DataIngestion
 
-__all__ = [DataIngestion]
+__all__ = ['DataIngestion']

--- a/plugins/data/sunnybrook/digitsDataPluginSunnybrook/__init__.py
+++ b/plugins/data/sunnybrook/digitsDataPluginSunnybrook/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 
 from .data import DataIngestion
 
-__all__ = [DataIngestion]
+__all__ = ['DataIngestion']

--- a/plugins/data/textClassification/digitsDataPluginTextClassification/__init__.py
+++ b/plugins/data/textClassification/digitsDataPluginTextClassification/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 
 from .data import DataIngestion
 
-__all__ = [DataIngestion]
+__all__ = ['DataIngestion']

--- a/plugins/view/imageGradients/digitsViewPluginImageGradients/__init__.py
+++ b/plugins/view/imageGradients/digitsViewPluginImageGradients/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 
 from .view import Visualization
 
-__all__ = [Visualization]
+__all__ = ['Visualization']

--- a/plugins/view/textClassification/digitsViewPluginTextClassification/__init__.py
+++ b/plugins/view/textClassification/digitsViewPluginTextClassification/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 
 from .view import Visualization
 
-__all__ = [Visualization]
+__all__ = ['Visualization']


### PR DESCRIPTION
`__all__` is supposed to contain an array of strings. My bad from https://github.com/NVIDIA/DIGITS/pull/1198.
```
$ python -c "from digitsDataPluginImageGradients import *"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: Item in ``from list'' not a string
```