### PR TITLE
Correct shebang for prepare_pascal_voc_data.sh

### DIFF
--- a/examples/semantic-segmentation/prepare_pascal_voc_data.sh
+++ b/examples/semantic-segmentation/prepare_pascal_voc_data.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 # Copyright (c) 2016-2017, NVIDIA CORPORATION.  All rights reserved.
 
 if [ "$#" -ne 2 ]; then


### PR DESCRIPTION
This just a minor change. But the incorrect #/bin/bash creates problems for users of (t)csh