### PR TITLE
Fix shellcheck-related bug in PPA upload script

### DIFF
--- a/scripts/travis/ppa-upload.sh
+++ b/scripts/travis/ppa-upload.sh
@@ -19,10 +19,12 @@ openssl aes-256-cbc -in private.key.enc -out private.key -d \
     -K "$encrypted_34c893741e32_key" -iv "$encrypted_34c893741e32_iv"
 gpg --import private.key
 
-cd "$ROOT_DIR/packaging/deb/dist/*trusty"
+cd "$ROOT_DIR/packaging/deb/dist/"
+cd ./*trusty/
 debsign -k 97A4B458 ./*source.changes
 dput -U "ppa:nvidia-digits/${PPA_NAME}/ubuntu/trusty" ./*source.changes
 
-cd "$ROOT_DIR/packaging/deb/dist/*xenial"
+cd "$ROOT_DIR/packaging/deb/dist/"
+cd ./*xenial/
 debsign -k 97A4B458 ./*source.changes
 dput -U "ppa:nvidia-digits/${PPA_NAME}/ubuntu/xenial" ./*source.changes


### PR DESCRIPTION
Caused by https://github.com/NVIDIA/DIGITS/pull/1475.

> `./scripts/travis/ppa-upload.sh: line 22: cd: /home/travis/build/NVIDIA/DIGITS/packaging/deb/dist/*trusty: No such file or directory`
https://travis-ci.org/NVIDIA/DIGITS/jobs/205060340