### PR TITLE
Add explicit error message for missing frameworks

### DIFF
--- a/digits/inference/job.py
+++ b/digits/inference/job.py
@@ -27,6 +27,11 @@ class InferenceJob(Job):
         fw_id = model.train_task().framework_id
         fw = digits.frameworks.get_framework_by_id(fw_id)
 
+        if fw is None:
+            raise RuntimeError(
+                'The "%s" framework cannot be found. Check your server configuration.'
+                % fw_id)
+
         # create inference task
         self.tasks.append(fw.create_inference_task(
             job_dir=self.dir(),


### PR DESCRIPTION
This happens when you train a Torch model, then restart your server without Torch support and try to run inference on your model.

Throwing a clear error message helps to quickly explain the issue.