### PR TITLE
Tensorflow: fix network customization bug

### DIFF
--- a/digits/frameworks/tensorflow_framework.py
+++ b/digits/frameworks/tensorflow_framework.py
@@ -60,7 +60,7 @@ class TensorflowFramework(Framework):
             path = os.path.join(networks_dir, filename)
             if os.path.isfile(path):
                 match = None
-                match = re.match(r'%s.py' % network, filename)
+                match = re.match(r'%s.py$' % network, filename)
                 if match:
                     with open(path) as infile:
                         return infile.read()


### PR DESCRIPTION
Without this fix to the regular expression, the `re` module will happily
match `lenet.pyc` in addition to `lenet.py`. If your filesystem happens
to return `lenet.pyc` first, then you get a cryptic unicode error when
you try to customize the LeNet network. Presumably you'd get a nasty
error if you tried to actually train with this file as well.