### PR TITLE
Display the filename of the image that caused the exception

### DIFF
--- a/digits/utils/image.py
+++ b/digits/utils/image.py
@@ -63,7 +63,7 @@ def load_image(path):
             image = PIL.Image.open(path)
             image.load()
         except IOError as e:
-            raise errors.LoadImageError, 'IOError: %s' % e.message
+            raise errors.LoadImageError, 'IOError: Trying to load "%s": %s' % (path, e.message)
     else:
         raise errors.LoadImageError, '"%s" not found' % path
 


### PR DESCRIPTION
It was annoying when I created a dataset and after a few minutes DIGITS only displayed an error about an image that couldn't load, but it didn't display/log the filename of the image.

The simple change in this pull request ensures that the filename of the problem image is included when displaying / logging the exception.