### PR TITLE
[Packaging] Make nginx site easier to customize programmatically

### DIFF
--- a/packaging/deb/extras/digits.nginx-site
+++ b/packaging/deb/extras/digits.nginx-site
@@ -44,8 +44,7 @@ server {
         alias /usr/lib/python2.7/dist-packages/digits/static;
     }
     location /files {
-        # This should mirror DIGITS_JOBS_DIR
-        alias /var/lib/digits/jobs;
+        alias /var/lib/digits/jobs; #AUTOCONFIG jobs_dir (DO NOT DELETE THIS LINE)
         autoindex on;
         autoindex_exact_size off;
         autoindex_localtime on;


### PR DESCRIPTION
The 3.0 and 4.0 packages had this. Somehow we lost it for 5.0.

This is a noop change which makes it easier for other packages to customize your DIGITS installation.