### PR TITLE
objectDetection: data.py: Fix '_csv.reader' object has no attribute '…

### DIFF
--- a/digits/extensions/data/objectDetection/data.py
+++ b/digits/extensions/data/objectDetection/data.py
@@ -35,7 +35,7 @@ class DataIngestion(DataIngestionInterface):
             s = StringIO.StringIO(self.custom_classes)
             reader = csv.reader(s)
             self.class_mappings = {}
-            for idx, name in enumerate(reader.next()):
+            for idx, name in enumerate(next(reader)):
                 self.class_mappings[name.strip().lower()] = idx
         else:
             self.class_mappings = None


### PR DESCRIPTION
…next' error.

For Python 3.x, we have to use next(reader) instead of reader.next()

Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>