### PR TITLE
Fix softmax visualization by scaling to image range

### DIFF
--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -1363,13 +1363,17 @@ class CaffeTrainTask(TrainTask):
                         if top in net.blobs and top not in added_activations:
                             data = net.blobs[top].data[0]
                             normalize = True
-                            # don't normalize softmax layers
+                            # don't normalize softmax layers but scale by 255 to fill image range
                             if layer.type == 'Softmax':
-                                normalize = False
-                            vis = utils.image.get_layer_vis_square(data,
-                                                                   normalize=normalize,
-                                                                   allow_heatmap=bool(top != 'data'),
-                                                                   channel_order='BGR')
+                                vis = utils.image.get_layer_vis_square(data * 255,
+                                                                       normalize=False,
+                                                                       allow_heatmap=bool(top != 'data'),
+                                                                       channel_order='BGR')
+                            else:
+                                vis = utils.image.get_layer_vis_square(data,
+                                                                       normalize=normalize,
+                                                                       allow_heatmap=bool(top != 'data'),
+                                                                       channel_order='BGR')
                             mean, std, hist = self.get_layer_statistics(data)
                             visualizations.append(
                                 {


### PR DESCRIPTION
Fixes issue #1645, where softmax output was left in 0-1 range (as compared to 0-255 image) which prevented proper visualization. See image for before&after comparison. Changes `digits/model/tasks/caffe_train.py` per @lukeyeager's suggestion.

![before and after](http://i.imgur.com/GLI4sc9.png "before and after")