### PR TITLE
Fix Caffe search paths in Windows

### DIFF
--- a/digits/config/caffe.py
+++ b/digits/config/caffe.py
@@ -19,8 +19,12 @@ def load_from_envvar(envvar):
     """
     value = os.environ[envvar].strip().strip("\"' ")
 
-    executable_dir = os.path.join(value, 'build', 'tools')
-    python_dir = os.path.join(value, 'python')
+    if platform.system() == 'Windows':
+        executable_dir = os.path.join(value, 'install', 'bin')
+        python_dir = os.path.join(value, 'install', 'python')
+    else:
+        executable_dir = os.path.join(value, 'build', 'tools')
+        python_dir = os.path.join(value, 'python')
 
     try:
         executable = find_executable_in_dir(executable_dir)


### PR DESCRIPTION
This pull request fixes the problem that happens in Windows platforms when DIGITS tries to find where Caffe is installed, based on CAFFE_ROOT environment variable. Currently, the official Windows Caffe version is (https://github.com/bvlc/caffe/tree/windows), in which once the installation folder is generated (typically it should be a folder called "install" within the Caffe root folder), the caffe.exe executable is in the folder called "bin" and not in "build/tools" and pycaffe files are in the "python" folder inside it.