### PR TITLE
caffe_pb2 module should be imported as submodule, not standalone

### DIFF
--- a/digits/config/caffe.py
+++ b/digits/config/caffe.py
@@ -128,10 +128,6 @@ def import_pycaffe(dirname=None):
         print 'Did you forget to "make pycaffe"?'
         raise
 
-    # Strange issue with protocol buffers and pickle - see issue #32
-    sys.path.insert(0, os.path.join(
-        os.path.dirname(caffe.__file__), 'proto'))
-
     # Turn GLOG output back on for subprocess calls
     if GLOG_minloglevel is None:
         del os.environ['GLOG_minloglevel']

--- a/digits/dataset/generic/views.py
+++ b/digits/dataset/generic/views.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from StringIO import StringIO
 
-import caffe_pb2
+import caffe.proto.caffe_pb2 as caffe_pb2
 import flask
 import matplotlib as mpl
 import matplotlib.pyplot as plt

--- a/digits/dataset/images/classification/job.py
+++ b/digits/dataset/images/classification/job.py
@@ -33,7 +33,7 @@ class ImageClassificationDatasetJob(ImageDatasetJob):
                 if task.encoding == "jpg":
                     if task.mean_file.endswith('.binaryproto'):
                         import numpy as np
-                        import caffe_pb2
+                        import caffe.proto.caffe_pb2 as caffe_pb2
 
                         old_blob = caffe_pb2.BlobProto()
                         with open(task.path(task.mean_file), 'rb') as infile:

--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from StringIO import StringIO
 
-import caffe_pb2
+import caffe.proto.caffe_pb2 as caffe_pb2
 import flask
 import PIL.Image
 

--- a/digits/dataset/images/generic/test_lmdb_creator.py
+++ b/digits/dataset/images/generic/test_lmdb_creator.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     import digits.config  # noqa
 
 # Import digits.config first to set the path to Caffe
-import caffe_pb2  # noqa
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 
 IMAGE_SIZE = 10

--- a/digits/frameworks/caffe_framework.py
+++ b/digits/frameworks/caffe_framework.py
@@ -5,7 +5,7 @@ import os
 import re
 
 import caffe.draw
-import caffe_pb2
+import caffe.proto.caffe_pb2 as caffe_pb2
 from google.protobuf import text_format
 
 from .errors import BadNetworkError

--- a/digits/model/images/classification/test_views.py
+++ b/digits/model/images/classification/test_views.py
@@ -8,7 +8,7 @@ import shutil
 import tempfile
 import time
 import unittest
-import caffe_pb2
+import caffe.proto.caffe_pb2 as caffe_pb2
 import math
 
 

--- a/digits/model/tasks/caffe_train.py
+++ b/digits/model/tasks/caffe_train.py
@@ -25,7 +25,7 @@ from digits.utils.filesystem import tail
 
 # Must import after importing digit.config
 import caffe
-import caffe_pb2
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 # NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 5

--- a/digits/model/tasks/test_caffe_sanity_checks.py
+++ b/digits/model/tasks/test_caffe_sanity_checks.py
@@ -7,7 +7,7 @@ from google.protobuf import text_format
 from digits import test_utils
 
 # Must import after importing digit.config
-import caffe_pb2
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 
 def check_positive(desc, stage):

--- a/digits/model/tasks/torch_train.py
+++ b/digits/model/tasks/torch_train.py
@@ -20,7 +20,7 @@ from digits.config import config_value
 from digits.utils import subclass, override, constants
 
 # Must import after importing digit.config
-import caffe_pb2
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 # NOTE: Increment this every time the pickled object changes
 PICKLE_VERSION = 1

--- a/digits/tools/analyze_db.py
+++ b/digits/tools/analyze_db.py
@@ -26,7 +26,7 @@ from digits import log  # noqa
 
 # Import digits.config first to set path to Caffe
 import caffe.io  # noqa
-import caffe_pb2  # noqa
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 logger = logging.getLogger('digits.tools.analyze_db')
 np.set_printoptions(suppress=True, precision=3)

--- a/digits/tools/create_db.py
+++ b/digits/tools/create_db.py
@@ -32,7 +32,7 @@ from digits import utils, log  # noqa
 
 # Import digits.config first to set the path to Caffe
 import caffe.io  # noqa
-import caffe_pb2  # noqa
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 if digits.config.config_value('tensorflow')['enabled']:
     import tensorflow as tf

--- a/digits/tools/create_generic_db.py
+++ b/digits/tools/create_generic_db.py
@@ -24,7 +24,7 @@ from digits.job import Job  # noqa
 
 # Import digits.config first to set the path to Caffe
 import caffe.io  # noqa
-import caffe_pb2  # noqa
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 logger = logging.getLogger('digits.tools.create_dataset')
 

--- a/digits/tools/inference.py
+++ b/digits/tools/inference.py
@@ -23,7 +23,7 @@ from digits.job import Job  # noqa
 from digits.utils.lmdbreader import DbReader  # noqa
 
 # Import digits.config before caffe to set the path
-import caffe_pb2  # noqa
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 logger = logging.getLogger('digits.tools.inference')
 

--- a/examples/classification/example.py
+++ b/examples/classification/example.py
@@ -18,7 +18,7 @@ import scipy.misc
 
 os.environ['GLOG_minloglevel'] = '2'  # Suppress most caffe output
 import caffe  # noqa
-from caffe.proto import caffe_pb2  # noqa
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 
 def get_net(caffemodel, deploy_file, use_gpu=True):

--- a/examples/gan/gan_features.py
+++ b/examples/gan/gan_features.py
@@ -22,7 +22,7 @@ from digits.job import Job  # noqa
 from digits.utils.lmdbreader import DbReader  # noqa
 
 # Import digits.config before caffe to set the path
-import caffe_pb2  # noqa
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 logger = logging.getLogger('digits.tools.inference')
 

--- a/examples/siamese/create_db.py
+++ b/examples/siamese/create_db.py
@@ -25,7 +25,7 @@ from digits import utils  # noqa
 
 # Import digits.config first to set the path to Caffe
 import caffe.io  # noqa
-import caffe_pb2  # noqa
+import caffe.proto.caffe_pb2 as caffe_pb2
 
 IMAGE_SIZE = 10
 TRAIN_IMAGE_COUNT = 1000


### PR DESCRIPTION
Related: https://github.com/NVIDIA/DIGITS/issues/306
My system is Centos 7 (64 bit). Recently I encountered pickling errors when I made some experiments with DIGITS and pycaffe. After time  I came to the conclusion that initially this problem was related to the caffe. Protobuf compiler builds python caffe_pb2 module within wrong namespace ('caffe_pb2' instead of 'caffe.proto.caffe_pb2'). Proof:
```
>>> from caffe.proto import caffe_pb2
>>> net = caffe_pb2.NetParameter()
>>> print net.__module__
caffe_pb2
```
DIGITS uses caffe_pb2 as standalone module, and caffe module imports caffe_pb2 as his submodule, so it causes errors when pickling. The solution I found is the importing caffe_pb2 only as submodule.
Also this patch is needed for the caffe-0.15:
https://github.com/uhfband/caffe/commit/eb301a8f603e12b241ff08bd8db4dfdeedccdb84
I hope this information will be useful.