### PR TITLE
Fix linguist detection with gitattribute overrides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+digits/static/js/3rdparty/* linguist-vendored
+digits/static/tb/* linguist-vendored


### PR DESCRIPTION
Before:
```
65.12%  HTML
30.38%  Python
2.73%   Lua
1.33%   JavaScript
0.32%   Shell
0.11%   CSS
0.00%   Makefile
```
After:
```
70.28%  Python
19.32%  HTML
6.31%   Lua
3.08%   JavaScript
0.75%   Shell
0.25%   CSS
0.01%   Makefile
```