### PR TITLE
fix variable reuse probolem

### DIFF
--- a/digits/tools/tensorflow/model.py
+++ b/digits/tools/tensorflow/model.py
@@ -144,16 +144,17 @@ class Model(object):
                 current_scope = stage_scope if len(available_devices) == 1 else ('tower_%d' % dev_i)
                 with tf.name_scope(current_scope) as scope_tower:
 
-                    if self.stage != digits.STAGE_INF:
-                        tower_model = self.add_tower(obj_tower=obj_UserModel,
-                                                     x=batch_x_split[dev_i],
-                                                     y=batch_y_split[dev_i])
-                    else:
-                        tower_model = self.add_tower(obj_tower=obj_UserModel,
-                                                     x=batch_x_split[dev_i],
-                                                     y=None)
-
                     with tf.variable_scope(digits.GraphKeys.MODEL, reuse=dev_i > 0 or self._reuse):
+
+                        if self.stage != digits.STAGE_INF:
+                             tower_model = self.add_tower(obj_tower=obj_UserModel,
+                                                          x=batch_x_split[dev_i],
+                                                          y=batch_y_split[dev_i])
+                        else:
+                             tower_model = self.add_tower(obj_tower=obj_UserModel,
+                                                          x=batch_x_split[dev_i],
+                                                          y=None)
+
                         tower_model.inference  # touch to initialize
 
                         # Reuse the variables in this scope for the next tower/device


### PR DESCRIPTION
Traceback (most recent call last):
  File "model/main.py", line 427, in <module>
    tf.app.run()
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "model/main.py", line 233, in main
    train_model.create_model(UserModel, stage_scope)
  File "/gfs/atlas/zhanghui/postfilter-gan/model/base.py", line 163, in create_model
    y=batch_y_split[dev_i])
  File "/gfs/atlas/zhanghui/postfilter-gan/model/base.py", line 240, in add_tower
    tower = obj_tower(x, y, input_shape, self.nclasses, is_training, is_inference)
  File "<string>", line 41, in __init__
  File "<string>", line 119, in postfilter_gan_init
  File "<string>", line 142, in build_model
  File "<string>", line 291, in generator
  File "/gfs/atlas/zhanghui/postfilter-gan/model/ops.py", line 80, in conv2d
    initializer=tf.truncated_normal_initializer(stddev=stddev))
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/variable_scope.py", line 1065, in get_variable
    use_resource=use_resource, custom_getter=custom_getter)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/variable_scope.py", line 962, in get_variable
    use_resource=use_resource, custom_getter=custom_getter)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/variable_scope.py", line 367, in get_variable
    validate_shape=validate_shape, use_resource=use_resource)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/variable_scope.py", line 352, in _true_getter
    use_resource=use_resource)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/variable_scope.py", line 664, in _get_single_variable
    name, "".join(traceback.format_list(tb))))
ValueError: Variable generator/g_h0_conv/w already exists, disallowed. Did you mean to set reuse=True in VarScope? Originally defined at:



I have this problem in use this repo, may be this PR is the correct solution.
