### PR TITLE
Adding support for pydicom 1.0 (and pydicom 0.9.9)

### DIFF
--- a/plugins/data/sunnybrook/digitsDataPluginSunnybrook/data.py
+++ b/plugins/data/sunnybrook/digitsDataPluginSunnybrook/data.py
@@ -8,8 +8,10 @@ import math
 import os
 import random
 import re
-
-import dicom
+try:
+    import dicom
+except:
+    import pydicom as dicom
 import numpy as np
 
 from digits.utils import subclass, override, constants


### PR DESCRIPTION
Pydicom via 'import dicom' has been removed in pydicom version 1.0. Please install the `dicom` package to restore function of code relying on pydicom 0.9.9 or earlier. E.g. `pip install dicom`. Alternatively, most code can easily be converted to pydicom > 1.0 by changing import lines from 'import dicom' to 'import pydicom'. See the Transition Guide at https://pydicom.github.io/pydicom/stable/transition_to_pydicom1.html.