### PR TITLE
Fix BVLC caffe test in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
     global:
         - PROTOBUF_ROOT=~/protobuf
         - CAFFE_ROOT=~/caffe
-        - CAFFE_TAG=v0.16.4
+        - NV_CAFFE_TAG=v0.16.4
+        - BVLC_CAFFE_COMMIT=306672023ea79f0755e92ca345bc70c068a91cc4
         - TORCH_ROOT=~/torch
         - OMP_NUM_THREADS=1
         - OPENBLAS_MAIN_FREE=1

--- a/digits/config/tensorflow.py
+++ b/digits/config/tensorflow.py
@@ -10,7 +10,7 @@ def test_tf_import():
     try:
         import tensorflow  # noqa
         return True
-    except ImportError:
+    except (ImportError, TypeError):
         return False
 
 tf_enabled = test_tf_import()

--- a/scripts/travis/install-caffe.sh
+++ b/scripts/travis/install-caffe.sh
@@ -25,14 +25,19 @@ fi
 
 set -x
 
-# get source
-git clone "https://github.com/${CAFFE_FORK}/caffe.git" "$INSTALL_DIR" $CAFFE_BRANCH --depth 1
-
-# configure project
-cd "$INSTALL_DIR"
 if [ "$CAFFE_FORK" == "NVIDIA" ]; then
+    # get source
+    git clone "https://github.com/${CAFFE_FORK}/caffe.git" "$INSTALL_DIR" $CAFFE_BRANCH --depth 1
+    # configure project
+    cd "$INSTALL_DIR"
     git fetch --all --tags --prune
-    git checkout "tags/$CAFFE_TAG"
+    git checkout "tags/$NV_CAFFE_TAG"
+else
+    # get source
+    git clone "https://github.com/${CAFFE_FORK}/caffe.git" "$INSTALL_DIR" 
+    # configure project
+    cd "$INSTALL_DIR"
+    git checkout "$BVLC_CAFFE_COMMIT"
 fi
 mkdir -p build
 cd build


### PR DESCRIPTION
BVLC recently changed caffe_pb2 namespace, which caused incompatibility between nv-caffe and bvlc-caffe.  This PR only tries to make CI pass by build BVLC Caffe from the latest commit before that change.