### PR TITLE
Multi-bounding box labeling fix while also preserving order

### DIFF
--- a/digits/extensions/view/boundingBox/app_begin_template.html
+++ b/digits/extensions/view/boundingBox/app_begin_template.html
@@ -41,7 +41,6 @@
 
  // Add a bounding box draw method to the canvas
      CanvasRenderingContext2D.prototype.draw_bbox = function(bbox, color, opacity) {
-     console.log(bbox);			 
      this.globalAlpha = opacity;
      this.fillStyle = color;
      this.fillRect(bbox[0],
@@ -148,7 +147,6 @@
 
      // Draw the image and the bounding boxes with line_width and desaturated by desaturation.
      $scope.draw_bboxes = function(image, bboxes) {
-	 console.log("in draw bboxes");
 	 var canvas = document.getElementById($scope.canvas_id);
          var context = canvas.getContext('2d'); 
          
@@ -174,7 +172,6 @@
          var opacity = $rootScope.storage.opacity / 100.0;
 
 	 // draw the bounding boxes
-	 console.log(bboxes);					     
          for (var b = 0; b < bboxes.length; b++) {
              var color = $scope.get_color(b);
 	     var key = Object.keys(bboxes[b])[0];

--- a/digits/extensions/view/boundingBox/app_begin_template.html
+++ b/digits/extensions/view/boundingBox/app_begin_template.html
@@ -40,7 +40,8 @@
  };
 
  // Add a bounding box draw method to the canvas
- CanvasRenderingContext2D.prototype.draw_bbox = function(bbox, color, opacity) {
+     CanvasRenderingContext2D.prototype.draw_bbox = function(bbox, color, opacity) {
+     console.log(bbox);			 
      this.globalAlpha = opacity;
      this.fillStyle = color;
      this.fillRect(bbox[0],
@@ -147,7 +148,8 @@
 
      // Draw the image and the bounding boxes with line_width and desaturated by desaturation.
      $scope.draw_bboxes = function(image, bboxes) {
-         var canvas = document.getElementById($scope.canvas_id);
+	 console.log("in draw bboxes");
+	 var canvas = document.getElementById($scope.canvas_id);
          var context = canvas.getContext('2d'); 
          
          // first set the size of the canvas
@@ -171,14 +173,12 @@
          // rectangle fill opacity
          var opacity = $rootScope.storage.opacity / 100.0;
 
-         // draw the bounding boxes
-         var keys = Object.keys(bboxes);
-         keys.sort();
-         for (var k = 0; k < keys.length; k++) {
-             var color = $scope.get_color(k);
-             for (var i = 0; i < bboxes[keys[k]].length; i++) {
-                 context.draw_bbox(bboxes[keys[k]][i], color, opacity);
-             }
+	 // draw the bounding boxes
+	 console.log(bboxes);					     
+         for (var b = 0; b < bboxes.length; b++) {
+             var color = $scope.get_color(b);
+	     var key = Object.keys(bboxes[b])[0];
+	     context.draw_bbox(bboxes[b][key], color, opacity);
          }
      }
 

--- a/digits/extensions/view/boundingBox/view.py
+++ b/digits/extensions/view/boundingBox/view.py
@@ -114,15 +114,21 @@ class Visualization(VisualizationInterface):
 
         # create arrays in expected format
         keys = inference_data.keys()
-        bboxes = dict(zip(keys, [[] for x in range(0, len(keys))]))
+        bboxes = []
         for key, outputs in inference_data.items():
+            added = False
             # last number is confidence
-            bboxes[key] = [list(o) for o in outputs if o[-1] > 0]
-            self.bbox_count += len(bboxes[key])
+            for o in outputs:
+                if o[-1]>0:
+                    bboxes.append({key: list(o)})
+                    self.bbox_count += 1
+                    added = True
+            if not added:
+                bboxes.append({key: "null"})
         image_html = digits.utils.image.embed_image_html(image)
 
         return {
             'image': image_html,
-            'bboxes': bboxes,
+            'bboxes': sorted(bboxes),
             'index': self.image_count,
         }

--- a/digits/extensions/view/boundingBox/view_template.html
+++ b/digits/extensions/view/boundingBox/view_template.html
@@ -15,11 +15,13 @@
             style="max-width:100%;"
             resize></canvas>
     <p align="center">
-        <span ng-repeat="(key, boxes) in bboxes">
-            <span ng-if="boxes.length > 0" style="display:inline-block;">
-                <span style="display:inline-block; width:10px;height:10px;border:1px solid #000; background-color: {[get_color($index)]}"></span>
-                <span style="display:inline-block; padding-right:10px">{[key]}</span>
-            </span>
+      <span ng-repeat="(idx,boxobj) in bboxes">
+	<span ng-repeat="(key,boxes) in boxobj">
+          <span ng-if="boxes!='null'" style="display:inline-block;">
+            <span style="display:inline-block; width:10px;height:10px;border:1px solid #000; background-color: {[get_color(idx)]}"></span>
+	    <span style="display:inline-block; padding-right:10px">{[key]}</span>
+	  </span>
         </span>
+      </span>
     </p>
 </div>

--- a/docs/BuildDigits.md
+++ b/docs/BuildDigits.md
@@ -1,93 +1,153 @@
-# Building DIGITS
+# Building DIGITS for Ubuntu Server 16.04
 
-The following instructions will walk you through building the latest version of DIGITS from source.
-**These instructions are for installation on Ubuntu 14.04 and 16.04.**
-
-Alternatively, see [this guide](BuildDigitsWindows.md) for setting up DIGITS and Caffe on Windows machines.
-
-Other platforms are not officially supported, but users have successfully installed DIGITS on Ubuntu 12.04, CentOS, OSX, and possibly more.
-Since DIGITS itself is a pure Python project, installation is usually pretty trivial regardless of the platform.
-The difficulty comes from installing all the required dependencies for Caffe, Torch7 , Tensorflow, and configuring the builds.
-Doing so is your own adventure.
+I've built Ubuntu Server instances for DIGITS multiple times and have compiled a list of steps that seems to work well for me. Configuring all the dependencies and installing all the prerequisites can be tricky so I thought I'd share it in one place with some notes.
 
 ## Prerequisites
 
-You need an NVIDIA driver ([details and instructions](InstallCuda.md#driver)).
+You need an NVIDIA driver to begin with of course ([details and instructions](InstallCuda.md#driver)).
 
-Run the following commands to get access to some package repositories:
-```sh
-# For Ubuntu 14.04
-CUDA_REPO_PKG=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/cuda-repo-ubuntu1404_8.0.61-1_amd64.deb
-ML_REPO_PKG=http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/nvidia-machine-learning-repo-ubuntu1404_4.0-2_amd64.deb
+## Install Ubuntu 16.04 64-bit Server
+I do the typical installation using LVM to encrypt the whole drive. No automatic updates. Basic installation packages plus SSH server and really nothing else (at first).
 
-# For Ubuntu 16.04
+### Basic updates/upgrades after installation - modify for your editor of choice
+```
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install emacs
+```
+### I like to try and request a specific IP. Insert the following lines into dhclient.conf. If you can get a static IP even better.
+```
+emacs /etc/dhcp/dhclient.conf
+	#try to get a specific ip; dhclient -r -v to request again if it fails on startup
+	send dhcp-requested-address XXX.XX.XXX.XXX;
+```
+### Install CUDA which will pull the latest Nvidia driver. I have always pulled 8-0 which is good for DIGITS 6.
+```
+cd /tmp
 CUDA_REPO_PKG=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
 ML_REPO_PKG=http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb
-
-# Install repo packages
 wget "$CUDA_REPO_PKG" -O /tmp/cuda-repo.deb && sudo dpkg -i /tmp/cuda-repo.deb && rm -f /tmp/cuda-repo.deb
 wget "$ML_REPO_PKG" -O /tmp/ml-repo.deb && sudo dpkg -i /tmp/ml-repo.deb && rm -f /tmp/ml-repo.deb
-
-# Download new list of packages
 sudo apt-get update
+sudo apt-get install cuda-8-0
+sudo apt-mark hold cuda-8-0
+```
+### The above, in my experience, pulls the 390 version of the Nvidia drivers. If not, you can do the following.
+```
+sudo apt-get install nvidia-390
+apt-mark hold nvidia-390
+```
+### Since we are using Nvidia, don't use Nouveau. Make a few changes to not try to boot to the GUI but command line instead.
+```
+sudo emacs /etc/modprobe.d/blacklist-nouveau.conf
+	blacklist nouveau
+	blacklist lbm-nouveau
+	alias nouveau off
+	alias lbm-nouveau off
+sudo emacs /etc/default/grub
+	GRUB_CMDLINE_LINUX_DEFAULT="text"
+	GRUB_CMDLINE_LINUX="text"
+sudo systemctl set-default multi-user.target
+sudo reboot now
+```
+### After reboot, double check. The first command should show stuff, the second not (if successful).
+```
+lsmod | grep nvidia
+lsmod | grep nouveau
 ```
 
-## Dependencies
-
-Install some dependencies with Deb packages:
-```sh
-sudo apt-get install --no-install-recommends git graphviz python-dev python-flask python-flaskext.wtf python-gevent python-h5py python-numpy python-pil python-pip python-scipy python-tk
+## Dependencies - I choose to put everything in /usr/local but this is up to personal preference.
+### Protobuf - in some cases I had trouble with git:// endpoints so I modified to always use https in the second line.
+```
+sudo apt-get install autoconf automake libtool curl make g++ git python-dev python-setuptools unzip
+git config --global url."https://".insteadOf git://
+export PROTOBUF_ROOT=/usr/local/protobuf
+sudo git clone https://github.com/google/protobuf.git $PROTOBUF_ROOT -b '3.2.x'
+cd $PROTOBUF_ROOT
+sudo ./autogen.sh
+sudo ./configure
+sudo make "-j$(nproc)"
+sudo make install
+sudo ldconfig
+cd python
+sudo python setup.py install --cpp_implementation
 ```
 
-Follow [these instructions](BuildCaffe.md) to build Caffe (**required**).
-
-Follow [these instructions](BuildTorch.md) to build Torch7 (*suggested*).
-
-Follow [these instructions](BuildTensorflow.md) to build Tensorflow (*suggseted*).
-
-## Download source
-
-```sh
-# example location - can be customized
-DIGITS_ROOT=~/digits
-git clone https://github.com/NVIDIA/DIGITS.git $DIGITS_ROOT
+### Caffe. I use Cudnn version 5 though I think it will work with version 6. Note that you need to add an environment variable to the .bashrc file for whatever user will be running DIGITS so it knows where Caffe is.
+```
+sudo apt-get install libcudnn5
+sudo apt-mark hold libcudnn5
+sudo apt-get install --no-install-recommends build-essential cmake git gfortran libatlas-base-dev libboost-filesystem-dev libboost-python-dev libboost-system-dev libboost-thread-dev libgflags-dev libgoogle-glog-dev libhdf5-serial-dev libleveldb-dev liblmdb-dev libopencv-dev libsnappy-dev python-all-dev python-dev python-h5py python-matplotlib python-numpy python-opencv python-pil python-pip python-pydot python-scipy python-skimage python-sklearn libnccl-dev
+emacs ~/.bashrc
+	export CAFFE_ROOT=/usr/local/caffe
+source ~/.bashrc
+sudo git clone https://github.com/NVIDIA/caffe.git $CAFFE_ROOT -b 'caffe-0.15'
+pip install -r $CAFFE_ROOT/python/requirements.txt
+cd $CAFFE_ROOT
+sudo mkdir build
+cd build
+sudo cmake ..
+sudo make -j"$(nproc)"
+sudo make install
 ```
 
-Throughout the docs, we'll refer to your install location as `DIGITS_ROOT` (`~/digits` in this case), though you don't need to actually set that environment variable.
-
-## Python packages
-
-Several PyPI packages need to be installed:
-```sh
-sudo pip install -r $DIGITS_ROOT/requirements.txt
+### Torch
+```
+sudo apt-get install --no-install-recommends git software-properties-common
+export TORCH_ROOT=/usr/local/torch
+git clone https://github.com/torch/distro.git $TORCH_ROOT --recursive
+cd $TORCH_ROOT
+sudo ./install-deps
+sudo ./install.sh -b
+sudo apt-get install --no-install-recommends libhdf5-serial-dev liblmdb-dev
+source ~/.bashrc
+sudo su
+source /usr/local/torch/install/bin/torch-activate
+luarocks install tds
+luarocks install "https://raw.github.com/deepmind/torch-hdf5/master/hdf5-0-0.rockspec"
+luarocks install "https://raw.github.com/Neopallium/lua-pb/master/lua-pb-scm-0.rockspec"
+luarocks install lightningmdb 0.9.18.1-1 LMDB_INCDIR=/usr/include LMDB_LIBDIR=/usr/lib/x86_64-linux-gnu
+<exit root>
 ```
 
-# [Optional] Enable support for plug-ins
-
-DIGITS needs to be installed to enable loading data and visualization plug-ins:
+### Tensorflow. Using 1.2.1 currently per DIGITS recommendations but I've worked with 1.4 as well. Some of this depends on the compute capability of your card.
 ```
+pip install tensorflow-gpu==1.2.1
+```
+
+### DIGITS. Note that I've given control to the local user for the jobs directory and digits log file. This depends on what user will be running the DIGITS server.
+```
+DIGITS_ROOT=/usr/local/digits
+sudo git clone https://github.com/NVIDIA/DIGITS.git $DIGITS_ROOT
+pip install -r $DIGITS_ROOT/requirements.txt
 sudo pip install -e $DIGITS_ROOT
+sudo apt-get install python-tk
+sudo mkdir /usr/local/digits/digits/jobs
+sudo chown <user>:<user> /usr/local/digits/digits/jobs
+sudo touch /usr/local/digits/digits/digits.log
+sudo chown <user>:<user> /usr/local/digits/digits/digits.log
 ```
 
-# Starting the server
+## Now you should have everything installed and can start DIGITS using the digits-devserver executable. Good idea to test here to be sure. I like to create a startup job as follows.
 
-```sh
-./digits-devserver
 ```
+sudo emacs /lib/systemd/system/digits.service
+	[Unit]
+	Description=Start Digits
 
-Starts a server at `http://localhost:5000/`.
-```
-$ ./digits-devserver --help
-usage: __main__.py [-h] [-p PORT] [-d] [--version]
+	[Service]
+	User=<user>
+	Environment=CAFFE_ROOT=/usr/local/caffe
+	WorkingDirectory=/usr/local/digits
+	ExecStart=/bin/bash digits-devserver
+	Restart=always
+	RestartSec=30
 
-DIGITS development server
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -p PORT, --port PORT  Port to run app on (default 5000)
-  -d, --debug           Run the application in debug mode (reloads when the
-                        source changes and gives more detailed error messages)
-  --version             Print the version number and exit
+	[Install]
+	WantedBy=multi-user.target
+systemctl daemon-reload
+systemctl enable digits
+systemctl start digits
 ```
 
 # Getting started

--- a/docs/BuildDigits.md
+++ b/docs/BuildDigits.md
@@ -73,10 +73,12 @@ cd python
 sudo python setup.py install --cpp_implementation
 ```
 
-### Caffe. I use Cudnn version 5 though I think it will work with version 6. Note that you need to add an environment variable to the .bashrc file for whatever user will be running DIGITS so it knows where Caffe is.
+### Caffe. Update: the ubuntu libcudnn libraries are not found when you try and build Caffe. It's possible you could set environment variables to find them, but now I'm building from scratch using cudnn v. 7.1 for cuda 8.0 as follows. Note that you need to add an environment variable to the .bashrc file for whatever user will be running DIGITS so it knows where Caffe is.
 ```
-sudo apt-get install libcudnn5
-sudo apt-mark hold libcudnn5
+# download ubuntu cudnn packages from https://developer.nvidia.com/rdp/cudnn-download to match your version of CUDA and Ubuntu
+sudo dpkg -i libcudnn7_7*******  #whatever version
+sudo dpkg -i libcudnn7_7-dev
+sudo dpkg -i libcudnn7_7-doc   #if you want docs and code samples
 sudo apt-get install --no-install-recommends build-essential cmake git gfortran libatlas-base-dev libboost-filesystem-dev libboost-python-dev libboost-system-dev libboost-thread-dev libgflags-dev libgoogle-glog-dev libhdf5-serial-dev libleveldb-dev liblmdb-dev libopencv-dev libsnappy-dev python-all-dev python-dev python-h5py python-matplotlib python-numpy python-opencv python-pil python-pip python-pydot python-scipy python-skimage python-sklearn libnccl-dev
 emacs ~/.bashrc
 	export CAFFE_ROOT=/usr/local/caffe


### PR DESCRIPTION
Pull request #1680 elegantly fixes the problem where bounding boxes don't match the key in multi-class object detection problems, but I liked preserving the order of the classes in the key as well so I created this somewhat more complex fix that creates an ordered list prior to passing the information to the html template so one can rely on the indexing to get color and class.

The BuildDigits.md file is simply added because I've now build DIGITS on Ubuntu 16.04 servers several times and I've assembled this all-in-one guide which I've found works pretty reliably and is helpful in case others would like to use it.