### PR TITLE
Displaying affiliate name

### DIFF
--- a/digits/templates/store.html
+++ b/digits/templates/store.html
@@ -115,7 +115,7 @@
                         {[ model.info.username ]}
                     </td>
                     <td>
-                        <img ng-show="model.aux.logo" ng-src="{[value.base_url+model.dir_name]}/{[model.aux.logo]}" height="30" width="40"/>
+                        {[ model.aux.affiliate ]}
                     </td>
                     <td>
                         <div data-toggle="tooltip" title="{[model.info.note]}">


### PR DESCRIPTION
Not all affiliates have logo.  Change the affiliate column to display names in text.