### PR TITLE
Fix bounding box colors displayed, for multi class detections

### DIFF
--- a/digits/extensions/view/boundingBox/app_begin_template.html
+++ b/digits/extensions/view/boundingBox/app_begin_template.html
@@ -173,7 +173,6 @@
 
          // draw the bounding boxes
          var keys = Object.keys(bboxes);
-         keys.sort();
          for (var k = 0; k < keys.length; k++) {
              var color = $scope.get_color(k);
              for (var i = 0; i < bboxes[keys[k]].length; i++) {


### PR DESCRIPTION
Remove sorting of keys which caused a mismatch in colors with multi class detection networks.

The colors used to render the bounding boxes and the colors used to describe each key does not match because the keys get sorted. Removing the sort operation resolved the mismatching color issue.