### PR TITLE
[TravisCI] Cache local OpenBLAS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,9 @@ python: 2.7
 
 env:
     global:
+        - OPENBLAS_ROOT=~/openblas
         - CAFFE_ROOT=~/caffe
         - TORCH_ROOT=~/torch
-        # Fixes for Torch and OpenBLAS
-        - OMP_NUM_THREADS=1
-        - OPENBLAS_MAIN_FREE=1
         - secure: "WSqrE+PQm76DdoRLRGKTK6fRWfXZjIb0BWCZm3IgHgFO7OE6fcK2tBnpDNNw4XQjmo27FFWlEhxN32g18P84n5PvErHaH65IuS9Nv6FkLlPXZlVqGNxbPmEA4oTkD/6Y6kZyZWZtLh2+/1ijuzQAPnIy/4BEuL8pdO+PsoJ9hYM="
     matrix:
         - DIGITS_TEST_FRAMEWORK=caffe CAFFE_FORK=NVIDIA
@@ -72,6 +70,7 @@ matrix:
 cache:
     apt: true
     directories:
+        - $OPENBLAS_ROOT
         - $CAFFE_ROOT
         - $TORCH_ROOT
 
@@ -92,7 +91,6 @@ addons:
             - libhdf5-serial-dev
             - libleveldb-dev
             - liblmdb-dev
-            - libopenblas-dev
             - libopencv-dev
             - libprotobuf-dev
             - libsnappy-dev
@@ -126,8 +124,9 @@ before_install:
 install:
     - mkdir -p ~/.config/matplotlib
     - echo "backend:agg" > ~/.config/matplotlib/matplotlibrc
+    - ./scripts/travis/install-openblas.sh $OPENBLAS_ROOT
     - ./scripts/travis/install-caffe.sh $CAFFE_ROOT
-    - if [ "$DIGITS_TEST_FRAMEWORK" == "torch" ]; then travis_wait ./scripts/travis/install-torch.sh $TORCH_ROOT; else unset TORCH_ROOT; fi
+    - if [ "$DIGITS_TEST_FRAMEWORK" == "torch" ]; then ./scripts/travis/install-torch.sh $TORCH_ROOT; else unset TORCH_ROOT; fi
     - pip install -r ./requirements.txt
     - pip install -r ./requirements_test.txt
     - pip install -e .

--- a/scripts/travis/install-openblas.sh
+++ b/scripts/travis/install-openblas.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+set -e
+
+LOCAL_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+if [ "$#" -ne 1 ];
+then
+    echo "Usage: $0 INSTALL_DIR"
+    exit 1
+fi
+
+INSTALL_DIR=`readlink -f $1`
+if [ -d "$INSTALL_DIR" ] && ls $INSTALL_DIR/*.so >/dev/null 2>&1; then
+    echo "Using cached build at $INSTALL_DIR ..."
+else
+    rm -rf $INSTALL_DIR
+    git clone https://github.com/xianyi/OpenBLAS.git ${INSTALL_DIR} -b v0.2.18 --depth 1
+    cd $INSTALL_DIR
+
+    # Redirect build output to a log and only show it if an error occurs
+    # Otherwise there is too much output for TravisCI to display properly
+    LOG_FILE=$LOCAL_DIR/openblas-build.log
+    make NO_AFFINITY=1 USE_OPENMP=1 >$LOG_FILE 2>&1 || (cat $LOG_FILE && false)
+fi
+
+cd $INSTALL_DIR
+sudo make install PREFIX=/usr/local

--- a/scripts/travis/install-torch.sh
+++ b/scripts/travis/install-torch.sh
@@ -29,7 +29,7 @@ cd $INSTALL_DIR
 # Redirect build output to a log and only show it if an error occurs
 # Otherwise there is too much output for TravisCI to display properly
 LOG_FILE=$LOCAL_DIR/torch-install.log
-{ ./install-deps && ./install.sh -b ; } >$LOG_FILE 2>&1 || (cat $LOG_FILE && false)
+./install.sh -b >$LOG_FILE 2>&1 || (cat $LOG_FILE && false)
 
 # install custom packages
 ${INSTALL_DIR}/install/bin/luarocks install tds


### PR DESCRIPTION
*Fix https://github.com/NVIDIA/DIGITS/issues/1173, close https://github.com/NVIDIA/DIGITS/pull/1305*

We had only been building OpenBLAS from source when there was no cached
torch build present on the build machine. That meant you could get a
cached build of Torch which was built against one version of OpenBLAS,
but the system actually installed an older version. This led to memory
corruption and segmentation faults.