### PR TITLE
Running Example in CPU mode

### DIFF
--- a/examples/classification/example.py
+++ b/examples/classification/example.py
@@ -34,6 +34,8 @@ def get_net(caffemodel, deploy_file, use_gpu=True):
     """
     if use_gpu:
         caffe.set_mode_gpu()
+    else:
+        caffe.set_mode_cpu()
 
     # load a new model
     return caffe.Net(deploy_file, caffemodel, caffe.TEST)


### PR DESCRIPTION
The classification example was giving error in CPU mode due to a missing line.