### PR TITLE
socket.io prefix is not required

### DIFF
--- a/packaging/deb/extras/digits.nginx-site
+++ b/packaging/deb/extras/digits.nginx-site
@@ -20,7 +20,7 @@ server {
 
     # Socketio
     location /socket.io {
-        proxy_pass http://127.0.0.1:34448/socket.io;
+        proxy_pass http://127.0.0.1:34448;
         proxy_redirect off;
         proxy_buffering off;
 


### PR DESCRIPTION
socket.io prefix is not required