### PR TITLE
Copy labels.txt inside the dataset (Fix #1462)

### DIFF
--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import os
+import shutil
 
 # Find the best implementation available
 try:
@@ -156,12 +157,14 @@ def from_files(job, form):
     """
     # labels
     if form.textfile_use_local_files.data:
-        job.labels_file = form.textfile_local_labels_file.data.strip()
+        labels_file_from = form.textfile_local_labels_file.data.strip()
+        labels_file_to = os.path.join(job.dir(), utils.constants.LABELS_FILE)
+        shutil.copyfile(labels_file_from, labels_file_to)
     else:
         flask.request.files[form.textfile_labels_file.name].save(
             os.path.join(job.dir(), utils.constants.LABELS_FILE)
         )
-        job.labels_file = utils.constants.LABELS_FILE
+    job.labels_file = utils.constants.LABELS_FILE
 
     shuffle = bool(form.textfile_shuffle.data)
     backend = form.backend.data

--- a/digits/model/tasks/train.py
+++ b/digits/model/tasks/train.py
@@ -470,7 +470,9 @@ class TrainTask(Task):
 
         assert hasattr(self.dataset, 'labels_file'), 'labels_file not set'
         assert self.dataset.labels_file, 'labels_file not set'
-        assert os.path.exists(self.dataset.path(self.dataset.labels_file)), 'labels_file does not exist'
+        assert os.path.exists(self.dataset.path(self.dataset.labels_file)), 'labels_file does not exist: {}'.format(
+            self.dataset.path(self.dataset.labels_file)
+        )
 
         labels = []
         with open(self.dataset.path(self.dataset.labels_file)) as infile:


### PR DESCRIPTION
This aims to fix #1462 

To test it, I created and moved Image Classification datasets between two machines and everything worked as expected. In addition, I created Classification Models using these datasets in both machines and they worked as expected as well.

The change made in `digits/model/tasks/train.py` was just to make the error more informative.