### PR TITLE
Fix Distribution Graph

### DIFF
--- a/digits/dataset/tasks/create_db.py
+++ b/digits/dataset/tasks/create_db.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2014-2017, NVIDIA CORPORATION.  All rights reserved.
 from __future__ import absolute_import
 
-import operator
 import os.path
 import re
 import sys
@@ -61,6 +60,7 @@ class CreateDbTask(Task):
             self.image_channel_order = None
 
         self.entries_count = None
+        self.entries_error = None
         self.distribution = None
         self.create_db_log_file = "create_%s.log" % db_name
 
@@ -98,6 +98,14 @@ class CreateDbTask(Task):
             self.backend = 'lmdb'
         if not hasattr(self, 'compression') or self.compression is None:
             self.compression = 'none'
+
+        if not hasattr(self, 'entries_error'):
+            self.entries_error = 0
+            for key in self.distribution.keys():
+                self.distribution[key] = {
+                    'count': self.distribution[key],
+                    'error_count': 0
+                }
 
     @override
     def name(self):
@@ -169,8 +177,6 @@ class CreateDbTask(Task):
 
     @override
     def process_output(self, line):
-        from digits.webapp import socketio
-
         self.create_db_log.write('%s\n' % line)
         self.create_db_log.flush()
 
@@ -191,19 +197,22 @@ class CreateDbTask(Task):
             if not hasattr(self, 'distribution') or self.distribution is None:
                 self.distribution = {}
 
-            self.distribution[match.group(1)] = int(match.group(2))
+            self.distribution[match.group(1)] = {
+                'count': int(match.group(2)),
+                'error_count': 0
+            }
+            self.update_distribution_graph()
+            return True
 
-            data = self.distribution_data()
-            if data:
-                socketio.emit('task update',
-                              {
-                                  'task': self.html_id(),
-                                  'update': 'distribution',
-                                  'data': data,
-                              },
-                              namespace='/jobs',
-                              room=self.job_id,
-                              )
+        # add errors to the distribution
+        match = re.match(r'\[(.+) (\d+)\] LoadImageError: (.+)', message)
+        if match:
+            self.distribution[match.group(2)]['count'] -= 1
+            self.distribution[match.group(2)]['error_count'] += 1
+            if self.entries_error is None:
+                self.entries_error = 0
+            self.entries_error += 1
+            self.update_distribution_graph()
             return True
 
         # result
@@ -301,20 +310,32 @@ class CreateDbTask(Task):
         if len(self.distribution.keys()) != len(labels):
             return None
 
-        values = ['Count']
+        label_count = 'Count'
+        label_error = 'LoadImageError'
+
+        error_values = [label_error]
+        count_values = [label_count]
         titles = []
         for key, value in sorted(
                 self.distribution.items(),
-                key=operator.itemgetter(1),
+                key=lambda item: item[1]['count'],
                 reverse=True):
-            values.append(value)
+            count_values.append(value['count'])
+            error_values.append(value['error_count'])
             titles.append(labels[int(key)])
 
+        # distribution graph always displays the Count data
+        data = {'columns': [count_values], 'type': 'bar'}
+
+        # only display error data if any error occurred
+        if sum(error_values[1:]) > 0:
+            data['columns'] = [count_values, error_values]
+            data['groups'] = [[label_count, label_error]]
+            data['colors'] = {label_count: '#1F77B4', label_error: '#B73540'}
+            data['order'] = 'false'
+
         return {
-            'data': {
-                'columns': [values],
-                'type': 'bar'
-            },
+            'data': data,
             'axis': {
                 'x': {
                     'type': 'category',
@@ -322,3 +343,18 @@ class CreateDbTask(Task):
                 }
             },
         }
+
+    def update_distribution_graph(self):
+        from digits.webapp import socketio
+        data = self.distribution_data()
+
+        if data:
+            socketio.emit('task update',
+                          {
+                              'task': self.html_id(),
+                              'update': 'distribution',
+                              'data': data,
+                          },
+                          namespace='/jobs',
+                          room=self.job_id,
+                          )

--- a/digits/static/css/style.css
+++ b/digits/static/css/style.css
@@ -150,3 +150,7 @@ ul.inline li {
     margin-top:10px;
     margin-bottom:10px;
 }
+
+div.exploration {
+    margin-top: 10px;
+}

--- a/digits/templates/datasets/images/classification/show.html
+++ b/digits/templates/datasets/images/classification/show.html
@@ -87,7 +87,10 @@
         {% endif %}
         {% if task.entries_count %}
         <dt>DB Entries</dt>
-        <dd>{{task.entries_count}}</dd>
+        <dd>
+        {{task.entries_count}}
+        {% if task.entries_error %} ({{task.entries_error}} failed to load) {% endif %}
+        </dd>
         {% endif %}
     </dl>
 

--- a/digits/tools/create_db.py
+++ b/digits/tools/create_db.py
@@ -580,7 +580,7 @@ def _load_thread(load_queue, write_queue, summary_queue,
         try:
             image = utils.image.load_image(path)
         except utils.errors.LoadImageError as e:
-            logger.warning('[%s] %s: %s' % (path, type(e).__name__, e))
+            logger.warning('[%s %s] %s: %s' % (path, label, type(e).__name__, e))
             continue
 
         image = utils.image.resize_image(image,


### PR DESCRIPTION
This aims to fix #1473 

If any `LoadImageError` is raised, dataset pages will look like this:
- notice the `(%d failed to load)` on the **DB Entries**

![image](https://cloud.githubusercontent.com/assets/7027770/23721723/9384d1e4-0421-11e7-8825-0a37df26817f.png)

Datasets without any `LoadImageError` will look exactly the same:

![image](https://cloud.githubusercontent.com/assets/7027770/23721831/e205ecc2-0421-11e7-9962-fc239f1f17f9.png)
