### PR TITLE
[Docs] Fix spelling errors in comments

### DIFF
--- a/digits/dataset/generic/job.py
+++ b/digits/dataset/generic/job.py
@@ -5,7 +5,7 @@ from ..job import DatasetJob
 from digits.dataset import tasks
 from digits.utils import subclass, override, constants
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 

--- a/digits/dataset/images/classification/job.py
+++ b/digits/dataset/images/classification/job.py
@@ -8,7 +8,7 @@ from digits.dataset import tasks
 from digits.status import Status
 from digits.utils import subclass, override, constants
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 2
 
 

--- a/digits/dataset/images/generic/job.py
+++ b/digits/dataset/images/generic/job.py
@@ -5,7 +5,7 @@ from ..job import ImageDatasetJob
 from digits.dataset import tasks
 from digits.utils import subclass, override, constants
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 

--- a/digits/dataset/images/job.py
+++ b/digits/dataset/images/job.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 from ..job import DatasetJob
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 

--- a/digits/dataset/job.py
+++ b/digits/dataset/job.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from digits.job import Job
 from digits.utils import subclass
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 

--- a/digits/dataset/tasks/analyze_db.py
+++ b/digits/dataset/tasks/analyze_db.py
@@ -9,7 +9,7 @@ import digits
 from digits.task import Task
 from digits.utils import subclass, override
 
-# NOTE: Increment this everytime the pickled object
+# NOTE: Increment this every time the pickled object
 PICKLE_VERSION = 1
 
 

--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -11,7 +11,7 @@ from digits import utils
 from digits.task import Task
 from digits.utils import subclass, override
 
-# NOTE: Increment this everytime the pickled version changes
+# NOTE: Increment this every time the pickled version changes
 PICKLE_VERSION = 3
 
 

--- a/digits/dataset/tasks/create_generic_db.py
+++ b/digits/dataset/tasks/create_generic_db.py
@@ -9,7 +9,7 @@ import digits
 from digits.task import Task
 from digits.utils import subclass, override
 
-# NOTE: Increment this everytime the pickled version changes
+# NOTE: Increment this every time the pickled version changes
 PICKLE_VERSION = 1
 
 

--- a/digits/dataset/tasks/parse_folder.py
+++ b/digits/dataset/tasks/parse_folder.py
@@ -10,7 +10,7 @@ from digits import utils
 from digits.task import Task
 from digits.utils import subclass, override
 
-# NOTE: Increment this everytime the pickled object
+# NOTE: Increment this every time the pickled object
 PICKLE_VERSION = 1
 
 

--- a/digits/extensions/data/objectDetection/README.md
+++ b/digits/extensions/data/objectDetection/README.md
@@ -150,7 +150,7 @@ All classes which don't exist in the provided mapping are implicitly mapped to 0
 DetectNet is a single-class object detection network, and only cares about the "Car" class, which is expected to be ID 1.
 You can change the mapping in the DetectNet prototxt, but it's simplest to just make the class you care about map to 1.
 
-Custom class mappings may be used by specifiying a comma-separated list of class names in the Object Detection dataset creation form.
+Custom class mappings may be used by specifying a comma-separated list of class names in the Object Detection dataset creation form.
 All labels are converted to lower-case, so the matching is case-insensitive.
 
 For example, if you only want to detect pedestrians, enter `dontcare,pedestrian` in the "Custom classes" field to generate this mapping:

--- a/digits/extensions/data/objectDetection/utils.py
+++ b/digits/extensions/data/objectDetection/utils.py
@@ -49,7 +49,7 @@ class GroundTruthObj:
                           truncated refers to the object leaving image boundaries.
                           -1 corresponds to a don't care region.
         1    occluded     Integer (-1,0,1,2) indicating occlusion state:
-                          -1 = unkown, 0 = fully visible,
+                          -1 = unknown, 0 = fully visible,
                           1 = partly occluded, 2 = largely occluded
         1    alpha        Observation angle of object, ranging [-pi..pi]
         4    bbox         2D bounding box of object in the image (0-based index):

--- a/digits/job.py
+++ b/digits/job.py
@@ -14,7 +14,7 @@ from .status import Status, StatusCls
 from digits.config import config_value
 from digits.utils import sizeof_fmt, filesystem as fs
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 2
 
 

--- a/digits/model/images/classification/job.py
+++ b/digits/model/images/classification/job.py
@@ -6,7 +6,7 @@ import os.path
 from ..job import ImageModelJob
 from digits.utils import subclass, override
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -663,7 +663,7 @@ def top_n():
         scores = last_output_data
 
         if scores is None:
-            raise RuntimeError('An error occured while processing the images')
+            raise RuntimeError('An error occurred while processing the images')
 
         labels = model_job.train_task().get_labels()
         images = inputs['data']

--- a/digits/model/images/generic/job.py
+++ b/digits/model/images/generic/job.py
@@ -6,7 +6,7 @@ import os.path
 from ..job import ImageModelJob
 from digits.utils import subclass, override
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 

--- a/digits/model/images/job.py
+++ b/digits/model/images/job.py
@@ -5,7 +5,7 @@ import datetime
 from ..job import ModelJob
 from digits.utils import subclass, override
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 

--- a/digits/model/job.py
+++ b/digits/model/job.py
@@ -5,7 +5,7 @@ from . import tasks
 from digits.job import Job
 from digits.utils import override
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -27,7 +27,7 @@ from digits.utils.filesystem import tail
 import caffe
 import caffe_pb2
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 5
 
 # Constants

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -22,7 +22,7 @@ from digits.utils import subclass, override, constants
 # Must import after importing digit.config
 import caffe_pb2
 
-# NOTE: Increment this everytime the pickled object changes
+# NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1
 
 # Constants

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -13,7 +13,7 @@ from digits import device_query
 from digits.task import Task
 from digits.utils import subclass, override
 
-# NOTE: Increment this everytime the picked object changes
+# NOTE: Increment this every time the picked object changes
 PICKLE_VERSION = 2
 
 # Used to store network outputs

--- a/digits/standard-networks/torch/ImageNet-Training/googlenet.lua
+++ b/digits/standard-networks/torch/ImageNet-Training/googlenet.lua
@@ -84,7 +84,7 @@ function createModel(nChannels, nClasses)
    main_branch:add(nn.Linear(1024,nClasses))
    main_branch:add(nn.LogSoftMax())
 
-   -- add auxillary classifier here (thanks to Christian Szegedy for the details)
+   -- add auxiliary classifier here (thanks to Christian Szegedy for the details)
    local aux_classifier = nn.Sequential()
    local l = backend.SpatialAveragePooling(5,5,3,3)
    if backend == cudnn then l = l:ceil() end

--- a/digits/task.py
+++ b/digits/task.py
@@ -17,7 +17,7 @@ from .config import config_value
 from .status import Status, StatusCls
 import digits.log
 
-# NOTE: Increment this everytime the pickled version changes
+# NOTE: Increment this every time the pickled version changes
 PICKLE_VERSION = 1
 
 

--- a/digits/tools/torch/LRPolicy.lua
+++ b/digits/tools/torch/LRPolicy.lua
@@ -42,7 +42,7 @@ function LRPolicy:__init(...)
     if self.policy == 'step' or self.policy == 'sigmoid' then
       self.step_size = self.step_values[1]     -- if the policy is not multistep, then even though multiple step values are provided as input, we will consider only the first value.
     elseif self.policy == 'multistep' then
-      self.current_step = 1       -- this counter is important to take arbitary steps
+      self.current_step = 1       -- this counter is important to take arbitrary steps
       self.stepvalue_size = #self.step_values
     end
 

--- a/digits/tools/torch/data.lua
+++ b/digits/tools/torch/data.lua
@@ -151,11 +151,11 @@ end
 local rot90 = function(im, rotFlag)
     local rot
     if rotFlag == 2 then
-        rot = im:transpose(2,3) --switch X and Y dimentions
+        rot = im:transpose(2,3) --switch X and Y dimensions
         rot = image.vflip(rot)
         return rot
     elseif rotFlag == 3 then
-        rot = im:transpose(2,3) --switch X and Y dimentions
+        rot = im:transpose(2,3) --switch X and Y dimensions
         rot = image.hflip(rot)
         return rot
     elseif rotFlag == 4 then -- vflip+hflip=180 deg rotation

--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -427,7 +427,7 @@ def vis_square(images,
             if C is not set, a heatmap is computed for the result
 
     Keyword arguments:
-    padsize -- how many pixels go inbetween the tiles
+    padsize -- how many pixels go between the tiles
     normalize -- if true, scales (min, max) across all images out to (0, 1)
     colormap -- a string representing one of the supported colormaps
     """

--- a/examples/medical-imaging/README.md
+++ b/examples/medical-imaging/README.md
@@ -298,4 +298,4 @@ This would allow us to directly aim for this metric during training.
 ### Data augmentation
 
 FCN-8s exhibits some amount of overfit: the training loss is consistently lower than the validation loss.
-In order to reduce overfit, we can artifically augment the training dataset by applying random perturbations (color, contract changes, etc.).
+In order to reduce overfit, we can artificially augment the training dataset by applying random perturbations (color, contract changes, etc.).


### PR DESCRIPTION
Fix spelling errors in comments with [codespell](https://github.com/lucasdemarchi/codespell/) (thanks to @CDLuminate for pointing this project out in https://github.com/BVLC/caffe/pull/5035).

```
pip install codespell
git ls-files | xargs codespell.py -q2 -w
```