### PR TITLE
Fix TypeError

### DIFF
--- a/digits/extensions/data/imageSegmentation/data.py
+++ b/digits/extensions/data/imageSegmentation/data.py
@@ -220,7 +220,7 @@ class DataIngestion(DataIngestionInterface):
 
     def split_image_list(self, filelist, stage):
         if self.random_indices is None:
-            self.random_indices = range(len(filelist))
+            self.random_indices = list(range(len(filelist)))
             random.shuffle(self.random_indices)
         elif len(filelist) != len(self.random_indices):
             raise ValueError(


### PR DESCRIPTION
File "/opt/digits/digits/extensions/data/imageSegmentation/data.py", line 225, in split_image_list
random.shuffle(self.random_indices)
File "/usr/lib/python3.8/random.py", line 307, in shuffle
x[i], x[j] = x[j], x[i]
TypeError: 'range' object does not support item assignment