### PR TITLE
Add ng-cloak to remove flashing html codes during page loading.

### DIFF
--- a/digits/templates/home.html
+++ b/digits/templates/home.html
@@ -46,7 +46,8 @@
      id="all-jobs"
      ng-app="home_app"
      ng-controller="all_jobs_controller as jc"
-     ng-click="deselect_all();">
+     ng-click="deselect_all()"
+     ng-cloak>
     {[jc.running_jobs = (jobs | filter:is_running);'']}
     {[jc.dataset_jobs = (jobs | filter:is_dataset);'']}
     {[jc.model_jobs = (jobs | filter:is_model);'']}


### PR DESCRIPTION
During DIGITS home page loading, raw html codes may appear for short period of time (< 1 sec).  Adding ng-cloak removes that 'flashing' html codes on UI.