### PR TITLE
Enable selection of GPU on inference page

### DIFF
--- a/digits/inference/job.py
+++ b/digits/inference/job.py
@@ -13,7 +13,7 @@ class InferenceJob(Job):
     A Job that exercises the forward pass of a neural network
     """
 
-    def __init__(self, model, images, epoch, layers, resize=True, **kwargs):
+    def __init__(self, model, images, epoch, layers, resize=True, gpu=None, **kwargs):
         """
         Arguments:
         model   -- job object associated with model to perform inference on
@@ -40,6 +40,7 @@ class InferenceJob(Job):
             epoch=epoch,
             layers=layers,
             resize=resize,
+            gpu=gpu
         ))
 
     @override

--- a/digits/inference/tasks/inference.py
+++ b/digits/inference/tasks/inference.py
@@ -21,7 +21,7 @@ class InferenceTask(Task):
     A task for inference jobs
     """
 
-    def __init__(self, model, images, epoch, layers, resize, **kwargs):
+    def __init__(self, model, images, epoch, layers, resize, gpu=None, **kwargs):
         """
         Arguments:
         model  -- trained model to perform inference on
@@ -40,7 +40,7 @@ class InferenceTask(Task):
         self.inference_log_file = "inference.log"
 
         # resources
-        self.gpu = None
+        self.gpu = gpu
 
         # generated data
         self.inference_data_filename = None
@@ -180,6 +180,8 @@ class InferenceTask(Task):
                 if resources[gpu_key]:
                     for resource in resources[gpu_key]:
                         if resource.remaining() >= 1:
+                            if self.gpu is not None and self.gpu != int(resource.identifier):
+                                continue
                             self.gpu = int(resource.identifier)
                             reserved_resources[gpu_key] = [(resource.identifier, 1)]
                             break

--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -339,6 +339,23 @@ class ModelForm(Form):
         tooltip="The job won't start until all of the chosen GPUs are available."
     )
 
+    # Select 1 of several GPUs
+    select_one_of_gpus = utils.forms.SelectField(
+        'Select which GPU you would like to use',
+        choices=[('next', 'Next available')] + [(
+            index,
+            '#%s - %s (%s memory)' % (
+                index,
+                get_device(index).name,
+                sizeof_fmt(
+                    get_nvml_info(index)['memory']['total']
+                    if get_nvml_info(index) and 'memory' in get_nvml_info(index)
+                    else get_device(index).totalGlobalMem)
+            ),
+        ) for index in config_value('gpu_list').split(',') if index],
+        default='next',
+    )
+
     # XXX For testing
     # The Flask test framework can't handle SelectMultipleFields correctly
     select_gpus_list = wtforms.StringField('Select which GPU[s] you would like to use (comma separated)')

--- a/digits/model/forms.py
+++ b/digits/model/forms.py
@@ -305,55 +305,31 @@ class ModelForm(Form):
                 if filename and not os.path.exists(filename):
                     raise validators.ValidationError('File "%s" does not exist' % filename)
 
+    # List of GPUs
+    gpu_list = [(
+        index,
+        '#%s - %s (%s memory)' % (
+            index,
+            get_device(index).name,
+            sizeof_fmt(
+                get_nvml_info(index)['memory']['total']
+                if get_nvml_info(index) and 'memory' in get_nvml_info(index)
+                else get_device(index).totalGlobalMem)
+        ),
+    ) for index in config_value('gpu_list').split(',') if index]
+
     # Select one of several GPUs
     select_gpu = wtforms.RadioField(
         'Select which GPU you would like to use',
-        choices=[('next', 'Next available')] + [(
-            index,
-            '#%s - %s (%s memory)' % (
-                index,
-                get_device(index).name,
-                sizeof_fmt(
-                    get_nvml_info(index)['memory']['total']
-                    if get_nvml_info(index) and 'memory' in get_nvml_info(index)
-                    else get_device(index).totalGlobalMem)
-            ),
-        ) for index in config_value('gpu_list').split(',') if index],
+        choices=[('next', 'Next available')] + gpu_list,
         default='next',
     )
 
     # Select N of several GPUs
     select_gpus = utils.forms.SelectMultipleField(
         'Select which GPU[s] you would like to use',
-        choices=[(
-            index,
-            '#%s - %s (%s memory)' % (
-                index,
-                get_device(index).name,
-                sizeof_fmt(
-                    get_nvml_info(index)['memory']['total']
-                    if get_nvml_info(index) and 'memory' in get_nvml_info(index)
-                    else get_device(index).totalGlobalMem)
-            ),
-        ) for index in config_value('gpu_list').split(',') if index],
+        choices=gpu_list,
         tooltip="The job won't start until all of the chosen GPUs are available."
-    )
-
-    # Select 1 of several GPUs
-    select_one_of_gpus = utils.forms.SelectField(
-        'Select which GPU you would like to use',
-        choices=[('next', 'Next available')] + [(
-            index,
-            '#%s - %s (%s memory)' % (
-                index,
-                get_device(index).name,
-                sizeof_fmt(
-                    get_nvml_info(index)['memory']['total']
-                    if get_nvml_info(index) and 'memory' in get_nvml_info(index)
-                    else get_device(index).totalGlobalMem)
-            ),
-        ) for index in config_value('gpu_list').split(',') if index],
-        default='next',
     )
 
     # XXX For testing

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -336,13 +336,13 @@ def show(job, related_jobs=None):
     form = ImageClassificationModelForm()
     return flask.render_template(
         'models/images/classification/show.html',
-        form=form,
         job=job,
         framework_ids=[
             fw.get_id()
             for fw in frameworks.get_frameworks()
         ],
-        related_jobs=related_jobs
+        related_jobs=related_jobs,
+        gpu_list=form.gpu_list,
     )
 
 

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -19,7 +19,7 @@ from digits.inference import ImageInferenceJob
 from digits.pretrained_model.job import PretrainedModelJob
 from digits.status import Status
 from digits.utils import filesystem as fs
-from digits.utils.forms import fill_form_if_cloned, save_form_to_job
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job, get_selected_gpu
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import scheduler
 
@@ -333,8 +333,10 @@ def show(job, related_jobs=None):
     """
     Called from digits.model.views.models_show()
     """
+    form = ImageClassificationModelForm()
     return flask.render_template(
         'models/images/classification/show.html',
+        form=form,
         job=job,
         framework_ids=[
             fw.get_id()
@@ -384,6 +386,8 @@ def classify_one():
     if 'show_visualizations' in flask.request.form and flask.request.form['show_visualizations']:
         layers = 'all'
 
+    selected_gpu = get_selected_gpu(flask.request.form)
+
     # create inference job
     inference_job = ImageInferenceJob(
         username=utils.auth.get_username(),
@@ -391,7 +395,8 @@ def classify_one():
         model=model_job,
         images=[image_path],
         epoch=epoch,
-        layers=layers
+        layers=layers,
+        gpu=selected_gpu
     )
 
     # schedule tasks
@@ -477,6 +482,7 @@ def classify_many():
         epoch = float(flask.request.form['snapshot_epoch'])
 
     paths, ground_truths = read_image_list(image_list, image_folder, num_test_images)
+    selected_gpu = get_selected_gpu(flask.request.form)
 
     # create inference job
     inference_job = ImageInferenceJob(
@@ -485,7 +491,8 @@ def classify_many():
         model=model_job,
         images=paths,
         epoch=epoch,
-        layers='none'
+        layers='none',
+        gpu=selected_gpu
     )
 
     # schedule tasks
@@ -633,6 +640,7 @@ def top_n():
         num_test_images = None
 
     paths, _ = read_image_list(image_list, image_folder, num_test_images)
+    selected_gpu = get_selected_gpu(flask.request.form)
 
     # create inference job
     inference_job = ImageInferenceJob(
@@ -641,7 +649,8 @@ def top_n():
         model=model_job,
         images=paths,
         epoch=epoch,
-        layers='none'
+        layers='none',
+        gpu=selected_gpu
     )
 
     # schedule tasks

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -312,11 +312,11 @@ def show(job, related_jobs=None):
     generic_form = GenericImageModelForm()
     return flask.render_template(
         'models/images/generic/show.html',
-        form=generic_form,
         job=job,
         view_extensions=view_extensions,
         related_jobs=related_jobs,
         inference_form_html=inference_form_html,
+        gpu_list=generic_form.gpu_list,
     )
 
 

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -18,7 +18,7 @@ from digits.inference import ImageInferenceJob
 from digits.status import Status
 from digits.utils import filesystem as fs
 from digits.utils import constants
-from digits.utils.forms import fill_form_if_cloned, save_form_to_job
+from digits.utils.forms import fill_form_if_cloned, save_form_to_job, get_selected_gpu
 from digits.utils.routing import request_wants_json, job_from_request
 from digits.webapp import scheduler
 
@@ -309,8 +309,10 @@ def show(job, related_jobs=None):
             template, context = extension.get_inference_template(form)
             inference_form_html = flask.render_template_string(template, **context)
 
+    generic_form = GenericImageModelForm()
     return flask.render_template(
         'models/images/generic/show.html',
+        form=generic_form,
         job=job,
         view_extensions=view_extensions,
         related_jobs=related_jobs,
@@ -361,6 +363,8 @@ def infer_one():
     else:
         resize = True
 
+    selected_gpu = get_selected_gpu(flask.request.form)
+
     # create inference job
     inference_job = ImageInferenceJob(
         username=utils.auth.get_username(),
@@ -370,6 +374,7 @@ def infer_one():
         epoch=epoch,
         layers=layers,
         resize=resize,
+        gpu=selected_gpu
     )
 
     # schedule tasks
@@ -446,6 +451,8 @@ def infer_extension():
         if 'show_visualizations' in flask.request.form and flask.request.form['show_visualizations']:
             layers = 'all'
 
+        selected_gpu = get_selected_gpu(flask.request.form)
+
         # create inference job
         inference_job = ImageInferenceJob(
             username=utils.auth.get_username(),
@@ -455,6 +462,7 @@ def infer_extension():
             epoch=epoch,
             layers=layers,
             resize=False,
+            gpu=selected_gpu
         )
 
         # schedule tasks
@@ -539,6 +547,8 @@ def infer_db():
     else:
         resize = True
 
+    selected_gpu = get_selected_gpu(flask.request.form)
+
     # create inference job
     inference_job = ImageInferenceJob(
         username=utils.auth.get_username(),
@@ -548,6 +558,7 @@ def infer_db():
         epoch=epoch,
         layers='none',
         resize=resize,
+        gpu=selected_gpu
     )
 
     # schedule tasks
@@ -633,6 +644,8 @@ def infer_many():
     else:
         resize = True
 
+    selected_gpu = get_selected_gpu(flask.request.form)
+
     paths = []
 
     for line in image_list.readlines():
@@ -664,6 +677,7 @@ def infer_many():
         epoch=epoch,
         layers='none',
         resize=resize,
+        gpu=selected_gpu
     )
 
     # schedule tasks

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -2,12 +2,14 @@
 
 {% extends "job.html" %}
 {% from "helper.html" import serve_file %}
+{% from "helper.html" import mark_errors %}
 
 {% block job_content %}
 
 <script src="{{ url_for('static', filename='js/model-graphs.js', ver=dir_hash) }}"></script>
 
 {% set task = job.train_task() %}
+{% set show_multi_gpu_form = form.select_one_of_gpus.choices| length > 2 %}
 
 <div class="row">
     <div class="col-sm-6">
@@ -103,12 +105,8 @@
                 >
                 <h2>Trained Models</h2>
                 <div class="row">
-                    <div class="col-sm-12">
-                        <label for="snapshot_epoch">Select Model</label>
-                    </div>
-                </div>
-                <div class="row">
                     <div class="col-sm-6">
+                        <label for="snapshot_epoch">Select Model</label>
                         <div class="form-group">
                             <select id="snapshot_epoch" name="snapshot_epoch" class="form-control">
                             </select>
@@ -139,8 +137,7 @@ function updateSnapshotList(data) {
 updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescape %});
                             </script>
                         </div>
-                    </div>
-                    <div class="col-sm-6">
+                        {% if show_multi_gpu_form %}
                         <button
                             formaction="{{url_for('digits.model.views.download', job_id=job.id())}}"
                             formmethod="post"
@@ -155,7 +152,36 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             class="btn btn-success">
                             Make Pretrained Model
                         </button>
+                        {% endif %}
                     </div>
+                    {% if show_multi_gpu_form %}
+                    <div class="col-sm-6">
+                        <div class="form-group{{mark_errors([form.select_one_of_gpus])}}">
+                            {{form.select_one_of_gpus.label}}
+                            {{form.select_one_of_gpus(class='form-control', size=4)}}
+                        </div>
+                    </div>
+                    {% else %}
+                    <div class="col-sm-6">
+                        <label for="empty space">&nbsp;</label>
+                    </div>
+                    <div class="col-sm-6">
+                         <button
+                            formaction="{{url_for('digits.model.views.download', job_id=job.id())}}"
+                            formmethod="post"
+                            formenctype="multipart/form-data"
+                            class="btn btn-info">
+                            Download Model
+                        </button>
+                        <button
+                            formaction="{{url_for('digits.model.views.to_pretrained', job_id=job.id())}}"
+                            formmethod="post"
+                            formenctype="multipart/form-data"
+                            class="btn btn-success">
+                            Make Pretrained Model
+                        </button>
+                    </div>
+                    {% endif %}
                 </div>
                 {% if task.get_framework_id() in framework_ids %}
                 <div class="row">
@@ -184,6 +210,7 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                                 </div>
                             </div>
                         </div>
+
                         <script type="text/javascript">
                             // When you fill in one field, the other gets blanked out
                             $("#image_path").change(function() { $("#image_file").val(""); });

--- a/digits/templates/models/images/classification/show.html
+++ b/digits/templates/models/images/classification/show.html
@@ -2,14 +2,13 @@
 
 {% extends "job.html" %}
 {% from "helper.html" import serve_file %}
-{% from "helper.html" import mark_errors %}
 
 {% block job_content %}
 
 <script src="{{ url_for('static', filename='js/model-graphs.js', ver=dir_hash) }}"></script>
 
 {% set task = job.train_task() %}
-{% set show_multi_gpu_form = form.select_one_of_gpus.choices| length > 2 %}
+{% set show_multi_gpu_form = gpu_list| length > 1 %}
 
 <div class="row">
     <div class="col-sm-6">
@@ -156,9 +155,14 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                     </div>
                     {% if show_multi_gpu_form %}
                     <div class="col-sm-6">
-                        <div class="form-group{{mark_errors([form.select_one_of_gpus])}}">
-                            {{form.select_one_of_gpus.label}}
-                            {{form.select_one_of_gpus(class='form-control', size=4)}}
+                        <div class="form-group">
+                            <label for="select_one_of_gpus">Select which GPU you would like to use</label>
+                            <select class="form-control" id="select_one_of_gpus" name="select_one_of_gpus" size="4">
+                                <option selected="" value="next">Next available</option>
+                                {% for gpu_id, gpu_description in gpu_list %}
+                                    <option value="{{ gpu_id }}">{{ gpu_description }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
                     </div>
                     {% else %}

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -2,14 +2,13 @@
 
 {% extends "job.html" %}
 {% from "helper.html" import serve_file %}
-{% from "helper.html" import mark_errors %}
 
 {% block job_content %}
 
 <script src="{{ url_for('static', filename='js/model-graphs.js', ver=dir_hash) }}"></script>
 
 {% set task = job.train_task() %}
-{% set show_multi_gpu_form = form.select_one_of_gpus.choices| length > 2 %}
+{% set show_multi_gpu_form = gpu_list| length > 1 %}
 
 <div class="row">
     <div class="col-sm-6">
@@ -150,9 +149,14 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                     </div>
                     {% if show_multi_gpu_form %}
                     <div class="col-sm-6">
-                        <div class="form-group{{mark_errors([form.select_one_of_gpus])}}">
-                            {{form.select_one_of_gpus.label}}
-                            {{form.select_one_of_gpus(class='form-control', size=4)}}
+                        <div class="form-group">
+                            <label for="select_one_of_gpus">Select which GPU you would like to use</label>
+                            <select class="form-control" id="select_one_of_gpus" name="select_one_of_gpus" size="4">
+                                <option selected="" value="next">Next available</option>
+                                {% for gpu_id, gpu_description in gpu_list %}
+                                    <option value="{{ gpu_id }}">{{ gpu_description }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
                     </div>
                     {% else %}

--- a/digits/templates/models/images/generic/show.html
+++ b/digits/templates/models/images/generic/show.html
@@ -2,12 +2,14 @@
 
 {% extends "job.html" %}
 {% from "helper.html" import serve_file %}
+{% from "helper.html" import mark_errors %}
 
 {% block job_content %}
 
 <script src="{{ url_for('static', filename='js/model-graphs.js', ver=dir_hash) }}"></script>
 
 {% set task = job.train_task() %}
+{% set show_multi_gpu_form = form.select_one_of_gpus.choices| length > 2 %}
 
 <div class="row">
     <div class="col-sm-6">
@@ -97,12 +99,8 @@
                 >
                 <h2>Trained Models</h2>
                 <div class="row">
-                    <div class="col-sm-12">
+                    <div class="col-sm-6">
                         <label for="snapshot_epoch">Select Model</label>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-sm-8">
                         <div class="form-group">
                             <select id="snapshot_epoch" name="snapshot_epoch" class="form-control">
                             </select>
@@ -133,8 +131,7 @@ function updateSnapshotList(data) {
 updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescape %});
                             </script>
                         </div>
-                    </div>
-                    <div class="col-sm-4">
+                        {% if show_multi_gpu_form %}
                         <button
                             formaction="{{url_for('digits.model.views.download', job_id=job.id())}}"
                             formmethod="post"
@@ -149,7 +146,36 @@ updateSnapshotList({% autoescape false %}{{task.snapshot_list()}}{% endautoescap
                             class="btn btn-success">
                             Make Pretrained Model
                         </button>
+                        {% endif %}
                     </div>
+                    {% if show_multi_gpu_form %}
+                    <div class="col-sm-6">
+                        <div class="form-group{{mark_errors([form.select_one_of_gpus])}}">
+                            {{form.select_one_of_gpus.label}}
+                            {{form.select_one_of_gpus(class='form-control', size=4)}}
+                        </div>
+                    </div>
+                    {% else %}
+                    <div class="col-sm-6">
+                        <label for="empty space">&nbsp;</label>
+                    </div>
+                    <div class="col-sm-6">
+                         <button
+                            formaction="{{url_for('digits.model.views.download', job_id=job.id())}}"
+                            formmethod="post"
+                            formenctype="multipart/form-data"
+                            class="btn btn-info">
+                            Download Model
+                        </button>
+                        <button
+                            formaction="{{url_for('digits.model.views.to_pretrained', job_id=job.id())}}"
+                            formmethod="post"
+                            formenctype="multipart/form-data"
+                            class="btn btn-success">
+                            Make Pretrained Model
+                        </button>
+                    </div>
+                    {% endif %}
                 </div>
                 <div class="row">
                     <div class="col-sm-6">

--- a/digits/utils/forms.py
+++ b/digits/utils/forms.py
@@ -550,3 +550,11 @@ def fill_form_if_cloned(form):
     if clone is not None:
         clone_job = scheduler.get_job(clone)
         fill_form_from_job(clone_job, form)
+
+
+def get_selected_gpu(form):
+    selected_gpu = None
+    if 'select_one_of_gpus' in form:
+        if form['select_one_of_gpus'] != 'next':
+            selected_gpu = int(form['select_one_of_gpus'])
+    return selected_gpu


### PR DESCRIPTION
This PR attempts to fix #1418, see https://github.com/NVIDIA/DIGITS/issues/1418#issuecomment-285680223. I tried to minimize changes to avoid side-effects.

If the user doesn't have more than one GPU (or only one CUDA_VISIBLE_DEVICES for DIGITS), nothing is going to change:

![image](https://cloud.githubusercontent.com/assets/7027770/23798296/c2ff7282-0582-11e7-8d60-ff7881a00300.png)

But if the user has multiple GPUs (2 or more), it is going to look like this:

![image](https://cloud.githubusercontent.com/assets/7027770/23798291/b7435ee0-0582-11e7-9a98-af3cfdc8f4db.png)

where `Next Available` is the default choice and has the same behavior as the current implementation. If the user selects a GPU (only one can be selected), then this GPU will be used.

PS: I modified [images/generic/show.html](https://github.com/NVIDIA/DIGITS/compare/master...rodrigoberriel:select_gpu_inference?expand=1#diff-f16ada5c581ed885973db1abdde5fae5) the same way I did for [images/classification/show.html](https://github.com/NVIDIA/DIGITS/compare/master...rodrigoberriel:select_gpu_inference?expand=1#diff-41696ab7b1c04e66a23ac76fd94bb75f), but I didn't test the former as much as I did on the latter.