### PR TITLE
Optimize sorting for Python 2 and Python 3

### DIFF
--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -712,7 +712,7 @@ def get_datasets():
     return [(j.id(), j.name()) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, ImageClassificationDatasetJob) and
          (j.status.is_running() or j.status == Status.DONE)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]
 
@@ -732,7 +732,7 @@ def get_default_standard_network():
 def get_previous_networks():
     return [(j.id(), j.name()) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, ImageClassificationModelJob)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]
 
@@ -740,7 +740,7 @@ def get_previous_networks():
 def get_previous_networks_fulldetails():
     return [(j) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, ImageClassificationModelJob)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]
 
@@ -760,7 +760,7 @@ def get_previous_network_snapshots():
 def get_pretrained_networks():
     return [(j.id(), j.name()) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, PretrainedModelJob)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]
 
@@ -768,6 +768,6 @@ def get_pretrained_networks():
 def get_pretrained_networks_fulldetails():
     return [(j) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, PretrainedModelJob)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]

--- a/digits/model/images/generic/views.py
+++ b/digits/model/images/generic/views.py
@@ -784,7 +784,7 @@ def get_datasets(extension_id):
                 if (isinstance(j, GenericImageDatasetJob) or isinstance(j, GenericDatasetJob)) and
                 (j.status.is_running() or j.status == Status.DONE)]
     return [(j.id(), j.name())
-            for j in sorted(jobs, cmp=lambda x, y: cmp(y.id(), x.id()))]
+            for j in sorted(jobs, key=lambda x: x.id(), reversed=True)]
 
 
 def get_inference_visualizations(dataset, inputs, outputs):
@@ -831,7 +831,7 @@ def get_inference_visualizations(dataset, inputs, outputs):
 def get_previous_networks():
     return [(j.id(), j.name()) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, GenericImageModelJob)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]
 
@@ -839,7 +839,7 @@ def get_previous_networks():
 def get_previous_networks_fulldetails():
     return [(j) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, GenericImageModelJob)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]
 
@@ -859,7 +859,7 @@ def get_previous_network_snapshots():
 def get_pretrained_networks():
     return [(j.id(), j.name()) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, PretrainedModelJob)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]
 
@@ -867,7 +867,7 @@ def get_pretrained_networks():
 def get_pretrained_networks_fulldetails():
     return [(j) for j in sorted(
         [j for j in scheduler.jobs.values() if isinstance(j, PretrainedModelJob)],
-        cmp=lambda x, y: cmp(y.id(), x.id())
+        key=lambda x: x.id(), reversed=True
     )
     ]
 

--- a/digits/scheduler.py
+++ b/digits/scheduler.py
@@ -301,28 +301,28 @@ class Scheduler:
         """a query utility"""
         return sorted(
             [j for j in self.jobs.values() if isinstance(j, DatasetJob) and j.status.is_running()],
-            cmp=lambda x, y: cmp(y.id(), x.id())
+            key=lambda x: x.id(), reversed=True
         )
 
     def completed_dataset_jobs(self):
         """a query utility"""
         return sorted(
             [j for j in self.jobs.values() if isinstance(j, DatasetJob) and not j.status.is_running()],
-            cmp=lambda x, y: cmp(y.id(), x.id())
+            key=lambda x: x.id(), reversed=True
         )
 
     def running_model_jobs(self):
         """a query utility"""
         return sorted(
             [j for j in self.jobs.values() if isinstance(j, ModelJob) and j.status.is_running()],
-            cmp=lambda x, y: cmp(y.id(), x.id())
+            key=lambda x: x.id(), reversed=True
         )
 
     def completed_model_jobs(self):
         """a query utility"""
         return sorted(
             [j for j in self.jobs.values() if isinstance(j, ModelJob) and not j.status.is_running()],
-            cmp=lambda x, y: cmp(y.id(), x.id())
+            key=lambda x: x.id(), reversed=True
         )
 
     def start(self):


### PR DESCRIPTION
Python 3 dropped the builtin __cmp()__ in favor of rich comparisons.  The proposed changes speed up sorting and also make them Python 3 compatible.
* https://docs.python.org/3/howto/sorting.html#sortinghowto
* https://portingguide.readthedocs.io/en/latest/comparisons.html