### PR TITLE
Always install default signal handler for SIGINT.

### DIFF
--- a/digits/__main__.py
+++ b/digits/__main__.py
@@ -3,6 +3,7 @@
 import argparse
 import os.path
 import sys
+import signal
 
 
 # Update PATH to include the local DIGITS directory
@@ -15,6 +16,8 @@ for p in sys.path:
 if not found_parent_dir:
     sys.path.insert(0, PARENT_DIR)
 
+# Install default signal handler for SIGINT
+signal.signal(signal.SIGINT, signal.default_int_handler)
 
 def main():
     parser = argparse.ArgumentParser(description='DIGITS server')


### PR DESCRIPTION
Reason for this fix is that in my case I created a systemd unit file for CentOS7. 

Issuing `systemctl stop digits` makes it send `SIGTERM` to the Python process, but there is no handler for this. In `packaging/deb/templates/digits.service` I see there is a "hack" for Debian (make systemd use SIGINT instead of SIGTERM), but that doesn't seem to work on CentOS7. So what I did is create a bash script that *traps* SIGTERM from systemd and translates it into a SIGINT for Python.

Anyway in this case, the way Python is launched (as a subshell) it won't register the default handler for SIGINT. This is a small fix that simply always registers the SIGINT handler.. More info: http://stackoverflow.com/questions/40775054/capturing-sigint-using-keyboardinterrupt-exception-works-in-terminal-not-in-scr/40785230#40785230

I have another suggestion, maybe it's a better idea to additionally listen for SIGTERM?
If that is preferred I can update this PR with that solution?
